### PR TITLE
Add open telemetry to digitiser aggregator

### DIFF
--- a/digitiser-aggregator/src/frame/aggregated.rs
+++ b/digitiser-aggregator/src/frame/aggregated.rs
@@ -1,9 +1,32 @@
-use super::partial::PartialFrame;
+use super::partial::{PartialFrame, PartialFrameLike};
 use crate::data::{Accumulate, DigitiserData};
+use std::fmt::Debug;
 #[cfg(test)]
 use supermusr_common::DigitizerId;
 use supermusr_streaming_types::FrameMetadata;
 
+pub(crate) trait AggregatedFrameLike<D, P: PartialFrameLike<D>>:
+    Debug + AsRef<AggregatedFrame<D>> + AsMut<AggregatedFrame<D>> + From<P>
+{
+}
+
+impl<D> AsRef<Self> for AggregatedFrame<D> {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+impl<D> AsMut<Self> for AggregatedFrame<D> {
+    fn as_mut(&mut self) -> &mut Self {
+        self
+    }
+}
+
+impl<D: Debug> AggregatedFrameLike<D, PartialFrame<D>> for AggregatedFrame<D> where
+    Vec<(u8, D)>: Accumulate<D>
+{
+}
+
+#[derive(Debug)]
 pub(crate) struct AggregatedFrame<D> {
     pub(crate) metadata: FrameMetadata,
     #[cfg(test)]

--- a/digitiser-aggregator/src/frame/cache.rs
+++ b/digitiser-aggregator/src/frame/cache.rs
@@ -27,8 +27,8 @@ where
 
     pub(crate) fn find(&self, metadata: FrameMetadata) -> Option<&P> {
         self.frames
-        .iter()
-        .find(|frame| frame.as_ref().metadata == metadata)
+            .iter()
+            .find(|frame| frame.as_ref().metadata == metadata)
     }
 
     pub(crate) fn push(&mut self, digitiser_id: DigitizerId, metadata: FrameMetadata, data: D) {

--- a/digitiser-aggregator/src/frame/cache.rs
+++ b/digitiser-aggregator/src/frame/cache.rs
@@ -1,17 +1,18 @@
-use super::{aggregated::AggregatedFrame, partial::PartialFrame};
+use super::{aggregated::AggregatedFrameLike, partial::PartialFrameLike};
 use crate::data::{Accumulate, DigitiserData};
-use std::{collections::VecDeque, time::Duration};
+use std::{collections::VecDeque, fmt::Debug, marker::PhantomData, time::Duration};
 use supermusr_common::DigitizerId;
 use supermusr_streaming_types::FrameMetadata;
 
-pub(crate) struct FrameCache<D> {
+pub(crate) struct FrameCache<D: Debug, P: PartialFrameLike<D>, A: AggregatedFrameLike<D, P>> {
     ttl: Duration,
     expected_digitisers: Vec<DigitizerId>,
 
-    frames: VecDeque<PartialFrame<D>>,
+    frames: VecDeque<P>,
+    _phantom: PhantomData<(D, A)>,
 }
 
-impl<D> FrameCache<D>
+impl<D: Debug, P: PartialFrameLike<D>, A: AggregatedFrameLike<D, P>> FrameCache<D, P, A>
 where
     DigitiserData<D>: Accumulate<D>,
 {
@@ -20,6 +21,7 @@ where
             ttl,
             expected_digitisers,
             frames: Default::default(),
+            _phantom: Default::default(),
         }
     }
 
@@ -27,23 +29,25 @@ where
         match self
             .frames
             .iter_mut()
-            .find(|frame| frame.metadata == metadata)
+            .find(|frame| frame.as_ref().metadata == metadata)
         {
             Some(frame) => {
-                frame.push(digitiser_id, data);
+                frame.as_mut().push(digitiser_id, data);
             }
             None => {
-                let mut frame = PartialFrame::new(self.ttl, metadata);
-                frame.push(digitiser_id, data);
+                let mut frame = P::new(self.ttl, metadata);
+                frame.as_mut().push(digitiser_id, data);
                 self.frames.push_back(frame);
             }
         }
     }
 
-    pub(crate) fn poll(&mut self) -> Option<AggregatedFrame<D>> {
+    pub(crate) fn poll(&mut self) -> Option<A> {
         match self.frames.front() {
             Some(frame) => {
-                if frame.is_complete(&self.expected_digitisers) || frame.is_expired() {
+                if frame.as_ref().is_complete(&self.expected_digitisers)
+                    || frame.as_ref().is_expired()
+                {
                     Some(self.frames.pop_front().unwrap().into())
                 } else {
                     None
@@ -57,8 +61,10 @@ where
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::data::EventData;
+    use crate::{data::EventData, frame::AggregatedFrame, frame::PartialFrame};
     use chrono::Utc;
+
+    type FrameCache<D> = super::FrameCache<D, PartialFrame<D>, AggregatedFrame<D>>;
 
     #[test]
     fn one_frame_in_one_frame_out() {

--- a/digitiser-aggregator/src/frame/cache.rs
+++ b/digitiser-aggregator/src/frame/cache.rs
@@ -25,6 +25,12 @@ where
         }
     }
 
+    pub(crate) fn find(&self, metadata: FrameMetadata) -> Option<&P> {
+        self.frames
+        .iter()
+        .find(|frame| frame.as_ref().metadata == metadata)
+    }
+
     pub(crate) fn push(&mut self, digitiser_id: DigitizerId, metadata: FrameMetadata, data: D) {
         match self
             .frames

--- a/digitiser-aggregator/src/frame/mod.rs
+++ b/digitiser-aggregator/src/frame/mod.rs
@@ -3,4 +3,7 @@ mod cache;
 mod partial;
 
 pub(crate) use aggregated::AggregatedFrame;
+pub(crate) use aggregated::AggregatedFrameLike;
 pub(crate) use cache::FrameCache;
+pub(crate) use partial::PartialFrame;
+pub(crate) use partial::PartialFrameLike;

--- a/digitiser-aggregator/src/frame/partial.rs
+++ b/digitiser-aggregator/src/frame/partial.rs
@@ -1,18 +1,29 @@
 use crate::data::DigitiserData;
+use std::fmt::Debug;
 use std::time::Duration;
 use supermusr_common::DigitizerId;
 use supermusr_streaming_types::FrameMetadata;
 use tokio::time::Instant;
 
-pub(super) struct PartialFrame<D> {
-    expiry: Instant,
-
-    pub(super) metadata: FrameMetadata,
-    pub(super) digitiser_data: DigitiserData<D>,
+pub(crate) trait PartialFrameLike<D>:
+    Debug + AsRef<PartialFrame<D>> + AsMut<PartialFrame<D>>
+{
+    fn new(ttl: Duration, metadata: FrameMetadata) -> Self;
 }
 
-impl<D> PartialFrame<D> {
-    pub(super) fn new(ttl: Duration, metadata: FrameMetadata) -> Self {
+impl<D> AsRef<Self> for PartialFrame<D> {
+    fn as_ref(&self) -> &Self {
+        self
+    }
+}
+impl<D> AsMut<Self> for PartialFrame<D> {
+    fn as_mut(&mut self) -> &mut Self {
+        self
+    }
+}
+
+impl<D: Debug> PartialFrameLike<D> for PartialFrame<D> {
+    fn new(ttl: Duration, metadata: FrameMetadata) -> Self {
         let expiry = Instant::now() + ttl;
 
         Self {
@@ -21,7 +32,17 @@ impl<D> PartialFrame<D> {
             digitiser_data: Default::default(),
         }
     }
+}
 
+#[derive(Debug)]
+pub(crate) struct PartialFrame<D> {
+    expiry: Instant,
+
+    pub(super) metadata: FrameMetadata,
+    pub(super) digitiser_data: DigitiserData<D>,
+}
+
+impl<D> PartialFrame<D> {
     pub(super) fn digitiser_ids(&self) -> Vec<DigitizerId> {
         let mut cache_digitiser_ids: Vec<DigitizerId> =
             self.digitiser_data.iter().map(|i| i.0).collect();

--- a/digitiser-aggregator/src/main.rs
+++ b/digitiser-aggregator/src/main.rs
@@ -111,6 +111,7 @@ async fn main() {
     }
 }
 
+#[tracing::instrument(skip_all, name = "Event Formation Message", level = "trace")]
 async fn on_message(
     root_span: &Span,
     args: &Cli,
@@ -118,9 +119,6 @@ async fn on_message(
     producer: &FutureProducer,
     msg: &BorrowedMessage<'_>,
 ) {
-    let span = trace_span!("Event Formation Message");
-    let _guard = span.enter();
-
     if args.otel_endpoint.is_some() {
         if let Some(headers) = msg.headers() {
             debug!("Kafka Header Found");

--- a/digitiser-aggregator/src/main.rs
+++ b/digitiser-aggregator/src/main.rs
@@ -133,14 +133,13 @@ async fn on_message(
             match root_as_digitizer_event_list_message(payload) {
                 Ok(msg) => {
                     debug!("Event packet: metadata: {:?}", msg.metadata());
-                    root_span.in_scope(|| {
-                        cache.push(
-                            msg.digitizer_id(),
-                            msg.metadata().try_into().unwrap(),
-                            msg.into(),
-                        );
-                    });
+                    cache.push(
+                        msg.digitizer_id(),
+                        msg.metadata().try_into().unwrap(),
+                        msg.into(),
+                    );
                     if let Some(frame) = cache.find(msg.metadata().try_into().unwrap()) {
+                        OtelTracer::set_span_parent_to(&frame.span, root_span);
                         let cur_span = tracing::Span::current();
                         frame.span.in_scope(|| {
                             let span = trace_span!("Digitiser Event List Message");

--- a/digitiser-aggregator/src/main.rs
+++ b/digitiser-aggregator/src/main.rs
@@ -118,7 +118,7 @@ async fn on_message(
     producer: &FutureProducer,
     msg: &BorrowedMessage<'_>,
 ) {
-    let span = trace_span!("Kafka Message");
+    let span = trace_span!("Event Formation Message");
     let _guard = span.enter();
     
     if args.otel_endpoint.is_some() {
@@ -142,7 +142,7 @@ async fn on_message(
                         OtelTracer::set_span_parent_to(&frame.span, root_span);
                         let cur_span = tracing::Span::current();
                         frame.span.in_scope(|| {
-                            let span = trace_span!("Digitiser Event List Message");
+                            let span = trace_span!("Digitiser Event List");
                             span.follows_from(cur_span);
                         });
                     }

--- a/digitiser-aggregator/src/main.rs
+++ b/digitiser-aggregator/src/main.rs
@@ -120,7 +120,7 @@ async fn on_message(
 ) {
     let span = trace_span!("Event Formation Message");
     let _guard = span.enter();
-    
+
     if args.otel_endpoint.is_some() {
         if let Some(headers) = msg.headers() {
             debug!("Kafka Header Found");
@@ -158,11 +158,7 @@ async fn on_message(
     }
 }
 
-async fn cache_poll(
-    args: &Cli,
-    cache: &mut FrameCache<EventData>,
-    producer: &FutureProducer,
-) {
+async fn cache_poll(args: &Cli, cache: &mut FrameCache<EventData>, producer: &FutureProducer) {
     if let Some(frame) = cache.poll() {
         let data: Vec<u8> = frame.value.into();
 

--- a/digitiser-aggregator/src/main.rs
+++ b/digitiser-aggregator/src/main.rs
@@ -188,8 +188,8 @@ fn init_tracer(otel_endpoint: Option<&str>) -> Option<OtelTracer> {
         .map(|otel_endpoint| {
             OtelTracer::new(
                 otel_endpoint,
-                "Trace Reader",
-                Some(("trace_reader", LevelFilter::TRACE)),
+                "Digitiser Aggregator",
+                Some(("digitiser_aggregator", LevelFilter::TRACE)),
             )
             .expect("Open Telemetry Tracer is created")
         })

--- a/digitiser-aggregator/src/main.rs
+++ b/digitiser-aggregator/src/main.rs
@@ -111,7 +111,7 @@ async fn main() {
     }
 }
 
-#[tracing::instrument(skip_all, name = "Event Formation Message", level = "trace")]
+#[tracing::instrument(skip_all, level = "trace")]
 async fn on_message(
     root_span: &Span,
     args: &Cli,

--- a/digitiser-aggregator/src/spanned_frame.rs
+++ b/digitiser-aggregator/src/spanned_frame.rs
@@ -12,7 +12,7 @@ pub(crate) type SpannedPartialFrame<D> = Spanned<PartialFrame<D>>;
 
 impl<D: Debug> PartialFrameLike<D> for SpannedPartialFrame<D> {
     fn new(ttl: Duration, metadata: FrameMetadata) -> Self {
-        let span = trace_span!("Run");
+        let span = trace_span!("Frame");
         Spanned {
             span,
             value: PartialFrame::<D>::new(ttl, metadata),

--- a/digitiser-aggregator/src/spanned_frame.rs
+++ b/digitiser-aggregator/src/spanned_frame.rs
@@ -1,0 +1,64 @@
+use std::{fmt::Debug, time::Duration};
+use supermusr_common::tracer::Spanned;
+use supermusr_streaming_types::FrameMetadata;
+use tracing::{trace_span, Span};
+
+use crate::{
+    data::Accumulate,
+    frame::{AggregatedFrame, AggregatedFrameLike, FrameCache, PartialFrame, PartialFrameLike},
+};
+
+pub(crate) type SpannedPartialFrame<D> = Spanned<PartialFrame<D>>;
+
+impl<D: Debug> PartialFrameLike<D> for SpannedPartialFrame<D> {
+    fn new(ttl: Duration, metadata: FrameMetadata) -> Self {
+        let span = trace_span!("Run");
+        Spanned {
+            span,
+            value: PartialFrame::<D>::new(ttl, metadata),
+        }
+    }
+}
+
+pub(crate) struct SpannedAggregatedFrame<D> {
+    pub(crate) span: Span,
+    pub(crate) value: AggregatedFrame<D>,
+}
+
+impl<D: Debug> Debug for SpannedAggregatedFrame<D> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.value.fmt(f)
+    }
+}
+
+impl<D> AsRef<AggregatedFrame<D>> for SpannedAggregatedFrame<D> {
+    fn as_ref(&self) -> &AggregatedFrame<D> {
+        &self.value
+    }
+}
+
+impl<D> AsMut<AggregatedFrame<D>> for SpannedAggregatedFrame<D> {
+    fn as_mut(&mut self) -> &mut AggregatedFrame<D> {
+        &mut self.value
+    }
+}
+
+impl<D: Debug> AggregatedFrameLike<D, SpannedPartialFrame<D>> for SpannedAggregatedFrame<D> where
+    Vec<(u8, D)>: Accumulate<D>
+{
+}
+
+impl<D: Debug> From<SpannedPartialFrame<D>> for SpannedAggregatedFrame<D>
+where
+    Vec<(u8, D)>: Accumulate<D>,
+{
+    fn from(pf: SpannedPartialFrame<D>) -> Self {
+        SpannedAggregatedFrame {
+            span: pf.span,
+            value: pf.value.into(),
+        }
+    }
+}
+
+pub(crate) type SpannedFrameCache<D> =
+    FrameCache<D, SpannedPartialFrame<D>, SpannedAggregatedFrame<D>>;


### PR DESCRIPTION
Adds OpenTelemetry and some tracing to the aggregator component.

- otel_endpoint optional command line parameter added
- init_tracer function sets up OpenTelemetry if otel_endpoint is specified and runs tracing_subscriber::fmt::init() otherwise
- Extracts external trace from consumed Kafka headers if present and sets current trace as a child of it.
- Associates a trace with each Frame object, to which all relevant external traces are collected. (I'm not 100% happy with how fiddly this is - modifications are needed to the PartialFrame and AggregatedFrame functionality - it suggests there could be room to streamline the Spanned generic type in the future, but it works fine for the moment).