### PR TITLE
Ignore more warnings from flatbuffer generated code

### DIFF
--- a/events-to-histogram/src/processing.rs
+++ b/events-to-histogram/src/processing.rs
@@ -208,7 +208,7 @@ mod tests {
                             .collect::<Vec<_>>()
                     );
                 }
-                ch => panic!("Unexpected channel number: {}", ch),
+                ch => panic!("Unexpected channel number: {ch}"),
             }
         }
     }

--- a/live-plot/src/backend.rs
+++ b/live-plot/src/backend.rs
@@ -76,7 +76,7 @@ impl DrawingBackend for TextDrawingBackend {
             for c in 0..s.0 {
                 buf.push(self.0[r * s.0 + c].to_char());
             }
-            println!("{}", buf);
+            println!("{buf}");
         }
 
         Ok(())

--- a/stream-to-file/src/file/base.rs
+++ b/stream-to-file/src/file/base.rs
@@ -145,7 +145,7 @@ mod tests {
 
     fn create_test_filename(name: &str) -> PathBuf {
         let mut path = env::temp_dir();
-        path.push(format!("{}.h5", name));
+        path.push(format!("{name}.h5"));
         path
     }
 

--- a/stream-to-file/src/file/event.rs
+++ b/stream-to-file/src/file/event.rs
@@ -110,7 +110,7 @@ mod tests {
 
     fn create_test_filename(name: &str) -> PathBuf {
         let mut path = env::temp_dir();
-        path.push(format!("{}.h5", name));
+        path.push(format!("{name}.h5"));
         path
     }
 

--- a/stream-to-file/src/file/trace/tests/mod.rs
+++ b/stream-to-file/src/file/trace/tests/mod.rs
@@ -16,7 +16,7 @@ mod multiple_digitizers_missing_data;
 
 fn create_test_filename(name: &str) -> PathBuf {
     let mut path = env::temp_dir();
-    path.push(format!("{}.h5", name));
+    path.push(format!("{name}.h5"));
     path
 }
 

--- a/streaming-types/src/lib.rs
+++ b/streaming-types/src/lib.rs
@@ -1,19 +1,19 @@
 pub mod util;
 
 #[rustfmt::skip]
-#[allow(unused_imports, clippy::derivable_impls, clippy::derive_partial_eq_without_eq, clippy::size_of_in_element_count, clippy::missing_safety_doc)]
+#[allow(unused_imports, clippy::derivable_impls, clippy::derive_partial_eq_without_eq, clippy::size_of_in_element_count, clippy::missing_safety_doc, clippy::needless_lifetimes)]
 pub mod aev1_frame_assembled_event_v1_generated;
 
 #[rustfmt::skip]
-#[allow(unused_imports, clippy::derivable_impls, clippy::derive_partial_eq_without_eq, clippy::size_of_in_element_count, clippy::missing_safety_doc)]
+#[allow(unused_imports, clippy::derivable_impls, clippy::derive_partial_eq_without_eq, clippy::size_of_in_element_count, clippy::missing_safety_doc, clippy::needless_lifetimes)]
 pub mod dat1_digitizer_analog_trace_v1_generated;
 
 #[rustfmt::skip]
-#[allow(unused_imports, clippy::derivable_impls, clippy::derive_partial_eq_without_eq, clippy::size_of_in_element_count, clippy::missing_safety_doc)]
+#[allow(unused_imports, clippy::derivable_impls, clippy::derive_partial_eq_without_eq, clippy::size_of_in_element_count, clippy::missing_safety_doc, clippy::needless_lifetimes)]
 pub mod dev1_digitizer_event_v1_generated;
 
 #[rustfmt::skip]
-#[allow(unused_imports, clippy::derivable_impls, clippy::derive_partial_eq_without_eq, clippy::size_of_in_element_count, clippy::missing_safety_doc)]
+#[allow(unused_imports, clippy::derivable_impls, clippy::derive_partial_eq_without_eq, clippy::size_of_in_element_count, clippy::missing_safety_doc, clippy::needless_lifetimes)]
 pub mod hst1_histogram_v1_generated;
 
 #[rustfmt::skip]


### PR DESCRIPTION
Originally noticed here: https://github.com/STFC-ICD-Research-and-Design/supermusr-data-pipeline/actions/runs/4128980262/jobs/7134079097