### PR TITLE
Removed TIMESTAMP_FORMAT

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -17,6 +17,7 @@ pub type FrameNumber = u32;
 pub type SampleRate = u64;
 
 pub const CHANNELS_PER_DIGITIZER: usize = 8;
+pub const TIMESTAMP_FORMAT: &str = "%Y-%m-%dT%H:%M:%S%.f%z";
 
 pub fn channel_index(digitizer_index: usize, channel_index: usize) -> usize {
     (digitizer_index * CHANNELS_PER_DIGITIZER) + channel_index

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -17,7 +17,6 @@ pub type FrameNumber = u32;
 pub type SampleRate = u64;
 
 pub const CHANNELS_PER_DIGITIZER: usize = 8;
-pub const TIMESTAMP_FORMAT: &str = "%Y-%m-%dT%H:%M:%S%.f%z";
 
 pub fn channel_index(digitizer_index: usize, channel_index: usize) -> usize {
     (digitizer_index * CHANNELS_PER_DIGITIZER) + channel_index

--- a/nexus-writer/src/nexus/hdf5_file/run_file_components/event_run_file.rs
+++ b/nexus-writer/src/nexus/hdf5_file/run_file_components/event_run_file.rs
@@ -1,11 +1,11 @@
 use crate::nexus::{
     hdf5_file::{add_attribute_to, add_new_group_to, create_resizable_dataset},
-    nexus_class as NX, NexusSettings, TIMESTAMP_FORMAT,
+    nexus_class as NX, NexusSettings,
 };
 use chrono::{DateTime, Duration, Utc};
 use hdf5::{types::VarLenUnicode, Dataset, Group};
 use ndarray::s;
-use supermusr_common::{Channel, Time};
+use supermusr_common::{Channel, Time, TIMESTAMP_FORMAT};
 use supermusr_streaming_types::aev2_frame_assembled_event_v2_generated::FrameAssembledEventListMessage;
 use tracing::debug;
 

--- a/nexus-writer/src/nexus/hdf5_file/run_file_components/event_run_file.rs
+++ b/nexus-writer/src/nexus/hdf5_file/run_file_components/event_run_file.rs
@@ -5,7 +5,7 @@ use crate::nexus::{
 use chrono::{DateTime, Duration, Utc};
 use hdf5::{types::VarLenUnicode, Dataset, Group};
 use ndarray::s;
-use supermusr_common::{Channel, Time, TIMESTAMP_FORMAT};
+use supermusr_common::{Channel, Time};
 use supermusr_streaming_types::aev2_frame_assembled_event_v2_generated::FrameAssembledEventListMessage;
 use tracing::debug;
 
@@ -148,7 +148,7 @@ impl EventRun {
                 add_attribute_to(
                     &self.event_time_zero,
                     "offset",
-                    &timestamp.format(TIMESTAMP_FORMAT).to_string(),
+                    &timestamp.to_rfc3339(),
                 )?;
                 self.offset = Some(timestamp);
                 debug!("New offset set");

--- a/nexus-writer/src/nexus/hdf5_file/run_file_components/event_run_file.rs
+++ b/nexus-writer/src/nexus/hdf5_file/run_file_components/event_run_file.rs
@@ -145,11 +145,7 @@ impl EventRun {
                 debug!("Offset found");
                 timestamp - offset
             } else {
-                add_attribute_to(
-                    &self.event_time_zero,
-                    "offset",
-                    &timestamp.to_rfc3339(),
-                )?;
+                add_attribute_to(&self.event_time_zero, "offset", &timestamp.to_rfc3339())?;
                 self.offset = Some(timestamp);
                 debug!("New offset set");
                 Duration::zero()

--- a/nexus-writer/src/nexus/hdf5_file/run_file_components/timeseries_file.rs
+++ b/nexus-writer/src/nexus/hdf5_file/run_file_components/timeseries_file.rs
@@ -71,8 +71,7 @@ fn write_generic_logdata_slice_to_dataset<T: H5Type>(
 impl<'a> TimeSeriesDataSource<'a> for f144_LogData<'a> {
     #[tracing::instrument(skip(self))]
     fn write_initial_timestamp(&self, target: &Dataset) -> anyhow::Result<()> {
-        let time = DateTime::<Utc>::from_timestamp_nanos(self.timestamp())
-            .to_rfc3339();
+        let time = DateTime::<Utc>::from_timestamp_nanos(self.timestamp()).to_rfc3339();
         add_attribute_to(target, "Start", &time)?;
         add_attribute_to(target, "Units", "second")?;
         Ok(())
@@ -184,8 +183,7 @@ where
 impl<'a> TimeSeriesDataSource<'a> for se00_SampleEnvironmentData<'a> {
     #[tracing::instrument(skip(self))]
     fn write_initial_timestamp(&self, target: &Dataset) -> anyhow::Result<()> {
-        let time = DateTime::<Utc>::from_timestamp_nanos(self.packet_timestamp())
-            .to_rfc3339();
+        let time = DateTime::<Utc>::from_timestamp_nanos(self.packet_timestamp()).to_rfc3339();
         add_attribute_to(target, "Start", &time)?;
         add_attribute_to(target, "Units", "second")?;
         Ok(())

--- a/nexus-writer/src/nexus/hdf5_file/run_file_components/timeseries_file.rs
+++ b/nexus-writer/src/nexus/hdf5_file/run_file_components/timeseries_file.rs
@@ -5,7 +5,6 @@ use hdf5::{
 };
 use ndarray::{s, Dim, SliceInfo, SliceInfoElem};
 use std::fmt::Debug;
-use supermusr_common::TIMESTAMP_FORMAT;
 use supermusr_streaming_types::{
     ecs_f144_logdata_generated::{f144_LogData, Value},
     ecs_se00_data_generated::{se00_SampleEnvironmentData, ValueUnion},
@@ -73,8 +72,7 @@ impl<'a> TimeSeriesDataSource<'a> for f144_LogData<'a> {
     #[tracing::instrument(skip(self))]
     fn write_initial_timestamp(&self, target: &Dataset) -> anyhow::Result<()> {
         let time = DateTime::<Utc>::from_timestamp_nanos(self.timestamp())
-            .format(TIMESTAMP_FORMAT)
-            .to_string();
+            .to_rfc3339();
         add_attribute_to(target, "Start", &time)?;
         add_attribute_to(target, "Units", "second")?;
         Ok(())
@@ -187,8 +185,7 @@ impl<'a> TimeSeriesDataSource<'a> for se00_SampleEnvironmentData<'a> {
     #[tracing::instrument(skip(self))]
     fn write_initial_timestamp(&self, target: &Dataset) -> anyhow::Result<()> {
         let time = DateTime::<Utc>::from_timestamp_nanos(self.packet_timestamp())
-            .format(TIMESTAMP_FORMAT)
-            .to_string();
+            .to_rfc3339();
         add_attribute_to(target, "Start", &time)?;
         add_attribute_to(target, "Units", "second")?;
         Ok(())

--- a/nexus-writer/src/nexus/hdf5_file/run_file_components/timeseries_file.rs
+++ b/nexus-writer/src/nexus/hdf5_file/run_file_components/timeseries_file.rs
@@ -5,6 +5,7 @@ use hdf5::{
 };
 use ndarray::{s, Dim, SliceInfo, SliceInfoElem};
 use std::fmt::Debug;
+use supermusr_common::TIMESTAMP_FORMAT;
 use supermusr_streaming_types::{
     ecs_f144_logdata_generated::{f144_LogData, Value},
     ecs_se00_data_generated::{se00_SampleEnvironmentData, ValueUnion},
@@ -12,7 +13,7 @@ use supermusr_streaming_types::{
 };
 use tracing::{debug, trace};
 
-use crate::nexus::{hdf5_file::hdf5_writer::add_attribute_to, TIMESTAMP_FORMAT};
+use crate::nexus::hdf5_file::hdf5_writer::add_attribute_to;
 
 pub(super) type Slice1D = SliceInfo<[SliceInfoElem; 1], Dim<[usize; 1]>, Dim<[usize; 1]>>;
 

--- a/nexus-writer/src/nexus/mod.rs
+++ b/nexus-writer/src/nexus/mod.rs
@@ -7,7 +7,6 @@ pub(crate) use engine::{NexusEngine, NexusSettings};
 pub(crate) use run::Run;
 pub(crate) use run_parameters::RunParameters;
 
-pub(crate) const TIMESTAMP_FORMAT: &str = "%Y-%m-%dT%H:%M:%S%.f%z";
 pub(crate) const DATETIME_FORMAT: &str = "%Y-%m-%dT%H:%M:%S%z";
 
 pub(crate) mod nexus_class {


### PR DESCRIPTION
## Summary of changes

~~Moved the constant TIMESTAMP_FORMAT to common crate from the Nexus-Writer crate. This constant is used to parse `DateTime` objects into strings. Hence it is more logical to have a common format in a logical place.~~

Removed the constant `TIMESTAMP_FORMAT` from nexus-writer, and replaced its usage with `to_rfc3339()`.

## Instruction for review/testing

Ensure changes to code are as described above.
