### PR TITLE
Inherit metadata and dependencies from Cargo workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ anyhow = "1.0"
 chrono = "0.4.22"
 clap = { version = "4.0", features = ["derive"] }
 env_logger = "0.10"
+# hdf5 = { version = "0.8.1", features = ["static"] }
 hdf5 = { git = "https://github.com/aldanor/hdf5-rust", rev = "26046fb4900ec38afd2a1c0494cff688b288662e", features = ["static"] }
 kagiyama = "0.3.0"
 lazy_static = "1.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,8 @@ members = [
   "trace-archiver",
   "trace-to-events",
 ]
+
+[workspace.package]
+version = "0.1.0"
+license = "GPL-3.0-only"
+edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,3 +14,18 @@ members = [
 version = "0.1.0"
 license = "GPL-3.0-only"
 edition = "2021"
+
+[workspace.dependencies]
+anyhow = "1.0"
+chrono = "0.4.22"
+clap = { version = "4.0", features = ["derive"] }
+env_logger = "0.10"
+hdf5 = { git = "https://github.com/aldanor/hdf5-rust", rev = "26046fb4900ec38afd2a1c0494cff688b288662e", features = ["static"] }
+kagiyama = "0.3.0"
+lazy_static = "1.4.0"
+log = "0.4"
+ndarray = "0.15.4"
+ndarray-stats = "0.5.1"
+rdkafka = { version = "0.31.0", features = ["cmake-build", "ssl-vendored", "gssapi-vendored", "sasl"] }
+serde = { version = "1", features = ["derive"] }
+tokio = { version = "1.24", features = ["macros", "rt-multi-thread"] }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -5,5 +5,5 @@ license.workspace = true
 edition.workspace = true
 
 [dependencies]
-kagiyama = "0.3.0"
-rdkafka = { version = "0.31.0", features = ["cmake-build", "ssl-vendored", "gssapi-vendored", "sasl"] }
+kagiyama.workspace = true
+rdkafka.workspace = true

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "common"
-version = "0.1.0"
-license = "GPL-3.0-only"
-edition = "2021"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
 
 [dependencies]
 kagiyama = "0.3.0"

--- a/events-to-histogram/Cargo.toml
+++ b/events-to-histogram/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "events-to-histogram"
-version = "0.1.0"
-license = "GPL-3.0-only"
-edition = "2021"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
 
 [dependencies]
 common = { path = "../common" }

--- a/events-to-histogram/Cargo.toml
+++ b/events-to-histogram/Cargo.toml
@@ -8,16 +8,16 @@ edition.workspace = true
 common = { path = "../common" }
 streaming-types = { path = "../streaming-types" }
 
-anyhow = "1.0"
-clap = { version = "4.0", features = ["derive"] }
-env_logger = "0.10"
-kagiyama = "0.3.0"
-lazy_static = "1.4.0"
-log = "0.4"
-ndarray = "0.15.6"
-ndarray-stats = "0.5.1"
-rdkafka = { version = "0.31.0", features = ["cmake-build", "ssl-vendored", "gssapi-vendored", "sasl"] }
-tokio = { version = "1.24", features = ["macros", "rt-multi-thread"] }
+anyhow.workspace = true
+clap.workspace = true
+env_logger.workspace = true
+kagiyama.workspace = true
+lazy_static.workspace = true
+log.workspace = true
+ndarray.workspace = true
+ndarray-stats.workspace = true
+rdkafka.workspace = true
+tokio.workspace = true
 
 [dev-dependencies]
-chrono = "0.4.22"
+chrono.workspace = true

--- a/kafka-daq-report/Cargo.toml
+++ b/kafka-daq-report/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "kafka-daq-report"
-version = "0.1.0"
-license = "GPL-3.0-only"
-edition = "2021"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
 
 [dependencies]
 common = { path = "../common" }

--- a/kafka-daq-report/Cargo.toml
+++ b/kafka-daq-report/Cargo.toml
@@ -13,7 +13,6 @@ chrono.workspace = true
 clap.workspace = true
 crossterm = "0.26.1"
 env_logger.workspace = true
-# hdf5 = { version = "0.8.1", features = ["static"] }
 hdf5.workspace = true
 lazy_static.workspace = true
 log.workspace = true

--- a/kafka-daq-report/Cargo.toml
+++ b/kafka-daq-report/Cargo.toml
@@ -8,16 +8,16 @@ edition.workspace = true
 common = { path = "../common" }
 streaming-types = { path = "../streaming-types" }
 
-anyhow = "1.0"
-chrono = "0.4.22"
-clap = { version = "4.0", features = ["derive"] }
+anyhow.workspace = true
+chrono.workspace = true
+clap.workspace = true
 crossterm = "0.26.1"
-env_logger = "0.10"
+env_logger.workspace = true
 # hdf5 = { version = "0.8.1", features = ["static"] }
-hdf5 = { git = "https://github.com/aldanor/hdf5-rust", rev = "26046fb4900ec38afd2a1c0494cff688b288662e", features = ["static"] }
-lazy_static = "1.4.0"
-log = "0.4"
-ndarray = "0.15.4"
+hdf5.workspace = true
+lazy_static.workspace = true
+log.workspace = true
+ndarray.workspace = true
 ratatui = "0.22.0"
-rdkafka = { version = "0.31.0", features = ["cmake-build", "ssl-vendored", "gssapi-vendored", "sasl"] }
-tokio = { version = "1.24", features = ["macros", "rt-multi-thread"] }
+rdkafka.workspace = true
+tokio.workspace = true

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -8,11 +8,11 @@ edition.workspace = true
 common = { path = "../common" }
 streaming-types = { path = "../streaming-types" }
 
-clap = { version = "4.0", features = ["derive"] }
-chrono = "0.4.22"
-env_logger = "0.10"
-log = "0.4"
-rdkafka = { version = "0.31.0", features = ["cmake-build", "ssl-vendored", "gssapi-vendored", "sasl"] }
-serde = { version = "1", features = ["derive"] }
-tokio = { version = "1.24", features = ["macros", "rt-multi-thread"] }
+clap.workspace = true
+chrono.workspace = true
+env_logger.workspace = true
+log.workspace = true
+rdkafka.workspace = true
+serde.workspace = true
+tokio.workspace = true
 toml = "0.7"

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "simulator"
-version = "0.1.0"
-license = "GPL-3.0-only"
-edition = "2021"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
 
 [dependencies]
 common = { path = "../common" }

--- a/stream-to-file/Cargo.toml
+++ b/stream-to-file/Cargo.toml
@@ -8,17 +8,17 @@ edition.workspace = true
 common = { path = "../common" }
 streaming-types = { path = "../streaming-types" }
 
-anyhow = "1.0"
-chrono = "0.4.22"
-clap = { version = "4.0", features = ["derive"] }
-env_logger = "0.10"
+anyhow.workspace = true
+chrono.workspace = true
+clap.workspace = true
+env_logger.workspace = true
 # hdf5 = { version = "0.8.1", features = ["static"] }
-hdf5 = { git = "https://github.com/aldanor/hdf5-rust", rev = "26046fb4900ec38afd2a1c0494cff688b288662e", features = ["static"] }
-kagiyama = "0.3.0"
-lazy_static = "1.4.0"
-log = "0.4"
-ndarray = "0.15.4"
-ndarray-stats = "0.5.1"
-rdkafka = { version = "0.31.0", features = ["cmake-build", "ssl-vendored", "gssapi-vendored", "sasl"] }
-serde = { version = "1", features = ["derive"] }
-tokio = { version = "1.24", features = ["macros", "rt-multi-thread"] }
+hdf5.workspace = true
+kagiyama.workspace = true
+lazy_static.workspace = true
+log.workspace = true
+ndarray.workspace = true
+ndarray-stats.workspace = true
+rdkafka.workspace = true
+serde.workspace = true
+tokio.workspace = true

--- a/stream-to-file/Cargo.toml
+++ b/stream-to-file/Cargo.toml
@@ -12,7 +12,6 @@ anyhow.workspace = true
 chrono.workspace = true
 clap.workspace = true
 env_logger.workspace = true
-# hdf5 = { version = "0.8.1", features = ["static"] }
 hdf5.workspace = true
 kagiyama.workspace = true
 lazy_static.workspace = true

--- a/stream-to-file/Cargo.toml
+++ b/stream-to-file/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "stream-to-file"
-version = "0.1.0"
-license = "GPL-3.0-only"
-edition = "2021"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
 
 [dependencies]
 common = { path = "../common" }

--- a/streaming-types/Cargo.toml
+++ b/streaming-types/Cargo.toml
@@ -8,5 +8,5 @@ edition.workspace = true
 flatc-rust = "*"
 
 [dependencies]
-chrono = "0.4.22"
+chrono.workspace = true
 flatbuffers = "22.9.29"

--- a/streaming-types/Cargo.toml
+++ b/streaming-types/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "streaming-types"
-version = "0.1.0"
-license = "GPL-3.0-only"
-edition = "2021"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
 
 [build-dependencies]
 flatc-rust = "*"

--- a/trace-archiver/Cargo.toml
+++ b/trace-archiver/Cargo.toml
@@ -12,7 +12,6 @@ anyhow.workspace = true
 chrono.workspace = true
 clap.workspace = true
 env_logger.workspace = true
-# hdf5 = { version = "0.8.1", features = ["static"] }
 hdf5.workspace = true
 kagiyama.workspace = true
 lazy_static.workspace = true

--- a/trace-archiver/Cargo.toml
+++ b/trace-archiver/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "trace-archiver"
-version = "0.1.0"
-license = "GPL-3.0-only"
-edition = "2021"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
 
 [dependencies]
 common = { path = "../common" }

--- a/trace-archiver/Cargo.toml
+++ b/trace-archiver/Cargo.toml
@@ -8,15 +8,15 @@ edition.workspace = true
 common = { path = "../common" }
 streaming-types = { path = "../streaming-types" }
 
-anyhow = "1.0"
-chrono = "0.4.22"
-clap = { version = "4.0", features = ["derive"] }
-env_logger = "0.10"
+anyhow.workspace = true
+chrono.workspace = true
+clap.workspace = true
+env_logger.workspace = true
 # hdf5 = { version = "0.8.1", features = ["static"] }
-hdf5 = { git = "https://github.com/aldanor/hdf5-rust", rev = "26046fb4900ec38afd2a1c0494cff688b288662e", features = ["static"] }
-kagiyama = "0.3.0"
-lazy_static = "1.4.0"
-log = "0.4"
-ndarray = "0.15.4"
-rdkafka = { version = "0.31.0", features = ["cmake-build", "ssl-vendored", "gssapi-vendored", "sasl"] }
-tokio = { version = "1.24", features = ["macros", "rt-multi-thread"] }
+hdf5.workspace = true
+kagiyama.workspace = true
+lazy_static.workspace = true
+log.workspace = true
+ndarray.workspace = true
+rdkafka.workspace = true
+tokio.workspace = true

--- a/trace-to-events/Cargo.toml
+++ b/trace-to-events/Cargo.toml
@@ -8,16 +8,16 @@ edition.workspace = true
 common = { path = "../common" }
 streaming-types = { path = "../streaming-types" }
 
-anyhow = "1.0"
-clap = { version = "4.0", features = ["derive"] }
-env_logger = "0.10"
+anyhow.workspace = true
+clap.workspace = true
+env_logger.workspace = true
 itertools = "0.10.4"
-kagiyama = "0.3.0"
-lazy_static = "1.4.0"
-log = "0.4"
+kagiyama.workspace = true
+lazy_static.workspace = true
+log.workspace = true
 rayon = "1.5.3"
-rdkafka = { version = "0.31.0", features = ["cmake-build", "ssl-vendored", "gssapi-vendored", "sasl"] }
-tokio = { version = "1.24", features = ["macros", "rt-multi-thread"] }
+rdkafka.workspace = true
+tokio.workspace = true
 
 [dev-dependencies]
-chrono = "0.4.22"
+chrono.workspace = true

--- a/trace-to-events/Cargo.toml
+++ b/trace-to-events/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "trace-to-events"
-version = "0.1.0"
-license = "GPL-3.0-only"
-edition = "2021"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
 
 [dependencies]
 common = { path = "../common" }


### PR DESCRIPTION
Move duplicate code to the workspace `Cargo.toml` file and inherit dependencies.