### PR TITLE
Fix veto flag aggregation issue

### DIFF
--- a/digitiser-aggregator/src/frame/cache.rs
+++ b/digitiser-aggregator/src/frame/cache.rs
@@ -37,7 +37,7 @@ where
     pub(crate) fn find_span(&mut self, metadata: FrameMetadata) -> Option<&mut SpanOnce> {
         self.frames
             .iter_mut()
-            .find(|frame| frame.metadata.are_frames_equal(&metadata))
+            .find(|frame| frame.metadata.equals_ignoring_veto_flags(&metadata))
             .map(|frame| frame.span_mut())
     }
 
@@ -45,7 +45,7 @@ where
         match self
             .frames
             .iter_mut()
-            .find(|frame| frame.metadata.are_frames_equal(&metadata))
+            .find(|frame| frame.metadata.equals_ignoring_veto_flags(&metadata))
         {
             Some(frame) => {
                 frame.push(digitiser_id, data);

--- a/digitiser-aggregator/src/frame/cache.rs
+++ b/digitiser-aggregator/src/frame/cache.rs
@@ -37,7 +37,7 @@ where
     pub(crate) fn find_span(&mut self, metadata: FrameMetadata) -> Option<&mut SpanOnce> {
         self.frames
             .iter_mut()
-            .find(|frame| frame.metadata == metadata)
+            .find(|frame| frame.metadata.are_frames_equal(&metadata))
             .map(|frame| frame.span_mut())
     }
 
@@ -45,10 +45,11 @@ where
         match self
             .frames
             .iter_mut()
-            .find(|frame| frame.metadata == metadata)
+            .find(|frame| frame.metadata.are_frames_equal(&metadata))
         {
             Some(frame) => {
                 frame.push(digitiser_id, data);
+                frame.push_veto_flags(metadata.veto_flags)
             }
             None => {
                 let mut frame = PartialFrame::<D>::new(self.ttl, metadata);

--- a/digitiser-aggregator/src/frame/partial.rs
+++ b/digitiser-aggregator/src/frame/partial.rs
@@ -35,6 +35,10 @@ impl<D> PartialFrame<D> {
         self.digitiser_data.push((digitiser_id, data));
     }
 
+    pub(super) fn push_veto_flags(&mut self, veto_flags: u16) {
+        self.metadata.veto_flags |= veto_flags;
+    }
+
     pub(super) fn is_complete(&self, expected_digitisers: &[DigitizerId]) -> bool {
         self.digitiser_ids() == expected_digitisers
     }

--- a/streaming-types/src/frame_metadata.rs
+++ b/streaming-types/src/frame_metadata.rs
@@ -13,6 +13,16 @@ pub struct FrameMetadata {
     pub veto_flags: u16,
 }
 
+impl FrameMetadata {
+    pub fn are_frames_equal(&self, other: &Self) -> bool {
+        self.timestamp == other.timestamp
+            && self.period_number == other.period_number
+            && self.protons_per_pulse == other.protons_per_pulse
+            && self.running == other.running
+            && self.frame_number == other.frame_number
+    }
+}
+
 impl<'a> TryFrom<FrameMetadataV2<'a>> for FrameMetadata {
     type Error = GpsTimeConversionError;
 
@@ -86,5 +96,76 @@ mod tests {
         assert!(frame_metadata.running);
         assert_eq!(frame_metadata.frame_number, 559);
         assert_eq!(frame_metadata.veto_flags, 2);
+    }
+
+    #[test]
+    fn test_are_frames_equal() {
+        let m1 = FrameMetadata {
+            period_number: 12,
+            protons_per_pulse: 8,
+            running: true,
+            frame_number: 559,
+            timestamp: DateTime::from_timestamp_nanos(934856374698347),
+            veto_flags: 2,
+        };
+        let m2 = FrameMetadata {
+            period_number: 18,
+            protons_per_pulse: 8,
+            running: true,
+            frame_number: 559,
+            timestamp: DateTime::from_timestamp_nanos(934856374698347),
+            veto_flags: 2,
+        };
+        let m3 = FrameMetadata {
+            period_number: 12,
+            protons_per_pulse: 2,
+            running: true,
+            frame_number: 559,
+            timestamp: DateTime::from_timestamp_nanos(934856374698347),
+            veto_flags: 2,
+        };
+        let m4 = FrameMetadata {
+            period_number: 12,
+            protons_per_pulse: 8,
+            running: false,
+            frame_number: 559,
+            timestamp: DateTime::from_timestamp_nanos(934856374698347),
+            veto_flags: 2,
+        };
+        let m5 = FrameMetadata {
+            period_number: 12,
+            protons_per_pulse: 8,
+            running: true,
+            frame_number: 55,
+            timestamp: DateTime::from_timestamp_nanos(934856374698347),
+            veto_flags: 2,
+        };
+        let m6 = FrameMetadata {
+            period_number: 12,
+            protons_per_pulse: 8,
+            running: true,
+            frame_number: 559,
+            timestamp: DateTime::from_timestamp_nanos(934856374698348),
+            veto_flags: 2,
+        };
+        let m7 = FrameMetadata {
+            period_number: 12,
+            protons_per_pulse: 8,
+            running: true,
+            frame_number: 559,
+            timestamp: DateTime::from_timestamp_nanos(934856374698347),
+            veto_flags: 0,
+        };
+
+        // m1 has equal frame with m1
+        assert!(m1.are_frames_equal(&m1));
+        // The following comparisons should evalute to false
+        assert!(!m1.are_frames_equal(&m2));
+        assert!(!m1.are_frames_equal(&m3));
+        assert!(!m1.are_frames_equal(&m4));
+        assert!(!m1.are_frames_equal(&m5));
+        assert!(!m1.are_frames_equal(&m6));
+        // This one should be true however
+        assert!(m1.are_frames_equal(&m7));
     }
 }

--- a/streaming-types/src/frame_metadata.rs
+++ b/streaming-types/src/frame_metadata.rs
@@ -14,7 +14,7 @@ pub struct FrameMetadata {
 }
 
 impl FrameMetadata {
-    pub fn are_frames_equal(&self, other: &Self) -> bool {
+    pub fn equals_ignoring_veto_flags(&self, other: &Self) -> bool {
         self.timestamp == other.timestamp
             && self.period_number == other.period_number
             && self.protons_per_pulse == other.protons_per_pulse
@@ -158,14 +158,14 @@ mod tests {
         };
 
         // m1 has equal frame with m1
-        assert!(m1.are_frames_equal(&m1));
+        assert!(m1.equals_ignoring_veto_flags(&m1));
         // The following comparisons should evalute to false
-        assert!(!m1.are_frames_equal(&m2));
-        assert!(!m1.are_frames_equal(&m3));
-        assert!(!m1.are_frames_equal(&m4));
-        assert!(!m1.are_frames_equal(&m5));
-        assert!(!m1.are_frames_equal(&m6));
+        assert!(!m1.equals_ignoring_veto_flags(&m2));
+        assert!(!m1.equals_ignoring_veto_flags(&m3));
+        assert!(!m1.equals_ignoring_veto_flags(&m4));
+        assert!(!m1.equals_ignoring_veto_flags(&m5));
+        assert!(!m1.equals_ignoring_veto_flags(&m6));
         // This one should be true however
-        assert!(m1.are_frames_equal(&m7));
+        assert!(m1.equals_ignoring_veto_flags(&m7));
     }
 }


### PR DESCRIPTION
Digitiser-Aggregator was assigning digitiser messages to different frames because these messages had different veto flags. These modifications fixes that issue, and aggregates the veto flags by bitwise OR.

Closes https://github.com/STFC-ICD-Research-and-Design/supermusr-data-pipeline/issues/184.