### PR TITLE
Add clippy::unnecessary_cast to flatbuffer ignore rules

### DIFF
--- a/streaming-types/src/lib.rs
+++ b/streaming-types/src/lib.rs
@@ -17,7 +17,7 @@ pub mod dev1_digitizer_event_v1_generated;
 pub mod hst1_histogram_v1_generated;
 
 #[rustfmt::skip]
-#[allow(unused_imports, clippy::derivable_impls, clippy::derive_partial_eq_without_eq, clippy::extra_unused_lifetimes, clippy::missing_safety_doc, clippy::size_of_in_element_count)]
+#[allow(unused_imports, clippy::derivable_impls, clippy::derive_partial_eq_without_eq, clippy::extra_unused_lifetimes, clippy::missing_safety_doc, clippy::size_of_in_element_count, clippy::unnecessary_cast)]
 pub mod frame_metadata_v1_generated;
 
 pub use flatbuffers;


### PR DESCRIPTION
Ignores `clippy::unnecessary_cast` in `flatc` generated code.