### PR TITLE
Update ADR and docs for Rust error handling

### DIFF
--- a/docs/adr/0007-standardise-error-handling.md
+++ b/docs/adr/0007-standardise-error-handling.md
@@ -27,13 +27,14 @@ This comes with the following issues:
 The above rules will be replaced with:
 
 1. This should never happen under normal or abnormal execution: `expect()`
-2. This might fail and the callee needs to care (i.e. in a library): `thiserror`
-3. This might fail and the user might care (i.e. in a binary): `anyhow`
+2. This might fail and the callee needs to care (i.e. in a library or modules containing logic in a binary): `thiserror`
+3. This might fail and the user might care (i.e. in only the setup proedure in a binary): `anyhow`
 
 The key changes, for clarity:
 
 - Move cases of 2 into 4
 - Forbid `unwrap()` and `panic()`
+- `anyhow` is only ever allowed to be the return value of `main()`
 
 `unwrap()` is also used extensively in automated tests, for the time being the above rules will only apply to production code, not testing.
 "Production code" in this case is defined as anything not inside or descending from a module named `test`.
@@ -43,3 +44,5 @@ The key changes, for clarity:
 Error handling throughout the codebase will need to be audited to ensure it complies with the above (there are certainly a good amount of changes that will need to be made).
 
 Automated tooling should be considered to automatically detect uses of forbidden calls (rustc or Clippy may already have suitable lints for this which could be enabled).
+
+A follow up task later will be to look at the use of other operators and functions which might panic, e.g. `[]` vs `get()`.

--- a/docs/style.md
+++ b/docs/style.md
@@ -61,5 +61,16 @@ fn two() -> i32 {
 Based on the nature of the error:
 
 1. This should never happen under normal or abnormal execution: `expect()`
-2. This might fail and the callee needs to care (i.e. in a library): `thiserror`
-3. This might fail and the user might care (i.e. in a binary): `anyhow`
+2. This might fail and the callee needs to care (i.e. in a library or binary logic modules): `thiserror`
+3. This might terminally fail during setup/teardown (i.e. in `main()`): `anyhow`
+
+The following are prohibited:
+
+- `unwrap()` (outside of automated tests)
+- `panic!()`
+- `anyhow::Result` anywhere other than as the return value of `main()`
+- Anything else from `anyhow`
+
+The following are strongly discouraged:
+
+- `[]` (use `get()` with appropriate error handling instead)


### PR DESCRIPTION
## Summary of changes

Further restrict the use of `anyhow`.
The flexibility of this has led to some quite sloppy error handling, particularly cases where errors that can be recovered from (e.g. only affecting a single frame of data) are propagated to the point of being terminal (at which point they may as well have just panicked and provided a little more information about the error).

Explicitly list the things that should not be done and are best not to do in the developer docs.

Note the desire to address other panicking operations and functions later on.

## Instruction for review/testing

- review revised wording of ADR and developer style guide
- see that the proposed guidelines are reasonable, clear/unambiguous and generally make sense
