### PR TITLE
Added record_metadata_fields_to_span macro to common crate

### DIFF
--- a/common/src/tracer/mod.rs
+++ b/common/src/tracer/mod.rs
@@ -59,13 +59,7 @@ macro_rules! init_tracer {
 #[macro_export]
 macro_rules! record_metadata_fields_to_span {
     ($metadata:expr, $span:expr) => {
-        $span.record(
-            "metadata_timestamp",
-            $metadata
-                .timestamp
-                .format(supermusr_common::TIMESTAMP_FORMAT)
-                .to_string(),
-        );
+        $span.record("metadata_timestamp", $metadata.timestamp.to_rfc3339());
         $span.record("metadata_frame_number", $metadata.frame_number);
         $span.record("metadata_period_number", $metadata.period_number);
         $span.record("metadata_veto_flags", $metadata.veto_flags);

--- a/common/src/tracer/mod.rs
+++ b/common/src/tracer/mod.rs
@@ -26,3 +26,50 @@ macro_rules! init_tracer {
         tracer
     }};
 }
+
+/// Should be called to populate the metadata fields of a given span
+/// # Arguments
+/// - metadata: supermusr_streaming_types::frame_metadata::FrameMetadata
+/// - span: Span
+///
+/// # Prerequisites
+/// The span should have been created with appropriate empty fields, either by
+/// ```ignore
+/// fields(
+///     //...
+///     metadata_timestamp = tracing::field::Empty,
+///     metadata_frame_number = tracing::field::Empty,
+///     metadata_period_number = tracing::field::Empty,
+///     metadata_veto_flags = tracing::field::Empty,
+///     metadata_protons_per_pulse = tracing::field::Empty,
+///     metadata_running = tracing::field::Empty,
+///     //...
+/// )
+/// ```
+/// if using the #[instrument] macro over a function, or with
+/// ```ignore
+///     "metadata_timestamp" = tracing::field::Empty,
+///     "metadata_frame_number" = tracing::field::Empty,
+///     "metadata_period_number" = tracing::field::Empty,
+///     "metadata_veto_flags" = tracing::field::Empty,
+///     "metadata_protons_per_pulse" = tracing::field::Empty,
+///     "metadata_running" = tracing::field::Empty,
+/// ```
+/// if creating the span directly using `info_span!()` or similar.
+#[macro_export]
+macro_rules! record_metadata_fields_to_span {
+    ($metadata:expr, $span:expr) => {
+        $span.record(
+            "metadata_timestamp",
+            $metadata
+                .timestamp
+                .format(supermusr_common::TIMESTAMP_FORMAT)
+                .to_string(),
+        );
+        $span.record("metadata_frame_number", $metadata.frame_number);
+        $span.record("metadata_period_number", $metadata.period_number);
+        $span.record("metadata_veto_flags", $metadata.veto_flags);
+        $span.record("metadata_protons_per_pulse", $metadata.protons_per_pulse);
+        $span.record("metadata_running", $metadata.running);
+    };
+}

--- a/digitiser-aggregator/src/frame/cache.rs
+++ b/digitiser-aggregator/src/frame/cache.rs
@@ -27,18 +27,18 @@ where
         }
     }
 
-    pub(crate) fn push(&mut self, digitiser_id: DigitizerId, metadata: FrameMetadata, data: D) {
+    pub(crate) fn push(&mut self, digitiser_id: DigitizerId, metadata: &FrameMetadata, data: D) {
         match self
             .frames
             .iter_mut()
-            .find(|frame| frame.metadata.equals_ignoring_veto_flags(&metadata))
+            .find(|frame| frame.metadata.equals_ignoring_veto_flags(metadata))
         {
             Some(frame) => {
                 frame.push(digitiser_id, data);
                 frame.push_veto_flags(metadata.veto_flags)
             }
             None => {
-                let mut frame = PartialFrame::<D>::new(self.ttl, metadata);
+                let mut frame = PartialFrame::<D>::new(self.ttl, metadata.clone());
                 frame.push(digitiser_id, data);
                 self.frames.push_back(frame);
             }
@@ -98,23 +98,19 @@ mod test {
 
         assert!(cache.poll().is_none());
 
-        cache.push(0, frame_1.clone(), EventData::dummy_data(0, 5, &[0, 1, 2]));
+        cache.push(0, &frame_1, EventData::dummy_data(0, 5, &[0, 1, 2]));
 
         assert!(cache.poll().is_none());
 
-        cache.push(1, frame_1.clone(), EventData::dummy_data(0, 5, &[3, 4, 5]));
+        cache.push(1, &frame_1, EventData::dummy_data(0, 5, &[3, 4, 5]));
 
         assert!(cache.poll().is_none());
 
-        cache.push(4, frame_1.clone(), EventData::dummy_data(0, 5, &[6, 7, 8]));
+        cache.push(4, &frame_1, EventData::dummy_data(0, 5, &[6, 7, 8]));
 
         assert!(cache.poll().is_none());
 
-        cache.push(
-            8,
-            frame_1.clone(),
-            EventData::dummy_data(0, 5, &[9, 10, 11]),
-        );
+        cache.push(8, &frame_1, EventData::dummy_data(0, 5, &[9, 10, 11]));
 
         {
             let frame = cache.poll().unwrap();
@@ -161,19 +157,15 @@ mod test {
 
         assert!(cache.poll().is_none());
 
-        cache.push(0, frame_1.clone(), EventData::dummy_data(0, 5, &[0, 1, 2]));
+        cache.push(0, &frame_1, EventData::dummy_data(0, 5, &[0, 1, 2]));
 
         assert!(cache.poll().is_none());
 
-        cache.push(1, frame_1.clone(), EventData::dummy_data(0, 5, &[3, 4, 5]));
+        cache.push(1, &frame_1, EventData::dummy_data(0, 5, &[3, 4, 5]));
 
         assert!(cache.poll().is_none());
 
-        cache.push(
-            8,
-            frame_1.clone(),
-            EventData::dummy_data(0, 5, &[9, 10, 11]),
-        );
+        cache.push(8, &frame_1, EventData::dummy_data(0, 5, &[9, 10, 11]));
 
         assert!(cache.poll().is_none());
 

--- a/digitiser-aggregator/src/main.rs
+++ b/digitiser-aggregator/src/main.rs
@@ -20,6 +20,7 @@ use supermusr_common::{
         messages_received::{self, MessageKind},
         metric_names::{FAILURES, FRAMES_SENT, MESSAGES_PROCESSED, MESSAGES_RECEIVED},
     },
+    record_metadata_fields_to_span,
     spanned::{FindSpanMut, Spanned},
     tracer::{FutureRecordTracerExt, OptionalHeaderTracerExt, TracerEngine, TracerOptions},
     CommonKafkaOpts, DigitizerId,
@@ -158,7 +159,15 @@ async fn main() -> anyhow::Result<()> {
     }
 }
 
-#[tracing::instrument(skip_all, level = "trace")]
+#[tracing::instrument(skip_all, fields(
+    digitiser_id = tracing::field::Empty,
+    metadata_timestamp = tracing::field::Empty,
+    metadata_frame_number = tracing::field::Empty,
+    metadata_period_number = tracing::field::Empty,
+    metadata_veto_flags = tracing::field::Empty,
+    metadata_protons_per_pulse = tracing::field::Empty,
+    metadata_running = tracing::field::Empty,
+))]
 async fn on_message(
     use_otel: bool,
     kafka_producer_thread_set: &mut JoinSet<()>,
@@ -180,6 +189,9 @@ async fn on_message(
                     let metadata_result: Result<FrameMetadata, _> = msg.metadata().try_into();
                     match metadata_result {
                         Ok(metadata) => {
+                            tracing::Span::current().record("digitiser_id", msg.digitizer_id());
+                            record_metadata_fields_to_span!(&metadata, tracing::Span::current());
+
                             debug!("Event packet: metadata: {:?}", msg.metadata());
                             cache.push(msg.digitizer_id(), metadata.clone(), msg.into());
 

--- a/nexus-writer/src/main.rs
+++ b/nexus-writer/src/main.rs
@@ -265,8 +265,7 @@ fn process_frame_assembled_event_list_message(nexus_engine: &mut NexusEngine, pa
     match root_as_frame_assembled_event_list_message(payload) {
         Ok(data) => match nexus_engine.process_event_list(&data) {
             Ok(run) => {
-                let metadata_result: Result<FrameMetadata, _> = data.metadata().try_into();
-                match metadata_result {
+                match data.metadata().try_into() as Result<FrameMetadata, _> {
                     Ok(metadata) => {
                         record_metadata_fields_to_span!(&metadata, tracing::Span::current());
                     }

--- a/nexus-writer/src/main.rs
+++ b/nexus-writer/src/main.rs
@@ -17,6 +17,7 @@ use supermusr_common::{
         messages_received::{self, MessageKind},
         metric_names::{FAILURES, MESSAGES_PROCESSED, MESSAGES_RECEIVED},
     },
+    record_metadata_fields_to_span,
     spanned::SpannedAggregator,
     tracer::{OptionalHeaderTracerExt, TracerEngine, TracerOptions},
     CommonKafkaOpts,


### PR DESCRIPTION
## Summary of changes

Added `record_metadata_fields_to_span` macro to populate spans which are setup to record metadata fields.

## Instruction for review/testing

Does code reflect description above, and does the attached doc comment make sense and adequately explain its purpose.
