### PR TITLE
Add open telemetry to simulator

### DIFF
--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -212,12 +212,12 @@ async fn send(
                     &mut headers,
                 );
 
-                FutureRecord::to(&topic)
+                FutureRecord::to(topic)
                     .payload(fbb.finished_data())
                     .headers(headers)
                     .key("Simulated Event")
             } else {
-                FutureRecord::to(&topic)
+                FutureRecord::to(topic)
                     .payload(fbb.finished_data())
                     .key("Simulated Event")
             }
@@ -348,12 +348,12 @@ async fn send(
                     &mut headers,
                 );
 
-                FutureRecord::to(&topic)
+                FutureRecord::to(topic)
                     .payload(fbb.finished_data())
                     .headers(headers)
                     .key("Simulated Trace")
             } else {
-                FutureRecord::to(&topic)
+                FutureRecord::to(topic)
                     .payload(fbb.finished_data())
                     .key("Simulated Trace")
             }
@@ -395,7 +395,6 @@ async fn run_configured_simulation(cli: &Cli, producer: &FutureProducer, defined
             .flat_map(|v| std::iter::repeat(v).take(repeat))
             .enumerate()
         {
-
             let ts = trace.create_time_stamp(&now, index);
             let templates = trace
                 .create_frame_templates(frame_index, frame, &ts)

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -362,7 +362,7 @@ async fn send(
         let timeout = Timeout::After(Duration::from_millis(100));
         match producer.send(future_record, timeout).await {
             Ok(r) => debug!("Delivery: {:?}", r),
-            Err(e) => error!("Delivery failed: {:?}", e),
+            Err(e) => error!("Delivery failed: {:?}", e.0),
         };
 
         info!(

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -384,14 +384,9 @@ async fn run_configured_simulation(cli: &Cli, producer: &FutureProducer, defined
     let mut fbb = FlatBufferBuilder::new();
 
     let Defined { file, repeat } = defined;
-    let span = trace_span!("Defined Traces");
-    let _guard = span.enter();
 
     let obj: Simulation = serde_json::from_reader(File::open(file).unwrap()).unwrap();
     for trace in obj.traces {
-        let span = trace_span!("Trace Message");
-        let _guard = span.enter();
-
         let now = Utc::now();
         for (index, (frame_index, frame)) in trace
             .frames
@@ -400,8 +395,6 @@ async fn run_configured_simulation(cli: &Cli, producer: &FutureProducer, defined
             .flat_map(|v| std::iter::repeat(v).take(repeat))
             .enumerate()
         {
-            let span = trace_span!("Frame");
-            let _guard = span.enter();
 
             let ts = trace.create_time_stamp(&now, index);
             let templates = trace
@@ -409,11 +402,8 @@ async fn run_configured_simulation(cli: &Cli, producer: &FutureProducer, defined
                 .expect("Templates created");
 
             for template in templates {
-                let span = trace_span!("Digitizer");
-                let _guard = span.enter();
-
                 if let Some(trace_topic) = cli.trace_topic.as_deref() {
-                    let span = trace_span!("Digitizer Trace");
+                    let span = trace_span!("Frame Trace");
                     let _guard = span.enter();
 
                     let headers = {

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -403,7 +403,7 @@ async fn run_configured_simulation(cli: &Cli, producer: &FutureProducer, defined
 
             for template in templates {
                 if let Some(trace_topic) = cli.trace_topic.as_deref() {
-                    let span = trace_span!("Frame Trace");
+                    let span = trace_span!("Digitiser");
                     let _guard = span.enter();
 
                     let headers = {

--- a/simulator/src/message.rs
+++ b/simulator/src/message.rs
@@ -39,7 +39,6 @@ impl<'a> TraceMessage {
         .attributes
     }
 
-    #[tracing::instrument]
     pub(crate) fn create_frame_templates(
         &'a self,
         frame_index: usize,
@@ -91,7 +90,6 @@ impl<'a> TraceMessage {
             .collect())
     }
 
-    #[tracing::instrument]
     pub(crate) fn create_time_stamp(&self, now: &DateTime<Utc>, frame_index: usize) -> GpsTime {
         match self.timestamp {
             crate::simulation_config::Timestamp::Now => {
@@ -116,7 +114,6 @@ pub(crate) struct TraceTemplate<'a> {
 }
 
 impl TraceTemplate<'_> {
-    #[tracing::instrument(skip(self))]
     fn generate_trace(
         &self,
         muons: &[MuonEvent],
@@ -139,7 +136,6 @@ impl TraceTemplate<'_> {
             .collect()
     }
 
-    #[tracing::instrument(skip(self, producer))]
     pub(crate) async fn send_trace_messages(
         &self,
         producer: &FutureProducer,
@@ -202,7 +198,6 @@ impl TraceTemplate<'_> {
         Ok(())
     }
 
-    #[tracing::instrument(skip(self, producer))]
     pub(crate) async fn send_event_messages(
         &self,
         producer: &FutureProducer,
@@ -250,7 +245,7 @@ impl TraceTemplate<'_> {
         let timeout = Timeout::After(Duration::from_millis(100));
         match producer.send(future_record, timeout).await {
             Ok(r) => debug!("Delivery: {:?}", r),
-            Err(e) => error!("Delivery failed: {:?}", e),
+            Err(e) => error!("Delivery failed: {:?}", e.0),
         };
         info!(
             "Simulated Events List: {0}, {1}",

--- a/simulator/src/message.rs
+++ b/simulator/src/message.rs
@@ -173,12 +173,12 @@ impl TraceTemplate<'_> {
 
         let future_record = {
             if let Some(headers) = headers {
-                FutureRecord::to(&topic)
+                FutureRecord::to(topic)
                     .payload(fbb.finished_data())
                     .headers(headers)
                     .key("Simulated Trace")
             } else {
-                FutureRecord::to(&topic)
+                FutureRecord::to(topic)
                     .payload(fbb.finished_data())
                     .key("Simulated Trace")
             }
@@ -231,12 +231,12 @@ impl TraceTemplate<'_> {
 
         let future_record = {
             if let Some(headers) = headers {
-                FutureRecord::to(&topic)
+                FutureRecord::to(topic)
                     .payload(fbb.finished_data())
                     .headers(headers)
                     .key("Simulated Event")
             } else {
-                FutureRecord::to(&topic)
+                FutureRecord::to(topic)
                     .payload(fbb.finished_data())
                     .key("Simulated Event")
             }


### PR DESCRIPTION
Adds OpenTelemetry and some tracing to the trace simulator component.

- otel_endpoint optional command line parameter added
- init_tracer function sets up OpenTelemetry if otel_endpoint is specified and runs tracing_subscriber::fmt::init() otherwise
- Propagates current trace to the next component via the Kafka header.