### PR TITLE
Updates to digitiser aggregator, and adding fields to spans

### DIFF
--- a/digitiser-aggregator/src/frame/cache.rs
+++ b/digitiser-aggregator/src/frame/cache.rs
@@ -45,8 +45,9 @@ where
             .or_insert_with(|| {
                 // or create a new PartialFrame
                 let mut frame = PartialFrame::<D>::new(self.ttl, metadata.clone());
+
+                // Initialise the span field
                 if let Err(e) = frame.span_init() {
-                    // Initialise the span field
                     warn!("Frame span initiation failed {e}")
                 }
                 frame
@@ -235,6 +236,8 @@ mod test {
             veto_flags: 5,
         };
 
+        assert_eq!(frame_1, frame_2);
+
         assert_eq!(cache.frames.len(), 0);
         assert!(cache.poll().is_none());
 
@@ -245,6 +248,5 @@ mod test {
         cache.push(2, &frame_2, EventData::dummy_data(0, 5, &[0, 1, 2]));
         assert_eq!(cache.frames.len(), 1);
         assert!(cache.poll().is_some());
-        //let frame = cache.poll().is_some();
     }
 }

--- a/digitiser-aggregator/src/frame/cache.rs
+++ b/digitiser-aggregator/src/frame/cache.rs
@@ -60,7 +60,7 @@ where
 
                     frame.push(digitiser_id, data);
                     self.frames.push_back(frame);
-                    self.frames.back().expect("Partial Frame Exists")
+                    self.frames.back().expect("This should never fails")
                 }
             }
         };
@@ -90,7 +90,7 @@ where
             .front()
             .is_some_and(|frame| frame.is_complete(&self.expected_digitisers) | frame.is_expired())
         {
-            let frame = self.frames.pop_front().expect("Frame Exists");
+            let frame = self.frames.pop_front().expect("This should never fail");
             if let Err(e) = frame.end_span() {
                 warn!("Frame span drop failed {e}")
             }

--- a/digitiser-aggregator/src/frame/cache.rs
+++ b/digitiser-aggregator/src/frame/cache.rs
@@ -40,7 +40,7 @@ where
         data: D,
     ) {
         let frame = {
-                match self
+            match self
                 .frames
                 .iter_mut()
                 .find(|frame| frame.metadata.equals_ignoring_veto_flags(metadata))
@@ -64,7 +64,7 @@ where
                 }
             }
         };
-            
+
         // Link this span with the frame aggregator span associated with `frame`
         if let Err(e) = frame.link_current_span(|| {
             let span = info_span!(target: "otel",

--- a/digitiser-aggregator/src/frame/cache.rs
+++ b/digitiser-aggregator/src/frame/cache.rs
@@ -60,7 +60,9 @@ where
 
                     frame.push(digitiser_id, data);
                     self.frames.push_back(frame);
-                    self.frames.back().expect("self.frames should be non-empty, this should never fails")
+                    self.frames
+                        .back()
+                        .expect("self.frames should be non-empty, this should never fails")
                 }
             }
         };
@@ -90,7 +92,10 @@ where
             .front()
             .is_some_and(|frame| frame.is_complete(&self.expected_digitisers) | frame.is_expired())
         {
-            let frame = self.frames.pop_front().expect("self.frames should be non-empty, this should never fail");
+            let frame = self
+                .frames
+                .pop_front()
+                .expect("self.frames should be non-empty, this should never fail");
             if let Err(e) = frame.end_span() {
                 warn!("Frame span drop failed {e}")
             }

--- a/digitiser-aggregator/src/frame/cache.rs
+++ b/digitiser-aggregator/src/frame/cache.rs
@@ -39,11 +39,7 @@ where
         metadata: &FrameMetadata,
         data: D,
     ) -> &'a impl SpannedAggregator {
-        if self
-            .frames
-            .iter()
-            .all(|frame| frame.metadata != *metadata)
-        {
+        if self.frames.iter().all(|frame| frame.metadata != *metadata) {
             self.frames.push_back({
                 // or create a new PartialFrame
                 let mut frame = PartialFrame::<D>::new(self.ttl, metadata.clone());

--- a/digitiser-aggregator/src/frame/cache.rs
+++ b/digitiser-aggregator/src/frame/cache.rs
@@ -60,7 +60,7 @@ where
 
                     frame.push(digitiser_id, data);
                     self.frames.push_back(frame);
-                    self.frames.back().expect("This should never fails")
+                    self.frames.back().expect("self.frames should be non-empty, this should never fails")
                 }
             }
         };
@@ -90,7 +90,7 @@ where
             .front()
             .is_some_and(|frame| frame.is_complete(&self.expected_digitisers) | frame.is_expired())
         {
-            let frame = self.frames.pop_front().expect("This should never fail");
+            let frame = self.frames.pop_front().expect("self.frames should be non-empty, this should never fail");
             if let Err(e) = frame.end_span() {
                 warn!("Frame span drop failed {e}")
             }

--- a/digitiser-aggregator/src/main.rs
+++ b/digitiser-aggregator/src/main.rs
@@ -35,8 +35,6 @@ use supermusr_streaming_types::{
 use tokio::task::JoinSet;
 use tracing::{debug, error, info_span, instrument, level_filters::LevelFilter, warn, Instrument};
 
-const TIMESTAMP_FORMAT: &str = "%Y-%m-%dT%H:%M:%S%.f%z";
-
 #[derive(Debug, Parser)]
 #[clap(author, version, about)]
 struct Cli {

--- a/digitiser-aggregator/src/main.rs
+++ b/digitiser-aggregator/src/main.rs
@@ -161,6 +161,7 @@ async fn main() -> anyhow::Result<()> {
     }
 }
 
+///  This function wraps the `root_as_digitizer_event_list_message` function, allowing it to be instrumented.
 #[instrument(skip_all, target = "otel")]
 fn spanned_root_as_digitizer_event_list_message(
     payload: &[u8],
@@ -200,6 +201,11 @@ async fn process_kafka_message(
                 }
                 Err(e) => {
                     warn!("Failed to parse message: {}", e);
+                    counter!(
+                        FAILURES,
+                        &[failures::get_label(FailureKind::UnableToDecodeMessage)]
+                    )
+                    .increment(1);
                 }
             }
         } else {

--- a/digitiser-aggregator/src/main.rs
+++ b/digitiser-aggregator/src/main.rs
@@ -8,7 +8,7 @@ use metrics::counter;
 use metrics_exporter_prometheus::PrometheusBuilder;
 use rdkafka::{
     consumer::{CommitMode, Consumer},
-    message::{BorrowedMessage, Message},
+    message::{BorrowedHeaders, BorrowedMessage, Message},
     producer::{FutureProducer, FutureRecord},
     util::Timeout,
 };
@@ -16,20 +16,26 @@ use std::{fmt::Debug, net::SocketAddr, time::Duration};
 use supermusr_common::{
     init_tracer,
     metrics::{
-        failures::{self, FailureKind},
         messages_received::{self, MessageKind},
         metric_names::{FAILURES, FRAMES_SENT, MESSAGES_PROCESSED, MESSAGES_RECEIVED},
     },
     record_metadata_fields_to_span,
-    spanned::{FindSpanMut, Spanned, SpannedAggregator},
+    spanned::{Spanned, SpannedAggregator},
     tracer::{FutureRecordTracerExt, OptionalHeaderTracerExt, TracerEngine, TracerOptions},
     CommonKafkaOpts, DigitizerId,
 };
-use supermusr_streaming_types::dev2_digitizer_event_v2_generated::{
-    digitizer_event_list_message_buffer_has_identifier, root_as_digitizer_event_list_message,
+use supermusr_streaming_types::{
+    dev2_digitizer_event_v2_generated::{
+        digitizer_event_list_message_buffer_has_identifier, root_as_digitizer_event_list_message,
+        DigitizerEventListMessage,
+    },
+    flatbuffers::InvalidFlatbuffer,
+    FrameMetadata,
 };
 use tokio::task::JoinSet;
-use tracing::{debug, error, info_span, level_filters::LevelFilter, warn};
+use tracing::{debug, error, info_span, instrument, level_filters::LevelFilter, warn, Instrument};
+
+const TIMESTAMP_FORMAT: &str = "%Y-%m-%dT%H:%M:%S%.f%z";
 
 #[derive(Debug, Parser)]
 #[clap(author, version, about)]
@@ -143,8 +149,9 @@ async fn main() -> anyhow::Result<()> {
             event = consumer.recv() => {
                 match event {
                     Ok(msg) => {
-                        on_message(tracer.use_otel(), &mut kafka_producer_thread_set, &mut cache, &producer, &args.output_topic, &msg).await;
-                        consumer.commit_message(&msg, CommitMode::Async)?;
+                        process_kafka_message(tracer.use_otel(), &mut kafka_producer_thread_set, &mut cache, &producer, &args.output_topic, &msg).await;
+                        consumer.commit_message(&msg, CommitMode::Async)
+                            .expect("Message should commit");
                     }
                     Err(e) => warn!("Kafka error: {}", e),
                 };
@@ -156,16 +163,15 @@ async fn main() -> anyhow::Result<()> {
     }
 }
 
-#[tracing::instrument(skip_all, fields(
-    digitiser_id = tracing::field::Empty,
-    metadata_timestamp = tracing::field::Empty,
-    metadata_frame_number = tracing::field::Empty,
-    metadata_period_number = tracing::field::Empty,
-    metadata_veto_flags = tracing::field::Empty,
-    metadata_protons_per_pulse = tracing::field::Empty,
-    metadata_running = tracing::field::Empty,
-))]
-async fn on_message(
+#[instrument(skip_all, target = "otel")]
+fn spanned_root_as_digitizer_event_list_message(
+    payload: &[u8],
+) -> Result<DigitizerEventListMessage<'_>, InvalidFlatbuffer> {
+    root_as_digitizer_event_list_message(payload)
+}
+
+#[instrument(skip_all, level = "info", fields(kafka_message_timestamp_ms = msg.timestamp().to_millis()))]
+async fn process_kafka_message(
     use_otel: bool,
     kafka_producer_thread_set: &mut JoinSet<()>,
     cache: &mut FrameCache<EventData>,
@@ -173,77 +179,99 @@ async fn on_message(
     output_topic: &str,
     msg: &BorrowedMessage<'_>,
 ) {
-    msg.headers().conditional_extract_to_current_span(use_otel);
-
     if let Some(payload) = msg.payload() {
         if digitizer_event_list_message_buffer_has_identifier(payload) {
             counter!(
                 MESSAGES_RECEIVED,
                 &[messages_received::get_label(MessageKind::Event)]
             );
-            match root_as_digitizer_event_list_message(payload) {
-                Ok(msg) => match msg.metadata().try_into() {
-                    Ok(metadata) => {
-                        debug!("Event packet: metadata: {:?}", msg.metadata());
-                        cache.push(msg.digitizer_id(), &metadata, msg.into());
-
-                        // Append Metadata to Span
-                        tracing::Span::current().record("digitiser_id", msg.digitizer_id());
-                        record_metadata_fields_to_span!(&metadata, tracing::Span::current());
-
-                        if let Some(frame_span) = cache.find_span_mut(metadata) {
-                            if frame_span.span().is_waiting() {
-                                if let Err(e) = frame_span.span_init() {
-                                    error!("Tracing error: {e}");
-                                }
-                            }
-
-                            if let Err(e) = frame_span.link_current_span(
-                                || info_span!(target: "otel", "Digitiser Event List"),
-                            ) {
-                                error!("Tracing error: {e}");
-                            }
-                        }
-                        cache_poll(
-                            use_otel,
-                            kafka_producer_thread_set,
-                            cache,
-                            producer,
-                            output_topic,
-                        )
-                        .await;
-                    }
-                    Err(e) => {
-                        warn!("Invalid Metadata: {e}");
-                        counter!(
-                            FAILURES,
-                            &[failures::get_label(FailureKind::InvalidMetadata)]
-                        )
-                        .increment(1);
-                    }
-                },
+            let headers = msg.headers();
+            match spanned_root_as_digitizer_event_list_message(payload) {
+                Ok(msg) => {
+                    process_digitiser_event_list_message(
+                        use_otel,
+                        headers,
+                        kafka_producer_thread_set,
+                        cache,
+                        producer,
+                        output_topic,
+                        msg,
+                    )
+                    .await;
+                }
                 Err(e) => {
                     warn!("Failed to parse message: {}", e);
-                    counter!(
-                        FAILURES,
-                        &[failures::get_label(FailureKind::UnableToDecodeMessage)]
-                    )
-                    .increment(1);
                 }
             }
         } else {
             warn!("Unexpected message type on topic \"{}\"", msg.topic());
             debug!("Message: {msg:?}");
             debug!("Payload size: {}", payload.len());
-            counter!(
-                MESSAGES_RECEIVED,
-                &[messages_received::get_label(MessageKind::Unexpected)]
-            )
-            .increment(1);
         }
     }
 }
 
+#[tracing::instrument(skip_all, fields(
+    digitiser_id = msg.digitizer_id(),
+    metadata_timestamp = tracing::field::Empty,
+    metadata_frame_number = tracing::field::Empty,
+    metadata_period_number = tracing::field::Empty,
+    metadata_veto_flags = tracing::field::Empty,
+    metadata_protons_per_pulse = tracing::field::Empty,
+    metadata_running = tracing::field::Empty,
+    num_cached_frames = cache.get_num_partial_frames(),
+))]
+async fn process_digitiser_event_list_message(
+    use_otel: bool,
+    headers: Option<&BorrowedHeaders>,
+    kafka_producer_thread_set: &mut JoinSet<()>,
+    cache: &mut FrameCache<EventData>,
+    producer: &FutureProducer,
+    output_topic: &str,
+    msg: DigitizerEventListMessage<'_>,
+) {
+    let metadata_result: Result<FrameMetadata, _> = msg.metadata().try_into();
+    match metadata_result {
+        Ok(metadata) => {
+            record_metadata_fields_to_span!(&metadata, tracing::Span::current());
+            headers.conditional_extract_to_current_span(use_otel);
+
+            debug!("Event packet: metadata: {:?}", msg.metadata());
+
+            // Push the current digitiser message to the frame cache, possibly creating a new partial frame
+            let frame_as_spanned_aggregator = cache.push(msg.digitizer_id(), &metadata, msg.into());
+
+            // Link this span with the frame aggregator span associated with `frame`
+            if let Err(e) = frame_as_spanned_aggregator.link_current_span(|| {
+                let span = info_span!(target: "otel",
+                    "Digitiser Event List",
+                    "metadata_timestamp" = tracing::field::Empty,
+                    "metadata_frame_number" = tracing::field::Empty,
+                    "metadata_period_number" = tracing::field::Empty,
+                    "metadata_veto_flags" = tracing::field::Empty,
+                    "metadata_protons_per_pulse" = tracing::field::Empty,
+                    "metadata_running" = tracing::field::Empty,
+                );
+                record_metadata_fields_to_span!(metadata, span);
+                span
+            }) {
+                warn!("Frame span linking failed {e}")
+            }
+
+            cache_poll(
+                use_otel,
+                kafka_producer_thread_set,
+                cache,
+                producer,
+                output_topic,
+            )
+            .await;
+        }
+        Err(e) => warn!("Invalid Metadata: {e}"),
+    }
+}
+
+#[tracing::instrument(skip_all, level = "trace")]
 async fn cache_poll(
     use_otel: bool,
     kafka_producer_thread_set: &mut JoinSet<()>,
@@ -252,38 +280,30 @@ async fn cache_poll(
     output_topic: &str,
 ) {
     if let Some(frame) = cache.poll() {
-        let span = frame
-            .span()
-            .get()
-            .expect("frame should have a span")
-            .clone();
-        let data: Vec<u8> = frame.into();
+        let span = info_span!(target: "otel", "Frame Complete");
+        let future = span.in_scope(|| {
+            let frame_span = frame.span().get().expect("Span should exist").clone();
+            let data: Vec<u8> = frame.into();
 
-        let producer = producer.to_owned();
-        let output_topic = output_topic.to_owned();
-        kafka_producer_thread_set.spawn(async move {
-            let future_record = FutureRecord::to(&output_topic)
-                .payload(data.as_slice())
-                .conditional_inject_span_into_headers(use_otel, &span)
-                .key("Frame Events List");
+            let producer = producer.to_owned();
+            let output_topic = output_topic.to_owned();
+            async move {
+                let future_record = FutureRecord::to(&output_topic)
+                    .payload(data.as_slice())
+                    .conditional_inject_span_into_headers(use_otel, &frame_span)
+                    .key("Frame Events List");
 
-            match producer
-                .send(future_record, Timeout::After(Duration::from_millis(100)))
-                .await
-            {
-                Ok(r) => {
-                    debug!("Delivery: {:?}", r);
-                    counter!(FRAMES_SENT).increment(1)
-                }
-                Err(e) => {
-                    error!("Delivery failed: {:?}", e);
-                    counter!(
-                        FAILURES,
-                        &[failures::get_label(FailureKind::KafkaPublishFailed)]
-                    )
-                    .increment(1);
+                match producer
+                    .send(future_record, Timeout::After(Duration::from_millis(100)))
+                    .await
+                {
+                    Ok(r) => debug!("Delivery: {:?}", r),
+                    Err(e) => error!("Delivery failed: {:?}", e),
                 }
             }
         });
+        kafka_producer_thread_set.spawn(
+            future.instrument(info_span!(target: "otel", parent: &span, "Message Producer")),
+        );
     }
 }

--- a/digitiser-aggregator/src/main.rs
+++ b/digitiser-aggregator/src/main.rs
@@ -16,7 +16,9 @@ use std::{fmt::Debug, net::SocketAddr, time::Duration};
 use supermusr_common::{
     init_tracer,
     metrics::{
-        failures::{self, FailureKind}, messages_received::{self, MessageKind}, metric_names::{FAILURES, FRAMES_SENT, MESSAGES_PROCESSED, MESSAGES_RECEIVED}
+        failures::{self, FailureKind},
+        messages_received::{self, MessageKind},
+        metric_names::{FAILURES, FRAMES_SENT, MESSAGES_PROCESSED, MESSAGES_RECEIVED},
     },
     record_metadata_fields_to_span,
     spanned::{Spanned, SpannedAggregator},
@@ -28,7 +30,7 @@ use supermusr_streaming_types::{
         digitizer_event_list_message_buffer_has_identifier, root_as_digitizer_event_list_message,
         DigitizerEventListMessage,
     },
-    flatbuffers::InvalidFlatbuffer
+    flatbuffers::InvalidFlatbuffer,
 };
 use tokio::task::JoinSet;
 use tracing::{debug, error, info_span, instrument, level_filters::LevelFilter, warn, Instrument};

--- a/streaming-types/src/frame_metadata.rs
+++ b/streaming-types/src/frame_metadata.rs
@@ -2,7 +2,6 @@ use crate::{
     frame_metadata_v2_generated::FrameMetadataV2, time_conversions::GpsTimeConversionError,
 };
 use chrono::{DateTime, Utc};
-use std::hash::Hash;
 
 #[derive(Debug, Clone, Eq)]
 pub struct FrameMetadata {
@@ -29,18 +28,6 @@ impl FrameMetadata {
 impl PartialEq for FrameMetadata {
     fn eq(&self, other: &Self) -> bool {
         self.equals_ignoring_veto_flags(other)
-    }
-}
-
-impl Hash for FrameMetadata {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.timestamp.hash(state);
-        self.period_number.hash(state);
-        self.protons_per_pulse.hash(state);
-        self.running.hash(state);
-        self.frame_number.hash(state);
-        // At the moment we do not consider the veto_flags
-        //self.veto_flags.hash(state);
     }
 }
 

--- a/streaming-types/src/frame_metadata.rs
+++ b/streaming-types/src/frame_metadata.rs
@@ -44,7 +44,6 @@ impl Hash for FrameMetadata {
     }
 }
 
-
 impl<'a> TryFrom<FrameMetadataV2<'a>> for FrameMetadata {
     type Error = GpsTimeConversionError;
 

--- a/streaming-types/src/frame_metadata.rs
+++ b/streaming-types/src/frame_metadata.rs
@@ -2,8 +2,9 @@ use crate::{
     frame_metadata_v2_generated::FrameMetadataV2, time_conversions::GpsTimeConversionError,
 };
 use chrono::{DateTime, Utc};
+use std::hash::Hash;
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Eq)]
 pub struct FrameMetadata {
     pub timestamp: DateTime<Utc>,
     pub period_number: u64,
@@ -22,6 +23,27 @@ impl FrameMetadata {
             && self.frame_number == other.frame_number
     }
 }
+
+/// This is a temporary implementation whilst the issue with veto flags being unequal in different digitisers persists.
+/// When that is solved we should replace this implementation block with the derived PartialEq.
+impl PartialEq for FrameMetadata {
+    fn eq(&self, other: &Self) -> bool {
+        self.equals_ignoring_veto_flags(other)
+    }
+}
+
+impl Hash for FrameMetadata {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.timestamp.hash(state);
+        self.period_number.hash(state);
+        self.protons_per_pulse.hash(state);
+        self.running.hash(state);
+        self.frame_number.hash(state);
+        // At the moment we do no consider the veto_flags
+        //self.veto_flags.hash(state);
+    }
+}
+
 
 impl<'a> TryFrom<FrameMetadataV2<'a>> for FrameMetadata {
     type Error = GpsTimeConversionError;

--- a/streaming-types/src/frame_metadata.rs
+++ b/streaming-types/src/frame_metadata.rs
@@ -39,7 +39,7 @@ impl Hash for FrameMetadata {
         self.protons_per_pulse.hash(state);
         self.running.hash(state);
         self.frame_number.hash(state);
-        // At the moment we do no consider the veto_flags
+        // At the moment we do not consider the veto_flags
         //self.veto_flags.hash(state);
     }
 }


### PR DESCRIPTION
## Summary of changes

### cache.rs
1. ~~Swapped `VecDeque` to `HashMap<FrameMetadata,_>` and implemented resulting changes~~
2. Added metadata to `push` function instrumentation.
3. Added `get_num_partial_frames` function.
4. Added `test_metadata_equality` test.
5. ~~`push` now returns `&impl SpannedAggregator`, and dependence on `FindSpan(Mut)` removed.~~

### partial.rs
1. Added metadata to `Frame` span.

### main.rs
1. Refactored `on_message` to `process_kafka_message` and `process_digitiser_event_list_message` functions.
2. Added metadata and other fields to `process_kafka_message` and `process_digitiser_event_list_message` instrumentation
3. Instrumented `root_as_digitizer_event_list_message` by wrapping with `span_of_root_as_digitizer_event_list_message`

### frame_metadata.rs
1. ~~Implemented `Hash` trait for `FrameMetadata`~~
2. Implemented `PartialEq` for `FrameMetadata` as a temporary measure to exclude `veto_flags` (this will be removed later).

## Instruction for review/testing

1. Do fields added to spans conform with the rules set out in `tracing.md`?
2. General code review.
