### PR TITLE
Add open telemetry to nexus writer

### DIFF
--- a/nexus-writer/Cargo.toml
+++ b/nexus-writer/Cargo.toml
@@ -4,10 +4,6 @@ version.workspace = true
 license.workspace = true
 edition.workspace = true
 
-[features]
-default = ["opentelemetry"]
-opentelemetry = []
-
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true

--- a/nexus-writer/Cargo.toml
+++ b/nexus-writer/Cargo.toml
@@ -4,6 +4,10 @@ version.workspace = true
 license.workspace = true
 edition.workspace = true
 
+[features]
+default = ["opentelemetry"]
+opentelemetry = []
+
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true

--- a/nexus-writer/src/main.rs
+++ b/nexus-writer/src/main.rs
@@ -186,7 +186,7 @@ fn process_digitizer_event_list_message(nexus: &mut Nexus<SpannedRun>, payload: 
                     if let Some(run) = run {
                         let cur_span = tracing::Span::current();
                         run.span.in_scope(|| {
-                            let span = trace_span!("DAT Event List Message");
+                            let span = trace_span!("DATEventsListMessage");
                             span.follows_from(cur_span);
                         });
                     }
@@ -209,7 +209,7 @@ fn process_frame_assembled_event_list_message(nexus: &mut Nexus<SpannedRun>, pay
                     if let Some(run) = run {
                         let cur_span = tracing::Span::current();
                         run.span.in_scope(|| {
-                            let span = trace_span!("Frame Event List Message");
+                            let span = trace_span!("FrameEventsListMessage");
                             span.follows_from(cur_span);
                         });
                     }

--- a/nexus-writer/src/main.rs
+++ b/nexus-writer/src/main.rs
@@ -71,8 +71,6 @@ struct Cli {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    tracing_subscriber::fmt::init();
-
     let args = Cli::parse();
 
     let _tracer = init_tracer(args.otel_endpoint.as_deref());

--- a/nexus-writer/src/nexus/builder.rs
+++ b/nexus-writer/src/nexus/builder.rs
@@ -1,4 +1,4 @@
-use super::{Run, RunParameters};
+use super::{RunLike, RunParameters};
 use crate::GenericEventMessage;
 use anyhow::{anyhow, Error, Result};
 use chrono::Duration;
@@ -11,17 +11,18 @@ use supermusr_streaming_types::{
 use tracing::warn;
 
 #[derive(Default, Debug)]
-pub(crate) struct Nexus {
+pub(crate) struct Nexus<R : RunLike> {
     filename: Option<PathBuf>,
-    run_cache: VecDeque<Run>,
+    run_cache: VecDeque<R>,
     run_number: u32,
 }
 
-impl Nexus {
+impl<R : RunLike> Nexus<R> {
     pub(crate) fn new(filename: Option<PathBuf>) -> Self {
         Self {
             filename,
-            ..Default::default()
+            run_cache: VecDeque::default(),
+            run_number: u32::default()
         }
     }
 
@@ -30,30 +31,30 @@ impl Nexus {
             "\nNexus Context: {0:?}\n{e}",
             self.run_cache
                 .iter()
-                .map(|run| run.get_name())
+                .map(|run| run.as_ref().get_name())
                 .collect::<Vec<_>>()
         )
     }
 
     #[cfg(test)]
-    fn cache_iter(&self) -> vec_deque::Iter<'_, Run> {
+    fn cache_iter(&self) -> vec_deque::Iter<'_, R> {
         self.run_cache.iter()
     }
 
-    pub(crate) fn start_command(&mut self, data: RunStart<'_>) -> Result<()> {
+    pub(crate) fn start_command(&mut self, data: RunStart<'_>) -> Result<&R> {
         //  Check that the last run has already had its stop command
         if self
             .run_cache
             .back()
-            .map(|run| run.has_run_stop())
+            .map(|run| run.as_ref().has_run_stop())
             .unwrap_or(true)
         {
-            let run = Run::new(
+            let run = R::new(
                 self.filename.as_deref(),
                 RunParameters::new(data, self.run_number)?,
             )?;
             self.run_cache.push_back(run);
-            Ok(())
+            Ok(self.run_cache.back().unwrap())
         } else {
             Err(self.append_context(anyhow!("Unexpected RunStart Command.")))
         }
@@ -62,6 +63,7 @@ impl Nexus {
     pub(crate) fn stop_command(&mut self, data: RunStop<'_>) -> Result<()> {
         if let Some(last_run) = self.run_cache.back_mut() {
             last_run
+                .as_mut()
                 .set_stop_if_valid(self.filename.as_deref(), data)
                 .map_err(|e| self.append_context(e))
         } else {
@@ -71,8 +73,8 @@ impl Nexus {
 
     pub(crate) fn process_message(&mut self, message: &GenericEventMessage<'_>) -> Result<()> {
         for run in &mut self.run_cache.iter_mut() {
-            if run.is_message_timestamp_valid(&message.timestamp)? {
-                run.push_message(self.filename.as_deref(), message)?;
+            if run.as_ref().is_message_timestamp_valid(&message.timestamp)? {
+                run.as_mut().push_message(self.filename.as_deref(), message)?;
                 return Ok(());
             }
         }
@@ -81,7 +83,7 @@ impl Nexus {
     }
 
     pub(crate) fn flush(&mut self, delay: &Duration) -> Result<()> {
-        self.run_cache.retain(|run| !run.has_completed(delay));
+        self.run_cache.retain(|run| !run.as_ref().has_completed(delay));
         Ok(())
     }
 }
@@ -90,9 +92,10 @@ impl Nexus {
 mod test {
     use crate::{
         event_message::{test::create_frame_assembled_message, GenericEventMessage},
-        nexus::Nexus,
+        nexus::{Nexus, Run},
     };
     use chrono::{DateTime, Duration, Utc};
+    use super::*;
     use supermusr_streaming_types::{
         ecs_6s4t_run_stop_generated::{
             finish_run_stop_buffer, root_as_run_stop, RunStop, RunStopArgs,
@@ -137,7 +140,7 @@ mod test {
 
     #[test]
     fn empty_run() {
-        let mut nexus = Nexus::new(None);
+        let mut nexus = Nexus::<Run>::new(None);
         let mut fbb = FlatBufferBuilder::new();
         let start = create_start(&mut fbb, "Test1", 16).unwrap();
         nexus.start_command(start).unwrap();
@@ -178,7 +181,7 @@ mod test {
 
     #[test]
     fn no_run_start() {
-        let mut nexus = Nexus::new(None);
+        let mut nexus = Nexus::<Run>::new(None);
         let mut fbb = FlatBufferBuilder::new();
 
         let stop = create_stop(&mut fbb, "Test1", 0).unwrap();
@@ -187,7 +190,7 @@ mod test {
 
     #[test]
     fn no_run_stop() {
-        let mut nexus = Nexus::new(None);
+        let mut nexus = Nexus::<Run>::new(None);
         let mut fbb = FlatBufferBuilder::new();
 
         let start1 = create_start(&mut fbb, "Test1", 0).unwrap();
@@ -200,7 +203,7 @@ mod test {
 
     #[test]
     fn frame_messages_correct() {
-        let mut nexus = Nexus::new(None);
+        let mut nexus = Nexus::<Run>::new(None);
         let mut fbb = FlatBufferBuilder::new();
 
         let ts = GpsTime::new(0, 1, 0, 0, 16, 0, 0, 0);

--- a/nexus-writer/src/nexus/mod.rs
+++ b/nexus-writer/src/nexus/mod.rs
@@ -4,8 +4,9 @@ mod run;
 mod run_parameters;
 
 pub(crate) use builder::Nexus;
-use run::Run;
-use run_parameters::RunParameters;
+pub(crate) use run::Run;
+pub(crate) use run::RunLike;
+pub(crate) use run_parameters::RunParameters;
 
 pub(crate) const TIMESTAMP_FORMAT: &str = "%Y-%m-%dT%H:%M:%S%.f%z";
 pub(crate) const DATETIME_FORMAT: &str = "%Y-%m-%dT%H:%M:%S%z";

--- a/nexus-writer/src/nexus/run.rs
+++ b/nexus-writer/src/nexus/run.rs
@@ -2,17 +2,11 @@ use super::{hdf5::RunFile, RunParameters};
 use crate::event_message::GenericEventMessage;
 use anyhow::Result;
 use chrono::{DateTime, Duration, Utc};
-use std::{
-    fmt::Debug,
-    path::Path,
-};
+use std::{fmt::Debug, path::Path};
 use supermusr_streaming_types::ecs_6s4t_run_stop_generated::RunStop;
 
 pub(crate) trait RunLike: Debug + AsRef<Run> + AsMut<Run> {
-    fn new(
-        filename: Option<&Path>,
-        parameters: RunParameters
-    ) -> Result<Self>
+    fn new(filename: Option<&Path>, parameters: RunParameters) -> Result<Self>
     where
         Self: Sized;
 }
@@ -35,10 +29,7 @@ impl AsMut<Self> for Run {
 
 impl RunLike for Run {
     #[tracing::instrument]
-    fn new(
-        filename: Option<&Path>,
-        parameters: RunParameters
-    ) -> Result<Self> {
+    fn new(filename: Option<&Path>, parameters: RunParameters) -> Result<Self> {
         if let Some(filename) = filename {
             let mut hdf5 = RunFile::new(filename, &parameters.run_name)?;
             hdf5.init(&parameters)?;
@@ -47,7 +38,6 @@ impl RunLike for Run {
         Ok(Self { parameters })
     }
 }
-
 
 impl Run {
     pub(crate) fn new(filename: Option<&Path>, parameters: RunParameters) -> Result<Self> {

--- a/nexus-writer/src/nexus/run.rs
+++ b/nexus-writer/src/nexus/run.rs
@@ -2,13 +2,52 @@ use super::{hdf5::RunFile, RunParameters};
 use crate::event_message::GenericEventMessage;
 use anyhow::Result;
 use chrono::{DateTime, Duration, Utc};
-use std::path::Path;
+use std::{
+    fmt::Debug,
+    path::Path,
+};
 use supermusr_streaming_types::ecs_6s4t_run_stop_generated::RunStop;
+
+pub(crate) trait RunLike: Debug + AsRef<Run> + AsMut<Run> {
+    fn new(
+        filename: Option<&Path>,
+        parameters: RunParameters
+    ) -> Result<Self>
+    where
+        Self: Sized;
+}
 
 #[derive(Debug)]
 pub(crate) struct Run {
     parameters: RunParameters,
 }
+
+impl AsRef<Self> for Run {
+    fn as_ref(&self) -> &Run {
+        self
+    }
+}
+impl AsMut<Self> for Run {
+    fn as_mut(&mut self) -> &mut Self {
+        self
+    }
+}
+
+impl RunLike for Run {
+    #[tracing::instrument]
+    fn new(
+        filename: Option<&Path>,
+        parameters: RunParameters
+    ) -> Result<Self> {
+        if let Some(filename) = filename {
+            let mut hdf5 = RunFile::new(filename, &parameters.run_name)?;
+            hdf5.init(&parameters)?;
+            hdf5.close()?;
+        }
+        Ok(Self { parameters })
+    }
+}
+
 
 impl Run {
     pub(crate) fn new(filename: Option<&Path>, parameters: RunParameters) -> Result<Self> {

--- a/nexus-writer/src/spanned_run.rs
+++ b/nexus-writer/src/spanned_run.rs
@@ -1,0 +1,19 @@
+use crate::nexus::{Run, RunLike, RunParameters};
+use anyhow::Result;
+use supermusr_common::tracer::Spanned;
+use tracing::trace_span;
+
+pub(crate) type SpannedRun = Spanned<Run>;
+
+impl RunLike for SpannedRun {
+    fn new(
+        filename: Option<&std::path::Path>,
+        parameters: RunParameters
+    ) -> Result<Self> {
+        let span = trace_span!("Run");
+        Ok(Spanned::new(
+            span,
+            Run::new(filename, parameters)?,
+        ))
+    }
+}

--- a/nexus-writer/src/spanned_run.rs
+++ b/nexus-writer/src/spanned_run.rs
@@ -6,14 +6,8 @@ use tracing::trace_span;
 pub(crate) type SpannedRun = Spanned<Run>;
 
 impl RunLike for SpannedRun {
-    fn new(
-        filename: Option<&std::path::Path>,
-        parameters: RunParameters
-    ) -> Result<Self> {
+    fn new(filename: Option<&std::path::Path>, parameters: RunParameters) -> Result<Self> {
         let span = trace_span!("Run");
-        Ok(Spanned::new(
-            span,
-            Run::new(filename, parameters)?,
-        ))
+        Ok(Spanned::new(span, Run::new(filename, parameters)?))
     }
 }


### PR DESCRIPTION
Adds OpenTelemetry and some tracing to the nexus writer component.

- otel_endpoint optional command line parameter added
- init_tracer function sets up OpenTelemetry if otel_endpoint is specified and runs tracing_subscriber::fmt::init() otherwise
- Extracts external trace from consumed Kafka headers if present and sets current trace as a child of it.
- Associates a trace with each Run object, to which all relevant external traces are collected.