### PR TITLE
Unauthenticated Kafka Connections

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,6 +200,7 @@ name = "common"
 version = "0.1.0"
 dependencies = [
  "kagiyama",
+ "rdkafka",
 ]
 
 [[package]]

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 
 [dependencies]
 kagiyama = "0.3.0"
+rdkafka = { version = "0.31.0", features = ["cmake-build", "ssl-vendored", "gssapi-vendored", "sasl"] }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -23,7 +23,7 @@ pub fn channel_index(digitizer_index: usize, channel_index: usize) -> usize {
     (digitizer_index * CHANNELS_PER_DIGITIZER) + channel_index
 }
 
-pub fn generate_client_config(
+pub fn generate_kafka_client_config(
     broker_address: &String,
     username: &Option<String>,
     password: &Option<String>,

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -25,7 +25,7 @@ pub fn channel_index(digitizer_index: usize, channel_index: usize) -> usize {
 
 pub fn generate_client_config(
     broker_address: &String,
-    opt_username: &Option<String>,
+    username: &Option<String>,
     opt_password: &Option<String>,
 ) -> ClientConfig {
     let mut client_config = ClientConfig::new()

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,5 +1,7 @@
 pub mod metrics;
 
+use rdkafka::config::ClientConfig;
+
 pub type DigitizerId = u8;
 pub type Time = u32;
 pub type Channel = u32;
@@ -7,8 +9,6 @@ pub type Intensity = u16;
 
 pub type FrameNumber = u32;
 pub type SampleRate = u64;
-
-use rdkafka::config::ClientConfig;
 
 #[derive(Default)]
 pub struct EventData {

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -26,7 +26,7 @@ pub fn channel_index(digitizer_index: usize, channel_index: usize) -> usize {
 pub fn generate_client_config(
     broker_address: &String,
     username: &Option<String>,
-    opt_password: &Option<String>,
+    password: &Option<String>,
 ) -> ClientConfig {
     let mut client_config = ClientConfig::new()
         .set("bootstrap.servers", broker_address)

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -25,8 +25,8 @@ pub fn channel_index(digitizer_index: usize, channel_index: usize) -> usize {
 
 pub fn generate_client_config(
     broker_address: &String,
-    opt_username: Option<&String>,
-    opt_password: Option<&String>,
+    opt_username: &Option<String>,
+    opt_password: &Option<String>,
 ) -> ClientConfig {
     let mut client_config = ClientConfig::new()
         .set("bootstrap.servers", broker_address)

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -26,7 +26,7 @@ pub fn channel_index(digitizer_index: usize, channel_index: usize) -> usize {
 pub fn generate_client_config(
     broker_address: &String,
     opt_username: Option<&String>,
-    opt_password: Option<&String>
+    opt_password: Option<&String>,
 ) -> ClientConfig {
     let mut client_config = ClientConfig::new()
         .set("bootstrap.servers", broker_address)

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -40,5 +40,5 @@ pub fn generate_client_config(
             .set("sasl.username", username)
             .set("sasl.password", password);
     }
-    return client_config;
+    client_config
 }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -8,6 +8,8 @@ pub type Intensity = u16;
 pub type FrameNumber = u32;
 pub type SampleRate = u64;
 
+use rdkafka::config::ClientConfig;
+
 #[derive(Default)]
 pub struct EventData {
     pub time: Vec<Time>,
@@ -19,4 +21,20 @@ pub const CHANNELS_PER_DIGITIZER: usize = 8;
 
 pub fn channel_index(digitizer_index: usize, channel_index: usize) -> usize {
     (digitizer_index * CHANNELS_PER_DIGITIZER) + channel_index
+}
+
+pub fn generate_client_config(broker_address: &String, opt_username: Option<&String>, opt_password: Option<&String>) -> ClientConfig {
+    let mut client_config = ClientConfig::new()
+        .set("bootstrap.servers", broker_address)
+        .clone();
+
+    // Allow for authenticated Kafka connection if details are provided
+    if let (Some(username), Some(password)) = (opt_username, opt_password) {
+        client_config
+            .set("sasl.mechanisms", "SCRAM-SHA-256")
+            .set("security.protocol", "sasl_plaintext")
+            .set("sasl.username", username)
+            .set("sasl.password", password);
+    }
+    return client_config;
 }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -23,7 +23,11 @@ pub fn channel_index(digitizer_index: usize, channel_index: usize) -> usize {
     (digitizer_index * CHANNELS_PER_DIGITIZER) + channel_index
 }
 
-pub fn generate_client_config(broker_address: &String, opt_username: Option<&String>, opt_password: Option<&String>) -> ClientConfig {
+pub fn generate_client_config(
+    broker_address: &String,
+    opt_username: Option<&String>,
+    opt_password: Option<&String>
+) -> ClientConfig {
     let mut client_config = ClientConfig::new()
         .set("bootstrap.servers", broker_address)
         .clone();

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -33,12 +33,12 @@ pub fn generate_kafka_client_config(
         .clone();
 
     // Allow for authenticated Kafka connection if details are provided
-    if let (Some(username), Some(password)) = (opt_username, opt_password) {
+    if let (Some(sasl_username), Some(sasl_password)) = (username, password) {
         client_config
             .set("sasl.mechanisms", "SCRAM-SHA-256")
             .set("security.protocol", "sasl_plaintext")
-            .set("sasl.username", username)
-            .set("sasl.password", password);
+            .set("sasl.username", sasl_username)
+            .set("sasl.password", sasl_password);
     }
     client_config
 }

--- a/events-to-histogram/src/main.rs
+++ b/events-to-histogram/src/main.rs
@@ -60,7 +60,8 @@ async fn main() -> Result<()> {
     metrics::register(&watcher);
     watcher.start_server(args.observability_address).await;
 
-    let client_config = common::generate_kafka_client_config(&args.broker, &args.username, &args.password);
+    let client_config =
+        common::generate_kafka_client_config(&args.broker, &args.username, &args.password);
 
     let consumer: StreamConsumer = client_config
         .set("group.id", &args.consumer_group)

--- a/events-to-histogram/src/main.rs
+++ b/events-to-histogram/src/main.rs
@@ -6,7 +6,6 @@ use clap::Parser;
 use common::{self, Time};
 use kagiyama::{AlwaysReady, Watcher};
 use rdkafka::{
-    config::ClientConfig,
     consumer::{stream_consumer::StreamConsumer, CommitMode, Consumer},
     message::Message,
     producer::{FutureProducer, FutureRecord},
@@ -60,7 +59,7 @@ async fn main() -> Result<()> {
     metrics::register(&watcher);
     watcher.start_server(args.observability_address).await;
 
-    let client_config =
+    let mut client_config =
         common::generate_kafka_client_config(&args.broker, &args.username, &args.password);
 
     let consumer: StreamConsumer = client_config

--- a/events-to-histogram/src/main.rs
+++ b/events-to-histogram/src/main.rs
@@ -3,7 +3,7 @@ mod processing;
 
 use anyhow::Result;
 use clap::Parser;
-use common::{self, Time};
+use common::Time;
 use kagiyama::{AlwaysReady, Watcher};
 use rdkafka::{
     consumer::{stream_consumer::StreamConsumer, CommitMode, Consumer},

--- a/events-to-histogram/src/main.rs
+++ b/events-to-histogram/src/main.rs
@@ -3,7 +3,7 @@ mod processing;
 
 use anyhow::Result;
 use clap::Parser;
-use common::Time;
+use common::{self, Time};
 use kagiyama::{AlwaysReady, Watcher};
 use rdkafka::{
     config::ClientConfig,
@@ -23,10 +23,10 @@ struct Cli {
     broker: String,
 
     #[clap(long)]
-    username: String,
+    username: Option<String>,
 
     #[clap(long)]
-    password: String,
+    password: Option<String>,
 
     #[clap(long = "group")]
     consumer_group: String,
@@ -60,12 +60,9 @@ async fn main() -> Result<()> {
     metrics::register(&watcher);
     watcher.start_server(args.observability_address).await;
 
-    let consumer: StreamConsumer = ClientConfig::new()
-        .set("bootstrap.servers", &args.broker)
-        .set("security.protocol", "sasl_plaintext")
-        .set("sasl.mechanisms", "SCRAM-SHA-256")
-        .set("sasl.username", &args.username)
-        .set("sasl.password", &args.password)
+    let client_config = common::generate_kafka_client_config(&args.broker, &args.username, &args.password);
+
+    let consumer: StreamConsumer = client_config
         .set("group.id", &args.consumer_group)
         .set("enable.partition.eof", "false")
         .set("session.timeout.ms", "6000")
@@ -74,13 +71,7 @@ async fn main() -> Result<()> {
 
     consumer.subscribe(&[&args.event_topic])?;
 
-    let producer: FutureProducer = ClientConfig::new()
-        .set("bootstrap.servers", &args.broker)
-        .set("security.protocol", "sasl_plaintext")
-        .set("sasl.mechanisms", "SCRAM-SHA-256")
-        .set("sasl.username", &args.username)
-        .set("sasl.password", &args.password)
-        .create()?;
+    let producer: FutureProducer = client_config.create()?;
 
     let edges = processing::make_bins_edges(args.time_start, args.time_end, args.time_bin_width);
 

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -105,15 +105,8 @@ async fn main() {
             .set("sasl.username", username)
             .set("sasl.password", password);
     }
-    
-    let producer: FutureProducer = client_conf
-        .create()
-        .unwrap();
 
-    let producer = ClientConfig::new()
-        .set("bootstrap.servers", &cli.broker_address)
-        //.set("security.protocol", "sasl_plaintext")
-        //.set("sasl.mechanisms", "SCRAM-SHA-256")
+    let producer = client_conf
         .create()
         .unwrap();
 

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -3,7 +3,7 @@ use clap::{Parser, Subcommand};
 use common::{Channel, Intensity, Time};
 use rdkafka::{
     config::ClientConfig,
-    producer::{FutureProducer, FutureRecord, self},
+    producer::{self, FutureProducer, FutureRecord},
     util::Timeout,
 };
 use std::time::{Duration, SystemTime};
@@ -93,7 +93,8 @@ async fn main() {
 
     let cli = Cli::parse();
 
-    let client_config = common::generate_client_config(&cli.broker_address, &cli.username, &cli.password);
+    let client_config = 
+        common::generate_client_config(&cli.broker_address, &cli.username, &cli.password);
     let producer = client_config.create().unwrap();
 
     let mut fbb = FlatBufferBuilder::new();

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -93,7 +93,7 @@ async fn main() {
     let cli = Cli::parse();
 
     let client_config =
-        common::generate_client_config(&cli.broker_address, &cli.username, &cli.password);
+        common::generate_kafka_client_config(&cli.broker_address, &cli.username, &cli.password);
     let producer = client_config.create().unwrap();
 
     let mut fbb = FlatBufferBuilder::new();

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -2,8 +2,7 @@ use chrono::Utc;
 use clap::{Parser, Subcommand};
 use common::{Channel, Intensity, Time};
 use rdkafka::{
-    config::ClientConfig,
-    producer::{self, FutureProducer, FutureRecord},
+    producer::{FutureProducer, FutureRecord},
     util::Timeout,
 };
 use std::time::{Duration, SystemTime};

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -93,7 +93,7 @@ async fn main() {
 
     let cli = Cli::parse();
 
-    let client_config = 
+    let client_config =
         common::generate_client_config(&cli.broker_address, &cli.username, &cli.password);
     let producer = client_config.create().unwrap();
 

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -106,9 +106,7 @@ async fn main() {
             .set("sasl.password", password);
     }
 
-    let producer = client_conf
-        .create()
-        .unwrap();
+    let producer = client_conf.create().unwrap();
 
     let mut fbb = FlatBufferBuilder::new();
 

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -3,7 +3,7 @@ use clap::{Parser, Subcommand};
 use common::{Channel, Intensity, Time};
 use rdkafka::{
     config::ClientConfig,
-    producer::{FutureProducer, FutureRecord},
+    producer::{FutureProducer, FutureRecord, self},
     util::Timeout,
 };
 use std::time::{Duration, SystemTime};
@@ -93,20 +93,8 @@ async fn main() {
 
     let cli = Cli::parse();
 
-    let mut client_conf = ClientConfig::new()
-        .set("bootstrap.servers", &cli.broker_address)
-        .clone();
-
-    // Allow for authenticated Kafka connection if details are provided
-    if let (Some(username), Some(password)) = (&cli.username, &cli.password) {
-        client_conf
-            .set("sasl.mechanisms", "SCRAM-SHA-256")
-            .set("security.protocol", "sasl_plaintext")
-            .set("sasl.username", username)
-            .set("sasl.password", password);
-    }
-
-    let producer = client_conf.create().unwrap();
+    let client_config = common::generate_client_config(&cli.broker_address, &cli.username, &cli.password);
+    let producer = client_config.create().unwrap();
 
     let mut fbb = FlatBufferBuilder::new();
 

--- a/stream-to-file/src/main.rs
+++ b/stream-to-file/src/main.rs
@@ -4,7 +4,6 @@ mod metrics;
 use crate::file::{EventFile, TraceFile};
 use anyhow::{anyhow, Result};
 use clap::Parser;
-use common;
 use kagiyama::{prometheus::metrics::info::Info, AlwaysReady, Watcher};
 use rdkafka::{
     consumer::{stream_consumer::StreamConsumer, CommitMode, Consumer},

--- a/stream-to-file/src/main.rs
+++ b/stream-to-file/src/main.rs
@@ -10,6 +10,7 @@ use rdkafka::{
     consumer::{stream_consumer::StreamConsumer, CommitMode, Consumer},
     message::Message,
 };
+use common;
 use std::{net::SocketAddr, path::PathBuf};
 use streaming_types::{
     aev1_frame_assembled_event_v1_generated::{
@@ -29,10 +30,10 @@ struct Cli {
     broker: String,
 
     #[clap(long)]
-    username: String,
+    username: Option<String>,
 
     #[clap(long)]
-    password: String,
+    password: Option<String>,
 
     #[clap(long = "group")]
     consumer_group: String,
@@ -88,12 +89,7 @@ async fn main() -> Result<()> {
     }
     watcher.start_server(args.observability_address).await;
 
-    let consumer: StreamConsumer = ClientConfig::new()
-        .set("bootstrap.servers", &args.broker)
-        .set("security.protocol", "sasl_plaintext")
-        .set("sasl.mechanisms", "SCRAM-SHA-256")
-        .set("sasl.username", &args.username)
-        .set("sasl.password", &args.password)
+    let consumer: StreamConsumer = common::generate_kafka_client_config(&args.broker, &args.username, &args.password)
         .set("group.id", &args.consumer_group)
         .set("enable.partition.eof", "false")
         .set("session.timeout.ms", "6000")

--- a/stream-to-file/src/main.rs
+++ b/stream-to-file/src/main.rs
@@ -7,7 +7,6 @@ use clap::Parser;
 use common;
 use kagiyama::{prometheus::metrics::info::Info, AlwaysReady, Watcher};
 use rdkafka::{
-    config::ClientConfig,
     consumer::{stream_consumer::StreamConsumer, CommitMode, Consumer},
     message::Message,
 };

--- a/stream-to-file/src/main.rs
+++ b/stream-to-file/src/main.rs
@@ -4,13 +4,13 @@ mod metrics;
 use crate::file::{EventFile, TraceFile};
 use anyhow::{anyhow, Result};
 use clap::Parser;
+use common;
 use kagiyama::{prometheus::metrics::info::Info, AlwaysReady, Watcher};
 use rdkafka::{
     config::ClientConfig,
     consumer::{stream_consumer::StreamConsumer, CommitMode, Consumer},
     message::Message,
 };
-use common;
 use std::{net::SocketAddr, path::PathBuf};
 use streaming_types::{
     aev1_frame_assembled_event_v1_generated::{
@@ -89,12 +89,13 @@ async fn main() -> Result<()> {
     }
     watcher.start_server(args.observability_address).await;
 
-    let consumer: StreamConsumer = common::generate_kafka_client_config(&args.broker, &args.username, &args.password)
-        .set("group.id", &args.consumer_group)
-        .set("enable.partition.eof", "false")
-        .set("session.timeout.ms", "6000")
-        .set("enable.auto.commit", "false")
-        .create()?;
+    let consumer: StreamConsumer =
+        common::generate_kafka_client_config(&args.broker, &args.username, &args.password)
+            .set("group.id", &args.consumer_group)
+            .set("enable.partition.eof", "false")
+            .set("session.timeout.ms", "6000")
+            .set("enable.auto.commit", "false")
+            .create()?;
 
     let topics_to_subscribe: Vec<String> = vec![args.event_topic, args.trace_topic]
         .into_iter()

--- a/trace-archiver/src/main.rs
+++ b/trace-archiver/src/main.rs
@@ -3,13 +3,13 @@ mod metrics;
 
 use anyhow::Result;
 use clap::Parser;
+use common;
 use kagiyama::{AlwaysReady, Watcher};
 use rdkafka::{
     config::ClientConfig,
     consumer::{stream_consumer::StreamConsumer, CommitMode, Consumer},
     message::Message,
 };
-use common;
 use std::{net::SocketAddr, path::PathBuf};
 use streaming_types::dat1_digitizer_analog_trace_v1_generated::{
     digitizer_analog_trace_message_buffer_has_identifier, root_as_digitizer_analog_trace_message,
@@ -51,12 +51,13 @@ async fn main() -> Result<()> {
     metrics::register(&mut watcher);
     watcher.start_server(args.observability_address).await;
 
-    let consumer: StreamConsumer = common::generate_kafka_client_config(&args.broker, &args.username, &args.password)
-        .set("group.id", &args.consumer_group)
-        .set("enable.partition.eof", "false")
-        .set("session.timeout.ms", "6000")
-        .set("enable.auto.commit", "false")
-        .create()?;
+    let consumer: StreamConsumer =
+        common::generate_kafka_client_config(&args.broker, &args.username, &args.password)
+            .set("group.id", &args.consumer_group)
+            .set("enable.partition.eof", "false")
+            .set("session.timeout.ms", "6000")
+            .set("enable.auto.commit", "false")
+            .create()?;
 
     consumer.subscribe(&[&args.trace_topic])?;
 

--- a/trace-archiver/src/main.rs
+++ b/trace-archiver/src/main.rs
@@ -3,7 +3,6 @@ mod metrics;
 
 use anyhow::Result;
 use clap::Parser;
-use common;
 use kagiyama::{AlwaysReady, Watcher};
 use rdkafka::{
     consumer::{stream_consumer::StreamConsumer, CommitMode, Consumer},

--- a/trace-archiver/src/main.rs
+++ b/trace-archiver/src/main.rs
@@ -6,7 +6,6 @@ use clap::Parser;
 use common;
 use kagiyama::{AlwaysReady, Watcher};
 use rdkafka::{
-    config::ClientConfig,
     consumer::{stream_consumer::StreamConsumer, CommitMode, Consumer},
     message::Message,
 };

--- a/trace-to-events/src/main.rs
+++ b/trace-to-events/src/main.rs
@@ -6,7 +6,6 @@ use clap::Parser;
 use common::{self, Intensity};
 use kagiyama::{AlwaysReady, Watcher};
 use rdkafka::{
-    config::ClientConfig,
     consumer::{stream_consumer::StreamConsumer, CommitMode, Consumer},
     message::Message,
     producer::{FutureProducer, FutureRecord},
@@ -54,7 +53,7 @@ async fn main() -> Result<()> {
     metrics::register(&watcher);
     watcher.start_server(args.observability_address).await;
 
-    let client_config =
+    let mut client_config =
         common::generate_kafka_client_config(&args.broker, &args.username, &args.password);
 
     let consumer: StreamConsumer = client_config

--- a/trace-to-events/src/main.rs
+++ b/trace-to-events/src/main.rs
@@ -54,7 +54,8 @@ async fn main() -> Result<()> {
     metrics::register(&watcher);
     watcher.start_server(args.observability_address).await;
 
-    let client_config = common::generate_kafka_client_config(&args.broker, &args.username, &args.password);
+    let client_config =
+        common::generate_kafka_client_config(&args.broker, &args.username, &args.password);
 
     let consumer: StreamConsumer = client_config
         .set("group.id", &args.consumer_group)

--- a/trace-to-events/src/main.rs
+++ b/trace-to-events/src/main.rs
@@ -3,7 +3,7 @@ mod processing;
 
 use anyhow::Result;
 use clap::Parser;
-use common::{self, Intensity};
+use common::Intensity;
 use kagiyama::{AlwaysReady, Watcher};
 use rdkafka::{
     consumer::{stream_consumer::StreamConsumer, CommitMode, Consumer},

--- a/trace-to-events/src/main.rs
+++ b/trace-to-events/src/main.rs
@@ -3,7 +3,7 @@ mod processing;
 
 use anyhow::Result;
 use clap::Parser;
-use common::Intensity;
+use common::{self, Intensity};
 use kagiyama::{AlwaysReady, Watcher};
 use rdkafka::{
     config::ClientConfig,
@@ -23,10 +23,10 @@ struct Cli {
     broker: String,
 
     #[clap(long)]
-    username: String,
+    username: Option<String>,
 
     #[clap(long)]
-    password: String,
+    password: Option<String>,
 
     #[clap(long = "group")]
     consumer_group: String,
@@ -54,12 +54,9 @@ async fn main() -> Result<()> {
     metrics::register(&watcher);
     watcher.start_server(args.observability_address).await;
 
-    let consumer: StreamConsumer = ClientConfig::new()
-        .set("bootstrap.servers", &args.broker)
-        .set("security.protocol", "sasl_plaintext")
-        .set("sasl.mechanisms", "SCRAM-SHA-256")
-        .set("sasl.username", &args.username)
-        .set("sasl.password", &args.password)
+    let client_config = common::generate_kafka_client_config(&args.broker, &args.username, &args.password);
+
+    let consumer: StreamConsumer = client_config
         .set("group.id", &args.consumer_group)
         .set("enable.partition.eof", "false")
         .set("session.timeout.ms", "6000")
@@ -68,13 +65,7 @@ async fn main() -> Result<()> {
 
     consumer.subscribe(&[&args.trace_topic])?;
 
-    let producer: FutureProducer = ClientConfig::new()
-        .set("bootstrap.servers", &args.broker)
-        .set("security.protocol", "sasl_plaintext")
-        .set("sasl.mechanisms", "SCRAM-SHA-256")
-        .set("sasl.username", &args.username)
-        .set("sasl.password", &args.password)
-        .create()?;
+    let producer: FutureProducer = client_config.create()?;
 
     loop {
         match consumer.recv().await {


### PR DESCRIPTION
Allows the `username` and `password` command line arguments to be omitted, in which case an unauthenticated Kafka connection is able to be created instead.