### PR TITLE
Add open telemetry to run simulator

### DIFF
--- a/run-simulator/Cargo.toml
+++ b/run-simulator/Cargo.toml
@@ -4,10 +4,6 @@ version.workspace = true
 license.workspace = true
 edition.workspace = true
 
-[features]
-default = ["opentelemetry"]
-opentelemetry = []
-
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true

--- a/run-simulator/Cargo.toml
+++ b/run-simulator/Cargo.toml
@@ -4,6 +4,10 @@ version.workspace = true
 license.workspace = true
 edition.workspace = true
 
+[features]
+default = ["opentelemetry"]
+opentelemetry = []
+
 [dependencies]
 anyhow.workspace = true
 chrono.workspace = true

--- a/run-simulator/src/main.rs
+++ b/run-simulator/src/main.rs
@@ -68,8 +68,6 @@ struct Status {
 
 #[tokio::main]
 async fn main() {
-    tracing_subscriber::fmt::init();
-
     let cli = Cli::parse();
 
     let _tracer = init_tracer(cli.otel_endpoint.as_deref());

--- a/run-simulator/src/main.rs
+++ b/run-simulator/src/main.rs
@@ -4,7 +4,8 @@ use clap::{Parser, Subcommand};
 #[cfg(feature = "opentelemetry")]
 use rdkafka::message::OwnedHeaders;
 use rdkafka::{
-    producer::{FutureProducer, FutureRecord}, util::Timeout
+    producer::{FutureProducer, FutureRecord},
+    util::Timeout,
 };
 use std::time::Duration;
 #[cfg(feature = "opentelemetry")]
@@ -16,7 +17,7 @@ use supermusr_streaming_types::{
 };
 #[cfg(feature = "opentelemetry")]
 use tracing::level_filters::LevelFilter;
-use tracing::{debug, trace_span, error, info};
+use tracing::{debug, error, info, trace_span};
 #[cfg(feature = "opentelemetry")]
 use tracing_subscriber as _;
 
@@ -105,10 +106,13 @@ async fn main() {
     let mut fbb = FlatBufferBuilder::new();
     let time = cli.time.unwrap_or(Utc::now());
     let bytes = match cli.mode.clone() {
-        Mode::RunStart(status) => create_run_start_command(&mut fbb, time, &cli.run_name, &status.instrument_name)
-                .expect("RunStart created"),
-        Mode::RunStop => create_run_stop_command(&mut fbb, time, &cli.run_name)
-            .expect("RunStop created"),
+        Mode::RunStart(status) => {
+            create_run_start_command(&mut fbb, time, &cli.run_name, &status.instrument_name)
+                .expect("RunStart created")
+        }
+        Mode::RunStop => {
+            create_run_stop_command(&mut fbb, time, &cli.run_name).expect("RunStop created")
+        }
     };
 
     // Send bytes to the broker


### PR DESCRIPTION
Adds OpenTelemetry and some tracing to the run simulator component.

- otel_endpoint optional command line parameter added
- init_tracer function sets up OpenTelemetry if otel_endpoint is specified and runs tracing_subscriber::fmt::init() otherwise
- Propagates current trace to the next component via the Kafka header.