### PR TITLE
Refactored functions in main.rs and added fields to spans

### DIFF
--- a/trace-to-events/src/main.rs
+++ b/trace-to-events/src/main.rs
@@ -8,6 +8,7 @@ use metrics_exporter_prometheus::PrometheusBuilder;
 use parameters::{DetectorSettings, Mode, Polarity};
 use rdkafka::{
     consumer::{CommitMode, Consumer},
+    message::{BorrowedHeaders, BorrowedMessage},
     producer::{FutureProducer, FutureRecord},
     Message,
 };
@@ -19,18 +20,20 @@ use supermusr_common::{
         messages_received::{self, MessageKind},
         metric_names::{FAILURES, MESSAGES_PROCESSED, MESSAGES_RECEIVED},
     },
+    record_metadata_fields_to_span,
     tracer::{FutureRecordTracerExt, OptionalHeaderTracerExt, TracerEngine, TracerOptions},
     CommonKafkaOpts, Intensity,
 };
 use supermusr_streaming_types::{
     dat2_digitizer_analog_trace_v2_generated::{
         digitizer_analog_trace_message_buffer_has_identifier,
-        root_as_digitizer_analog_trace_message,
+        root_as_digitizer_analog_trace_message, DigitizerAnalogTraceMessage,
     },
-    flatbuffers::FlatBufferBuilder,
+    flatbuffers::{FlatBufferBuilder, InvalidFlatbuffer},
+    FrameMetadata,
 };
 use tokio::task::JoinSet;
-use tracing::{debug, error, metadata::LevelFilter, trace, trace_span, warn};
+use tracing::{debug, error, instrument, metadata::LevelFilter, trace, warn};
 
 #[derive(Debug, Parser)]
 #[clap(author, version, about)]
@@ -87,7 +90,7 @@ async fn main() -> anyhow::Result<()> {
         args.otel_level
     ));
 
-    let kafka_opts = args.common_kafka_options;
+    let kafka_opts = &args.common_kafka_options;
 
     let client_config = supermusr_common::generate_kafka_client_config(
         &kafka_opts.broker,
@@ -132,93 +135,143 @@ async fn main() -> anyhow::Result<()> {
     loop {
         match consumer.recv().await {
             Ok(m) => {
-                let span = trace_span!("Trace Source Message");
-                m.headers()
-                    .conditional_extract_to_span(tracer.use_otel(), &span);
-                let _guard = span.enter();
-
-                debug!(
-                    "key: '{:?}', topic: {}, partition: {}, offset: {}, timestamp: {:?}",
-                    m.key(),
-                    m.topic(),
-                    m.partition(),
-                    m.offset(),
-                    m.timestamp()
+                process_kafka_message(
+                    &tracer,
+                    &args,
+                    &mut kafka_producer_thread_set,
+                    &producer,
+                    &m,
                 );
-
-                if let Some(payload) = m.payload() {
-                    if digitizer_analog_trace_message_buffer_has_identifier(payload) {
-                        counter!(
-                            MESSAGES_RECEIVED,
-                            &[messages_received::get_label(MessageKind::Trace)]
-                        )
-                        .increment(1);
-                        match root_as_digitizer_analog_trace_message(payload) {
-                            Ok(thing) => {
-                                let mut fbb = FlatBufferBuilder::new();
-                                processing::process(
-                                    &mut fbb,
-                                    &thing,
-                                    &DetectorSettings {
-                                        polarity: &args.polarity,
-                                        baseline: args.baseline,
-                                        mode: &args.mode,
-                                    },
-                                    args.save_file.as_deref(),
-                                );
-
-                                let future_record = FutureRecord::to(&args.event_topic)
-                                    .payload(fbb.finished_data())
-                                    .conditional_inject_current_span_into_headers(tracer.use_otel())
-                                    .key("Digitiser Events List");
-
-                                match producer.send_result(future_record) {
-                                    Ok(future) => {
-                                        kafka_producer_thread_set.spawn(async move {
-                                            match future.await {
-                                                Ok(_) => {
-                                                    trace!("Published event message");
-                                                    counter!(MESSAGES_PROCESSED).increment(1);
-                                                }
-                                                Err(e) => {
-                                                    error!("{:?}", e);
-                                                    counter!(
-                                                        FAILURES,
-                                                        &[failures::get_label(
-                                                            FailureKind::KafkaPublishFailed
-                                                        )]
-                                                    )
-                                                    .increment(1);
-                                                }
-                                            }
-                                        });
-                                    }
-                                    Err(e) => error!("Failed to enqueue message: {:?}", e),
-                                }
-
-                                fbb.reset();
-                            }
-                            Err(e) => {
-                                warn!("Failed to parse message: {}", e);
-                                counter!(
-                                    FAILURES,
-                                    &[failures::get_label(FailureKind::UnableToDecodeMessage)]
-                                )
-                                .increment(1);
-                            }
-                        }
-                    } else {
-                        warn!("Unexpected message type on topic \"{}\"", m.topic());
-                        counter!(
-                            MESSAGES_RECEIVED,
-                            &[messages_received::get_label(MessageKind::Unexpected)]
-                        )
-                        .increment(1);
-                    }
-                }
                 consumer.commit_message(&m, CommitMode::Async).unwrap();
             }
             Err(e) => warn!("Kafka error: {}", e),
         }
     }
+}
+
+#[instrument(skip_all, target = "otel", err(level = "WARN"))]
+fn spanned_root_as_digitizer_analog_trace_message(
+    payload: &[u8],
+) -> Result<DigitizerAnalogTraceMessage<'_>, InvalidFlatbuffer> {
+    root_as_digitizer_analog_trace_message(payload)
+}
+
+#[instrument(skip_all, target = "otel", fields(kafka_message_timestamp_ms = m.timestamp().to_millis()))]
+fn process_kafka_message(
+    tracer: &TracerEngine,
+    args: &Cli,
+    kafka_producer_thread_set: &mut JoinSet<()>,
+    producer: &FutureProducer,
+    m: &BorrowedMessage,
+) {
+    debug!(
+        "key: '{:?}', topic: {}, partition: {}, offset: {}, timestamp: {:?}",
+        m.key(),
+        m.topic(),
+        m.partition(),
+        m.offset(),
+        m.timestamp()
+    );
+
+    if let Some(payload) = m.payload() {
+        if digitizer_analog_trace_message_buffer_has_identifier(payload) {
+            counter!(
+                MESSAGES_RECEIVED,
+                &[messages_received::get_label(MessageKind::Trace)]
+            )
+            .increment(1);
+            match spanned_root_as_digitizer_analog_trace_message(payload) {
+                Ok(thing) => process_digitiser_trace_message(
+                    tracer,
+                    m.headers(),
+                    args,
+                    kafka_producer_thread_set,
+                    producer,
+                    thing,
+                ),
+                Err(e) => {
+                    warn!("Failed to parse message: {}", e);
+                    counter!(
+                        FAILURES,
+                        &[failures::get_label(FailureKind::UnableToDecodeMessage)]
+                    )
+                    .increment(1);
+                }
+            }
+        } else {
+            warn!("Unexpected message type on topic \"{}\"", m.topic());
+            counter!(
+                MESSAGES_RECEIVED,
+                &[messages_received::get_label(MessageKind::Unexpected)]
+            )
+            .increment(1);
+        }
+    }
+}
+
+#[instrument(
+    skip_all,
+    target = "otel",
+    fields(
+        digitiser_id = thing.digitizer_id(),
+        metadata_timestamp = tracing::field::Empty,
+        metadata_frame_number = tracing::field::Empty,
+        metadata_period_number = tracing::field::Empty,
+        metadata_veto_flags = tracing::field::Empty,
+        metadata_protons_per_pulse = tracing::field::Empty,
+        metadata_running = tracing::field::Empty,
+    )
+)]
+fn process_digitiser_trace_message(
+    tracer: &TracerEngine,
+    headers: Option<&BorrowedHeaders>,
+    args: &Cli,
+    kafka_producer_thread_set: &mut JoinSet<()>,
+    producer: &FutureProducer,
+    thing: DigitizerAnalogTraceMessage,
+) {
+    thing
+        .metadata()
+        .try_into()
+        .map(|metadata: FrameMetadata| {
+            record_metadata_fields_to_span!(metadata, tracing::Span::current());
+        })
+        .ok();
+
+    headers.conditional_extract_to_current_span(tracer.use_otel());
+    let mut fbb = FlatBufferBuilder::new();
+    processing::process(
+        &mut fbb,
+        &thing,
+        &DetectorSettings {
+            polarity: &args.polarity,
+            baseline: args.baseline,
+            mode: &args.mode,
+        },
+        args.save_file.as_deref(),
+    );
+
+    let future_record = FutureRecord::to(&args.event_topic)
+        .payload(fbb.finished_data())
+        .conditional_inject_current_span_into_headers(tracer.use_otel())
+        .key("Digitiser Events List");
+
+    let future = producer.send_result(future_record).expect("Producer sends");
+
+    kafka_producer_thread_set.spawn(async move {
+        match future.await {
+            Ok(_) => {
+                trace!("Published event message");
+                counter!(MESSAGES_PROCESSED).increment(1);
+            }
+            Err(e) => {
+                error!("{:?}", e);
+                counter!(
+                    FAILURES,
+                    &[failures::get_label(FailureKind::KafkaPublishFailed)]
+                )
+                .increment(1);
+            }
+        }
+    });
 }

--- a/trace-to-events/src/processing.rs
+++ b/trace-to-events/src/processing.rs
@@ -27,7 +27,7 @@ use supermusr_streaming_types::{
 };
 use tracing::info;
 
-#[tracing::instrument(skip(trace))]
+#[tracing::instrument(skip_all, fields(channel = trace.channel(), num_pulses))]
 fn find_channel_events(
     metadata: &FrameMetadataV2,
     trace: &ChannelTrace,
@@ -35,7 +35,7 @@ fn find_channel_events(
     detector_settings: &DetectorSettings,
     save_options: Option<&Path>,
 ) -> (Vec<Time>, Vec<Intensity>) {
-    match &detector_settings.mode {
+    let result = match &detector_settings.mode {
         Mode::FixedThresholdDiscriminator(parameters) => find_fixed_threshold_events(
             metadata,
             trace,
@@ -54,10 +54,12 @@ fn find_channel_events(
             parameters,
             save_options,
         ),
-    }
+    };
+    tracing::Span::current().record("num_pulses", result.0.len());
+    result
 }
 
-#[tracing::instrument(skip(trace), fields(num_pulses))]
+#[tracing::instrument(skip_all, level = "trace")]
 fn find_fixed_threshold_events(
     metadata: &FrameMetadataV2,
     trace: &ChannelTrace,
@@ -113,11 +115,10 @@ fn find_fixed_threshold_events(
         time.push(pulse.0 as Time);
         voltage.push(parameters.threshold as Intensity);
     }
-    tracing::Span::current().record("num_pulses", time.len());
     (time, voltage)
 }
 
-#[tracing::instrument(skip(trace), fields(num_pulses))]
+#[tracing::instrument(skip_all, level = "trace")]
 fn find_advanced_events(
     metadata: &FrameMetadataV2,
     trace: &ChannelTrace,
@@ -207,7 +208,6 @@ fn find_advanced_events(
         time.push(pulse.steepest_rise.time.unwrap_or_default() as Time);
         voltage.push(pulse.peak.value.unwrap_or_default() as Intensity);
     }
-    tracing::Span::current().record("num_pulses", time.len());
     (time, voltage)
 }
 
@@ -229,7 +229,7 @@ fn get_save_file_name(
     }
 }
 
-#[tracing::instrument(skip(trace))]
+#[tracing::instrument(skip_all)]
 pub(crate) fn process<'a>(
     fbb: &mut FlatBufferBuilder<'a>,
     trace: &'a DigitizerAnalogTraceMessage,


### PR DESCRIPTION
## Summary of changes

1. Refactored main loop into functions `process_kafka_message` and `process_digitiser_trace_message`
2. Added metadata and digitiser id fields to instrumented spans of the above functions and functions in `processing.rs`.

## Instruction for review/testing

Are changes as described above?
