### PR TITLE
Multiple digitizers trace saving

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1309,6 +1309,7 @@ dependencies = [
  "lazy_static",
  "log",
  "ndarray",
+ "ndarray-stats",
  "prometheus-client",
  "rdkafka",
  "serde",

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -4,9 +4,17 @@ pub type Time = u32;
 pub type Channel = u32;
 pub type Intensity = u16;
 
+pub type FrameNumber = u32;
+
 #[derive(Default)]
 pub struct EventData {
     pub time: Vec<Time>,
     pub channel: Vec<Channel>,
     pub voltage: Vec<Intensity>,
+}
+
+pub const CHANNELS_PER_DIGITIZER: usize = 8;
+
+pub fn channel_index(digitizer_index: usize, channel_index: usize) -> usize {
+    (digitizer_index * CHANNELS_PER_DIGITIZER) + channel_index
 }

--- a/stream-to-file/Cargo.toml
+++ b/stream-to-file/Cargo.toml
@@ -18,6 +18,7 @@ kagiyama = "0.1.0"
 lazy_static = "1.4.0"
 log = "0.4"
 ndarray = "0.15.4"
+ndarray-stats = "0.5.1"
 prometheus-client = "0.18.0"
 rdkafka = { version = "0.29", features = ["cmake-build", "ssl-vendored", "gssapi-vendored", "sasl"] }
 serde = { version = "1", features = ["derive"] }

--- a/stream-to-file/src/main.rs
+++ b/stream-to-file/src/main.rs
@@ -51,7 +51,7 @@ struct Cli {
     trace_file: Option<PathBuf>,
 
     #[clap(long)]
-    trace_channels: Option<usize>,
+    digitizer_count: Option<usize>,
 
     #[clap(long, default_value = "127.0.0.1:9090")]
     observability_address: SocketAddr,
@@ -117,13 +117,13 @@ async fn main() -> Result<()> {
     }
     consumer.subscribe(&topics_to_subscribe)?;
 
-    let event_file = match args.event_file {
+    let mut event_file = match args.event_file {
         Some(filename) => Some(EventFile::create(&filename)?),
         None => None,
     };
 
-    let trace_file = match args.trace_file {
-        Some(filename) => Some(TraceFile::create(&filename, args.trace_channels.unwrap())?),
+    let mut trace_file = match args.trace_file {
+        Some(filename) => Some(TraceFile::create(&filename, args.digitizer_count.unwrap())?),
         None => None,
     };
 
@@ -152,7 +152,7 @@ async fn main() -> Result<()> {
                                         metrics::MessageKind::Event,
                                     ))
                                     .inc();
-                                if let Err(e) = event_file.as_ref().unwrap().push(&data) {
+                                if let Err(e) = event_file.as_mut().unwrap().push(&data) {
                                     log::warn!("Failed to save events to file: {}", e);
                                     metrics::FAILURES
                                         .get_or_create(&metrics::FailureLabels::new(
@@ -186,7 +186,7 @@ async fn main() -> Result<()> {
                                         metrics::MessageKind::Trace,
                                     ))
                                     .inc();
-                                if let Err(e) = trace_file.as_ref().unwrap().push(&data) {
+                                if let Err(e) = trace_file.as_mut().unwrap().push(&data) {
                                     log::warn!("Failed to save traces to file: {}", e);
                                     metrics::FAILURES
                                         .get_or_create(&metrics::FailureLabels::new(


### PR DESCRIPTION
Correctly handle multiple digitizers when saving trace files.

To test:
- Start trace saver for 3 digitizers, ensure the consumer group is up to date
- Run the simulator for each digitiser in turn, ideally for an obviously different length of time
- Stop trace saver and load the file in https://h5web.panosc.eu/h5wasm
- See that `frame_start_index`:
  - increments in the measurement count given to the simulator
  - has no value is repeated
  - has the correct amount of entries
- See that `detector_data`:
  - has the expected dimensions for the number of channels
  - has data from all detectors
  - has simulator frame and digitizer ID markers in the correct positions

Closes #17 