### PR TITLE
Name change of mode in trace to events

### DIFF
--- a/trace-to-events/README.md
+++ b/trace-to-events/README.md
@@ -26,13 +26,13 @@ trace-to-events --help
 
 ### Commands
 
-- `ConstantPhaseDiscriminator`:       Detects events using a constant phase discriminator. Events consist only of a time value.
-- `AdvancedMuonDetector`:        Detects events using differential discriminators. Event lists consist of time and voltage values.
+- `fixed-threshold-discriminator`:       Detects events using a fixed threshold discriminator. Events consist only of a time value.
+- `advanced-muon-detector`:        Detects events using differential discriminators. Event lists consist of time and voltage values.
 - `help`:         Print this message or the help of the given subcommand(s)
 
 ### Constant Phase Discriminator
 
-`trace-to-events --broker <BROKER> constant-phase-discriminator --threshold <THRESHOLD>`
+`trace-to-events --broker <BROKER> fixed-threshold-discriminator --threshold <THRESHOLD>`
 
 ```shell
       --threshold <THRESHOLD>  If the detector is armed, an event is registered when the trace passes this value for the given duration
@@ -117,8 +117,8 @@ let pulses = events.assemble(BasicMuonAssembler::default())
 
 ## Detectors
 
-- Basic Muon Detector:
-- Threshold Detector:
+- Advanced Muon Detector:
+- Fixed Threshold Detector:
 
 ## Data Types
 

--- a/trace-to-events/README.md
+++ b/trace-to-events/README.md
@@ -26,9 +26,9 @@ trace-to-events --help
 
 ### Commands
 
-- `fixed-threshold-discriminator`:       Detects events using a fixed threshold discriminator. Events consist only of a time value.
-- `advanced-muon-detector`:        Detects events using differential discriminators. Event lists consist of time and voltage values.
-- `help`:         Print this message or the help of the given subcommand(s)
+- `fixed-threshold-discriminator`: Detects events using a fixed threshold discriminator. Events consist only of a time value.
+- `advanced-muon-detector`: Detects events using differential discriminators. Event lists consist of time and voltage values.
+- `help`: Print this message or the help of the given subcommand(s)
 
 ### Constant Phase Discriminator
 
@@ -117,8 +117,8 @@ let pulses = events.assemble(BasicMuonAssembler::default())
 
 ## Detectors
 
-- Advanced Muon Detector:
-- Fixed Threshold Detector:
+- Advanced Muon Detector
+- Fixed Threshold Detector
 
 ## Data Types
 

--- a/trace-to-events/src/parameters.rs
+++ b/trace-to-events/src/parameters.rs
@@ -16,7 +16,7 @@ pub(crate) enum Polarity {
 }
 
 #[derive(Default, Debug, Clone, Parser)]
-pub(crate) struct ConstantPhaseDiscriminatorParameters {
+pub(crate) struct FixedThresholdDiscriminatorParameters {
     /// If the detector is armed, an event is registered when the trace passes this value for the given duration.
     #[clap(long)]
     pub(crate) threshold: Real,
@@ -67,8 +67,8 @@ pub(crate) struct AdvancedMuonDetectorParameters {
 
 #[derive(Subcommand, Debug)]
 pub(crate) enum Mode {
-    /// Detects events using a constant phase discriminator. Events consist only of a time value.
-    ConstantPhaseDiscriminator(ConstantPhaseDiscriminatorParameters),
+    /// Detects events using a fixed threshold discriminator. Events consist only of a time value.
+    FixedThresholdDiscriminator(FixedThresholdDiscriminatorParameters),
     /// Detects events using differential discriminators. Event lists consist of time and voltage values.
     AdvancedMuonDetector(AdvancedMuonDetectorParameters),
 }

--- a/trace-to-events/src/processing.rs
+++ b/trace-to-events/src/processing.rs
@@ -1,10 +1,10 @@
 use crate::{
     parameters::{
-        AdvancedMuonDetectorParameters, ConstantPhaseDiscriminatorParameters, DetectorSettings,
+        AdvancedMuonDetectorParameters, FixedThresholdDiscriminatorParameters, DetectorSettings,
         Mode, Polarity,
     },
     pulse_detection::{
-        advanced_muon_detector::{AdvancedMuonDetector, BasicMuonAssembler},
+        advanced_muon_detector::{AdvancedMuonDetector, AdvancedMuonAssembler},
         threshold_detector::{ThresholdDetector, ThresholdDuration},
         window::{Baseline, FiniteDifferences, SmoothingWindow, WindowFilter},
         AssembleFilter, EventFilter, Real, SaveToFileFilter,
@@ -36,7 +36,7 @@ fn find_channel_events(
     save_options: Option<&Path>,
 ) -> (Vec<Time>, Vec<Intensity>) {
     match &detector_settings.mode {
-        Mode::ConstantPhaseDiscriminator(parameters) => find_constant_events(
+        Mode::FixedThresholdDiscriminator(parameters) => find_fixed_threshold_events(
             metadata,
             trace,
             sample_time,
@@ -58,13 +58,13 @@ fn find_channel_events(
 }
 
 #[tracing::instrument(skip(trace), fields(num_pulses))]
-fn find_constant_events(
+fn find_fixed_threshold_events(
     metadata: &FrameMetadataV2,
     trace: &ChannelTrace,
     sample_time: Real,
     polarity: &Polarity,
     baseline: Real,
-    parameters: &ConstantPhaseDiscriminatorParameters,
+    parameters: &FixedThresholdDiscriminatorParameters,
     save_path: Option<&Path>,
 ) -> (Vec<Time>, Vec<Intensity>) {
     let sign = match polarity {
@@ -158,7 +158,7 @@ fn find_advanced_events(
 
     let pulses = events
         .clone()
-        .assemble(BasicMuonAssembler::default())
+        .assemble(AdvancedMuonAssembler::default())
         .filter(|pulse| {
             Option::zip(parameters.min_amplitude, pulse.peak.value)
                 .map(|(min, val)| min <= val)
@@ -373,7 +373,7 @@ mod tests {
         let message = fbb.finished_data().to_vec();
         let message = root_as_digitizer_analog_trace_message(&message).unwrap();
 
-        let test_parameters = ConstantPhaseDiscriminatorParameters {
+        let test_parameters = FixedThresholdDiscriminatorParameters {
             threshold: 5.0,
             duration: 1,
             cool_off: 0,
@@ -383,7 +383,7 @@ mod tests {
             &mut fbb,
             &message,
             &DetectorSettings {
-                mode: &Mode::ConstantPhaseDiscriminator(test_parameters),
+                mode: &Mode::FixedThresholdDiscriminator(test_parameters),
                 polarity: &Polarity::Positive,
                 baseline: Intensity::default(),
             },
@@ -424,7 +424,7 @@ mod tests {
         let message = fbb.finished_data().to_vec();
         let message = root_as_digitizer_analog_trace_message(&message).unwrap();
 
-        let test_parameters = ConstantPhaseDiscriminatorParameters {
+        let test_parameters = FixedThresholdDiscriminatorParameters {
             threshold: 5.0,
             duration: 1,
             cool_off: 0,
@@ -434,7 +434,7 @@ mod tests {
             &mut fbb,
             &message,
             &DetectorSettings {
-                mode: &Mode::ConstantPhaseDiscriminator(test_parameters),
+                mode: &Mode::FixedThresholdDiscriminator(test_parameters),
                 polarity: &Polarity::Positive,
                 baseline: Intensity::default(),
             },
@@ -524,7 +524,7 @@ mod tests {
         let message = fbb.finished_data().to_vec();
         let message = root_as_digitizer_analog_trace_message(&message).unwrap();
 
-        let test_parameters = ConstantPhaseDiscriminatorParameters {
+        let test_parameters = FixedThresholdDiscriminatorParameters {
             threshold: 5.0,
             duration: 1,
             cool_off: 0,
@@ -534,7 +534,7 @@ mod tests {
             &mut fbb,
             &message,
             &DetectorSettings {
-                mode: &Mode::ConstantPhaseDiscriminator(test_parameters),
+                mode: &Mode::FixedThresholdDiscriminator(test_parameters),
                 polarity: &Polarity::Positive,
                 baseline: 3,
             },
@@ -624,7 +624,7 @@ mod tests {
         let message = fbb.finished_data().to_vec();
         let message = root_as_digitizer_analog_trace_message(&message).unwrap();
 
-        let test_parameters = ConstantPhaseDiscriminatorParameters {
+        let test_parameters = FixedThresholdDiscriminatorParameters {
             threshold: 5.0,
             duration: 1,
             cool_off: 0,
@@ -634,7 +634,7 @@ mod tests {
             &mut fbb,
             &message,
             &DetectorSettings {
-                mode: &Mode::ConstantPhaseDiscriminator(test_parameters),
+                mode: &Mode::FixedThresholdDiscriminator(test_parameters),
                 polarity: &Polarity::Negative,
                 baseline: 10,
             },

--- a/trace-to-events/src/processing.rs
+++ b/trace-to-events/src/processing.rs
@@ -1,10 +1,10 @@
 use crate::{
     parameters::{
-        AdvancedMuonDetectorParameters, FixedThresholdDiscriminatorParameters, DetectorSettings,
+        AdvancedMuonDetectorParameters, DetectorSettings, FixedThresholdDiscriminatorParameters,
         Mode, Polarity,
     },
     pulse_detection::{
-        advanced_muon_detector::{AdvancedMuonDetector, AdvancedMuonAssembler},
+        advanced_muon_detector::{AdvancedMuonAssembler, AdvancedMuonDetector},
         threshold_detector::{ThresholdDetector, ThresholdDuration},
         window::{Baseline, FiniteDifferences, SmoothingWindow, WindowFilter},
         AssembleFilter, EventFilter, Real, SaveToFileFilter,

--- a/trace-to-events/src/pulse_detection/detectors/advanced_muon_detector.rs
+++ b/trace-to-events/src/pulse_detection/detectors/advanced_muon_detector.rs
@@ -235,11 +235,11 @@ enum AssemblerMode {
 }
 
 #[derive(Default, Clone)]
-pub(crate) struct BasicMuonAssembler {
+pub(crate) struct AdvancedMuonAssembler {
     mode: AssemblerMode,
 }
 
-impl Assembler for BasicMuonAssembler {
+impl Assembler for AdvancedMuonAssembler {
     type DetectorType = AdvancedMuonDetector;
 
     fn assemble_pulses(&mut self, source: (Real, Data)) -> Option<Pulse> {


### PR DESCRIPTION
In trace-to-events: changes name of constant phase discriminator mode to fixed threshold discriminator

Closes https://github.com/STFC-ICD-Research-and-Design/supermusr-data-pipeline/issues/141