### PR TITLE
Implement join set multithreading for aggregator and event formation

### DIFF
--- a/digitiser-aggregator/src/main.rs
+++ b/digitiser-aggregator/src/main.rs
@@ -10,7 +10,6 @@ use rdkafka::{
     producer::{FutureProducer, FutureRecord},
     util::Timeout,
 };
-use tokio::task::JoinSet;
 use std::{fmt::Debug, net::SocketAddr, time::Duration};
 use supermusr_common::{
     conditional_init_tracer,
@@ -21,6 +20,7 @@ use supermusr_common::{
 use supermusr_streaming_types::dev2_digitizer_event_v2_generated::{
     digitizer_event_list_message_buffer_has_identifier, root_as_digitizer_event_list_message,
 };
+use tokio::task::JoinSet;
 use tracing::{debug, error, level_filters::LevelFilter, trace_span, warn};
 
 #[derive(Debug, Parser)]

--- a/trace-to-events/src/main.rs
+++ b/trace-to-events/src/main.rs
@@ -103,7 +103,7 @@ async fn main() {
         .subscribe(&[&args.trace_topic])
         .expect("Kafka Consumer should subscribe to trace-topic");
 
-    let mut join_set = JoinSet::new();
+    let mut kafka_producer_thread_set = JoinSet::new();
 
     loop {
         match consumer.recv().await {
@@ -151,7 +151,7 @@ async fn main() {
                                 let future =
                                     producer.send_result(future_record).expect("Producer sends");
 
-                                join_set.spawn(async move {
+                                kafka_producer_thread_set.spawn(async move {
                                     match future.await {
                                         Ok(_) => {
                                             trace!("Published event message");

--- a/trace-to-events/src/main.rs
+++ b/trace-to-events/src/main.rs
@@ -11,7 +11,6 @@ use rdkafka::{
     message::Message,
     producer::{FutureProducer, FutureRecord},
 };
-use tokio::task::JoinSet;
 use std::{net::SocketAddr, path::PathBuf};
 use supermusr_common::{
     conditional_init_tracer,
@@ -25,6 +24,7 @@ use supermusr_streaming_types::{
     },
     flatbuffers::FlatBufferBuilder,
 };
+use tokio::task::JoinSet;
 use tracing::{debug, error, metadata::LevelFilter, trace, trace_span, warn};
 
 #[derive(Debug, Parser)]
@@ -104,7 +104,7 @@ async fn main() {
         .expect("Kafka Consumer should subscribe to trace-topic");
 
     let mut join_set = JoinSet::new();
-    
+
     loop {
         match consumer.recv().await {
             Ok(m) => {


### PR DESCRIPTION
Message producing in digitiser-aggregator and trace-to-events now uses multithreading, freeing the main thread to continue consuming messages.

Closes https://github.com/STFC-ICD-Research-and-Design/supermusr-data-pipeline/issues/183