### PR TITLE
Remove Rust toolchain file

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,0 @@
-[toolchain]
-channel = "stable"
-components = ["rust-src", "clippy", "rustfmt", "rust-analyzer"]


### PR DESCRIPTION
No longer needed after #62.