### PR TITLE
Diagnostic refactoring

### DIFF
--- a/diagnostics/README.md
+++ b/diagnostics/README.md
@@ -10,12 +10,18 @@ A simple TUI tool that listens on the trace topic and reports in a table view th
 - Timestamp of first message received since starting kafka-daq-stats
 - Timestamp of last message received
 - Frame number of the last message received
-- Number of channels present in the last message received
-- A flag indicating if the number of channels has ever changed
-- Number of samples in the first channel of the last message received
-- A flag indicating if the number of samples is not identical in each channel
-- A flag indicating if the number of samples has ever changed
+- Status of the number of channels:
+   - Number of channels present in the last message received
+   - A flag indicating if the number of channels has ever changed. The flag reports `stable` if the number of channels has never changed, and `unstable` if the number has changed at all whilst the tool has been running.
+- Status of the number of samples:
+   - Number of samples in the first channel of the last message received
+   - A flag indicating if the number of samples is not identical in each channel. The flag reports `all channels` if all channels have the same number of samples, and `first channel only` if there are (or ever have been) differences in the number of samples.
+   - A flag indicating if the number of samples has ever changed. The flag reports `stable` if the number of samples has never changed, and `unstable` if the number has changed at all whilst the tool has been running.
 - Number of "bad" frames detected (i.e. frames with malformed timestamps).
+- Status of the samples of a single channel:
+   - The current index of the channel to monitor (this can be changed for each digitiser by the left/right key)
+   - The channel id of the currently monitored channel
+   - The range of samples values of the currently monitored channel (note the index/id is displayed as `index:id` with sample range as `(min:max)` beneath)
 
 ### Running in Podman
 

--- a/diagnostics/README.md
+++ b/diagnostics/README.md
@@ -46,7 +46,7 @@ To run using Podman, execute the following command, substituting the broker, top
 podman run --rm -it \
     ghcr.io/stfc-icd-research-and-design/supermusr-diagnostics:main \
     daq-trace
-    --broker 130.246.55.29:9090 \
+    --broker 130.246.55.29:9092 \
     --topic daq-traces-in  \
     --group vis-3
 ```

--- a/diagnostics/src/daq_trace/app.rs
+++ b/diagnostics/src/daq_trace/app.rs
@@ -1,4 +1,4 @@
-use super::DigitiserDataHashMap;
+use super::{data::DigitiserData, DigitiserDataHashMap};
 use chrono::{DateTime, Timelike, Utc};
 use ratatui::widgets::TableState;
 
@@ -13,23 +13,7 @@ impl App {
     /// Create a new instance with default values.
     pub fn new() -> App {
         App {
-            table_headers: [
-                "Digitiser ID",          // 1
-                "#Msgs Received",        // 2
-                "First Msg Timestamp",   // 3
-                "Last Msg Timestamp",    // 4
-                "Last Msg Frame",        // 5
-                "Message Rate (Hz)",     // 6
-                "#Present Channels",     // 7
-                "#Channels Changed?",    // 8
-                "First Channel Samples", // 9
-                "#Samples Identical?",   // 10
-                "#Samples Changed?",     // 11
-                "#Bad Frames?",          // 12
-            ]
-            .iter()
-            .map(|s| s.to_string())
-            .collect(),
+            table_headers: DigitiserData::generate_headers(),
             table_body: Vec::new(),
             table_state: TableState::default(),
         }
@@ -46,50 +30,7 @@ impl App {
         sorted_data.sort_by_key(|x| x.0);
         // Add rows to table.
         for (digitiser_id, digitiser_data) in sorted_data.iter() {
-            self.table_body.push(vec![
-                // 1. Digitiser ID.
-                digitiser_id.to_string(),
-                // 2. Number of messages received.
-                format!("{}", digitiser_data.msg_count),
-                // 3. First message timestamp.
-                format_timestamp(digitiser_data.first_msg_timestamp),
-                // 4. Last message timestamp.
-                format_timestamp(digitiser_data.last_msg_timestamp),
-                // 5. Last message frame.
-                format!("{}", digitiser_data.last_msg_frame),
-                // 6. Message rate.
-                format!("{:.1}", digitiser_data.msg_rate),
-                // 7. Number of channels present.
-                format!("{}", digitiser_data.num_channels_present),
-                // 8. Has the number of channels changed?
-                format!(
-                    "{}",
-                    match digitiser_data.has_num_channels_changed {
-                        true => "Yes",
-                        false => "No",
-                    }
-                ),
-                // 9. Number of samples in the first channel.
-                format!("{}", digitiser_data.num_samples_in_first_channel),
-                // 10. Is the number of samples identical?
-                format!(
-                    "{}",
-                    match digitiser_data.is_num_samples_identical {
-                        true => "Yes",
-                        false => "No",
-                    }
-                ),
-                // 11. Has the number of samples changed?
-                format!(
-                    "{}",
-                    match digitiser_data.has_num_samples_changed {
-                        true => "Yes",
-                        false => "No",
-                    }
-                ),
-                // 12. Number of Bad Frames
-                format!("{}", digitiser_data.bad_frame_count),
-            ])
+            self.table_body.push(digitiser_data.generate_row(**digitiser_id))
         }
     }
 
@@ -131,7 +72,7 @@ impl App {
 }
 
 /// Create a neatly formatted String from a timestamp.
-fn format_timestamp(timestamp: Option<DateTime<Utc>>) -> String {
+pub(crate) fn format_timestamp(timestamp: Option<DateTime<Utc>>) -> String {
     match timestamp {
         None => "N/A".to_string(),
         Some(t) => format!(

--- a/diagnostics/src/daq_trace/app.rs
+++ b/diagnostics/src/daq_trace/app.rs
@@ -6,7 +6,7 @@ use ratatui::widgets::TableState;
 pub struct App {
     pub table_headers: Vec<String>,
     pub table_body: Vec<Vec<String>>,
-    pub table_state: TableState
+    pub table_state: TableState,
 }
 
 impl App {
@@ -15,7 +15,7 @@ impl App {
         App {
             table_headers: DigitiserData::generate_headers(),
             table_body: Vec::new(),
-            table_state: TableState::default()
+            table_state: TableState::default(),
         }
     }
 
@@ -41,10 +41,12 @@ impl App {
     }
 
     /// Move to the next item in the table.
-    pub(crate) fn selected_digitiser_channel_delta(&mut self, common_dig_data_map: DigitiserDataHashMap, delta: isize) {
-        if let Some(selected_index) = self
-            .table_state
-            .selected() {
+    pub(crate) fn selected_digitiser_channel_delta(
+        &mut self,
+        common_dig_data_map: DigitiserDataHashMap,
+        delta: isize,
+    ) {
+        if let Some(selected_index) = self.table_state.selected() {
             let mut logged_data = common_dig_data_map
                 .lock()
                 .expect("should be able to lock common data");
@@ -55,7 +57,8 @@ impl App {
 
             if let Some((_, data)) = sorted_data.get_mut(selected_index) {
                 if data.num_channels_present != 0 {
-                    data.channel_index = data.channel_index 
+                    data.channel_index = data
+                        .channel_index
                         .checked_add((data.num_channels_present as isize + delta) as usize)
                         .expect("This should not overflow")
                         .rem_euclid(data.num_channels_present);

--- a/diagnostics/src/daq_trace/app.rs
+++ b/diagnostics/src/daq_trace/app.rs
@@ -6,68 +6,106 @@ use ratatui::widgets::TableState;
 pub struct App {
     pub table_headers: Vec<String>,
     pub table_body: Vec<Vec<String>>,
-    pub table_state: TableState,
+    pub table_state: TableState
 }
 
 impl App {
     /// Create a new instance with default values.
-    pub fn new() -> App {
+    pub(crate) fn new() -> App {
         App {
             table_headers: DigitiserData::generate_headers(),
             table_body: Vec::new(),
-            table_state: TableState::default(),
+            table_state: TableState::default()
         }
     }
 
-    pub fn generate_table_body(&mut self, common_dig_data_map: DigitiserDataHashMap) {
+    pub(crate) fn generate_table_body(&mut self, common_dig_data_map: DigitiserDataHashMap) {
         // Clear table body.
         self.table_body.clear();
+
         let logged_data = common_dig_data_map
             .lock()
             .expect("should be able to lock common data");
-        // Sort by digitiser ID.
+
         let mut sorted_data: Vec<_> = logged_data.iter().collect();
+        // Sort by digitiser ID.
         sorted_data.sort_by_key(|x| x.0);
-        // Add rows to table.
-        for (digitiser_id, digitiser_data) in sorted_data.iter() {
-            self.table_body.push(digitiser_data.generate_row(**digitiser_id))
+
+        // Insert into table
+        sorted_data
+            .iter()
+            .for_each(|(digitiser_id, digitiser_data)| {
+                self.table_body
+                    .push(digitiser_data.generate_row(**digitiser_id))
+            });
+    }
+
+    /// Move to the next item in the table.
+    pub(crate) fn selected_digitiser_channel_delta(&mut self, common_dig_data_map: DigitiserDataHashMap, delta: isize) {
+        if let Some(selected_index) = self
+            .table_state
+            .selected() {
+            let mut logged_data = common_dig_data_map
+                .lock()
+                .expect("should be able to lock common data");
+
+            let mut sorted_data: Vec<_> = logged_data.iter_mut().collect();
+            // Sort by digitiser ID.
+            sorted_data.sort_by_key(|x| x.0);
+
+            if let Some((_, data)) = sorted_data.get_mut(selected_index) {
+                if data.num_channels_present != 0 {
+                    data.channel_index = data.channel_index 
+                        .checked_add((data.num_channels_present as isize + delta) as usize)
+                        .expect("This should not overflow")
+                        .rem_euclid(data.num_channels_present);
+                }
+            }
         }
     }
 
     /// Move to the next item in the table.
-    pub fn next(&mut self) {
+    pub(crate) fn next(&mut self) {
         if self.table_body.is_empty() {
             return;
         }
-        let i = match self.table_state.selected() {
-            Some(i) => {
-                if i >= self.table_body.len() - 1 {
-                    0
-                } else {
-                    i + 1
-                }
-            }
-            None => 0,
-        };
-        self.table_state.select(Some(i));
+
+        //   Select next item, wrapping as appropriate
+        let index = self
+            .table_state
+            .selected()
+            .map(
+                |index| {
+                    index
+                        .checked_add(1)
+                        .expect("This should not overflow")
+                        .rem_euclid(self.table_body.len())
+                }, // Wrap around if `index > self.table_body.len()`
+            )
+            .unwrap_or_default();
+        self.table_state.select(Some(index));
     }
 
     /// Move to the previous item in the table.
-    pub fn previous(&mut self) {
+    pub(crate) fn previous(&mut self) {
         if self.table_body.is_empty() {
             return;
         }
-        let i = match self.table_state.selected() {
-            Some(i) => {
-                if i == 0 {
-                    self.table_body.len() - 1
-                } else {
-                    i - 1
-                }
-            }
-            None => 0,
-        };
-        self.table_state.select(Some(i));
+
+        //   Select next item, wrapping as appropriate
+        let index = self
+            .table_state
+            .selected()
+            .map(
+                |index| {
+                    index
+                        .checked_add(self.table_body.len() - 1)
+                        .expect("This should not overflow")
+                        .rem_euclid(self.table_body.len())
+                }, // Wrap around if `index > self.table_body.len()`
+            )
+            .unwrap_or_default();
+        self.table_state.select(Some(index));
     }
 }
 

--- a/diagnostics/src/daq_trace/data.rs
+++ b/diagnostics/src/daq_trace/data.rs
@@ -1,0 +1,152 @@
+use chrono::{DateTime, Utc};
+use supermusr_common::DigitizerId;
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+use crate::daq_trace::app::format_timestamp;
+
+pub(crate) type DigitiserDataHashMap = Arc<Mutex<HashMap<u8, DigitiserData>>>;
+
+enum Event<I> {
+    Input(I),
+    Tick,
+}
+
+/// Holds required data for a specific digitiser.
+pub struct DigitiserData {
+    pub msg_count: usize,
+    pub last_msg_count: usize,
+    pub msg_rate: f64,
+    pub first_msg_timestamp: Option<DateTime<Utc>>,
+    pub last_msg_timestamp: Option<DateTime<Utc>>,
+    pub last_msg_frame: u32,
+    pub num_channels_present: usize,
+    pub has_num_channels_changed: bool,
+    pub num_samples_in_first_channel: usize,
+    pub is_num_samples_identical: bool,
+    pub has_num_samples_changed: bool,
+    pub bad_frame_count: usize,
+}
+
+impl DigitiserData {
+    /// Create a new instance with default values.
+    pub fn new(
+        timestamp: Option<DateTime<Utc>>,
+        frame: u32,
+        num_channels_present: usize,
+        num_samples_in_first_channel: usize,
+        is_num_samples_identical: bool,
+    ) -> Self {
+        DigitiserData {
+            msg_count: 1,
+            msg_rate: 0 as f64,
+            last_msg_count: 1,
+            first_msg_timestamp: timestamp,
+            last_msg_timestamp: timestamp,
+            last_msg_frame: frame,
+            num_channels_present,
+            has_num_channels_changed: false,
+            num_samples_in_first_channel,
+            is_num_samples_identical,
+            has_num_samples_changed: false,
+            bad_frame_count: 0,
+        }
+    }
+
+    /// Update instance with new data
+    pub fn update(
+        &mut self,
+        timestamp: Option<DateTime<Utc>>,
+        frame_number: u32,
+        num_channels_present: usize,
+        num_samples_in_first_channel: usize,
+        is_num_samples_identical: bool,
+    ) {
+        self.msg_count += 1;
+
+        self.last_msg_timestamp = timestamp;
+        self.last_msg_frame = frame_number;
+
+        if timestamp.is_none() {
+            self.bad_frame_count += 1;
+        }
+
+        if !self.has_num_channels_changed {
+            self.has_num_channels_changed = num_channels_present != self.num_channels_present;
+        }
+        self.num_channels_present = num_channels_present;
+        if !self.has_num_channels_changed {
+            self.has_num_samples_changed =
+                num_samples_in_first_channel != self.num_samples_in_first_channel;
+        }
+        self.num_samples_in_first_channel = num_samples_in_first_channel;
+        self.is_num_samples_identical = is_num_samples_identical;
+    }
+
+    pub(crate) fn generate_headers() -> Vec<String> {[
+            "Digitiser ID",          // 1
+            "#Msgs Received",        // 2
+            "First Msg Timestamp",   // 3
+            "Last Msg Timestamp",    // 4
+            "Last Msg Frame",        // 5
+            "Message Rate (Hz)",     // 6
+            "#Present Channels",     // 7
+            "#Channels Changed?",    // 8
+            "First Channel Samples", // 9
+            "#Samples Identical?",   // 10
+            "#Samples Changed?",     // 11
+            "#Bad Frames?",          // 12
+        ]
+        .into_iter()
+        .map(ToString::to_string)
+        .collect()
+    }
+
+    pub(crate) fn generate_row(&self, digitiser_id: DigitizerId) -> Vec<String> {
+        vec![
+                // 1. Digitiser ID.
+                digitiser_id.to_string(),
+                // 2. Number of messages received.
+                format!("{}", self.msg_count),
+                // 3. First message timestamp.
+                format_timestamp(self.first_msg_timestamp),
+                // 4. Last message timestamp.
+                format_timestamp(self.last_msg_timestamp),
+                // 5. Last message frame.
+                format!("{}", self.last_msg_frame),
+                // 6. Message rate.
+                format!("{:.1}", self.msg_rate),
+                // 7. Number of channels present.
+                format!("{}", self.num_channels_present),
+                // 8. Has the number of channels changed?
+                format!(
+                    "{}",
+                    match self.has_num_channels_changed {
+                        true => "Yes",
+                        false => "No",
+                    }
+                ),
+                // 9. Number of samples in the first channel.
+                format!("{}", self.num_samples_in_first_channel),
+                // 10. Is the number of samples identical?
+                format!(
+                    "{}",
+                    match self.is_num_samples_identical {
+                        true => "Yes",
+                        false => "No",
+                    }
+                ),
+                // 11. Has the number of samples changed?
+                format!(
+                    "{}",
+                    match self.has_num_samples_changed {
+                        true => "Yes",
+                        false => "No",
+                    }
+                ),
+                // 12. Number of Bad Frames
+                format!("{}", self.bad_frame_count),
+            ]
+    }
+}

--- a/diagnostics/src/daq_trace/mod.rs
+++ b/diagnostics/src/daq_trace/mod.rs
@@ -27,7 +27,6 @@ use supermusr_streaming_types::dat2_digitizer_analog_trace_v2_generated::{
     digitizer_analog_trace_message_buffer_has_identifier, root_as_digitizer_analog_trace_message,
     DigitizerAnalogTraceMessage,
 };
-use supermusr_streaming_types::flatbuffers::Vector;
 use tokio::task;
 use tokio::time::sleep;
 use tracing::{debug, info, warn};
@@ -110,6 +109,8 @@ pub(crate) async fn run(args: DaqTraceOpts) -> anyhow::Result<()> {
                 KeyCode::Char('q') => break,
                 KeyCode::Down => app.next(),
                 KeyCode::Up => app.previous(),
+                KeyCode::Right => app.selected_digitiser_channel_delta(Arc::clone(&common_dig_data_map), 1),
+                KeyCode::Left => app.selected_digitiser_channel_delta(Arc::clone(&common_dig_data_map), -1),
                 _ => (),
             },
             Event::Tick => (),
@@ -241,7 +242,7 @@ fn process_digitizer_analog_trace_message(
                 frame_number,
                 num_channels_present,
                 num_samples_in_first_channel,
-                is_num_samples_identical,
+                is_num_samples_identical
             )
         })
         .or_insert(DigitiserData::new(

--- a/diagnostics/src/daq_trace/mod.rs
+++ b/diagnostics/src/daq_trace/mod.rs
@@ -1,15 +1,16 @@
 mod app;
+mod data;
 mod ui;
 
 use self::app::App;
 use self::ui::ui;
 use super::DaqTraceOpts;
-use chrono::{DateTime, Utc};
 use crossterm::event::{self, DisableMouseCapture, EnableMouseCapture, Event as CEvent, KeyCode};
 use crossterm::execute;
 use crossterm::terminal::{
     disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen,
 };
+use data::{DigitiserData, DigitiserDataHashMap};
 use ratatui::{prelude::CrosstermBackend, Terminal};
 use rdkafka::{
     consumer::{stream_consumer::StreamConsumer, CommitMode, Consumer},
@@ -24,58 +25,16 @@ use std::{
 };
 use supermusr_streaming_types::dat2_digitizer_analog_trace_v2_generated::{
     digitizer_analog_trace_message_buffer_has_identifier, root_as_digitizer_analog_trace_message,
+    DigitizerAnalogTraceMessage,
 };
+use supermusr_streaming_types::flatbuffers::Vector;
 use tokio::task;
 use tokio::time::sleep;
 use tracing::{debug, info, warn};
 
-type DigitiserDataHashMap = Arc<Mutex<HashMap<u8, DigitiserData>>>;
-
 enum Event<I> {
     Input(I),
     Tick,
-}
-
-/// Holds required data for a specific digitiser.
-pub struct DigitiserData {
-    pub msg_count: usize,
-    last_msg_count: usize,
-    pub msg_rate: f64,
-    pub first_msg_timestamp: Option<DateTime<Utc>>,
-    pub last_msg_timestamp: Option<DateTime<Utc>>,
-    pub last_msg_frame: u32,
-    pub num_channels_present: usize,
-    pub has_num_channels_changed: bool,
-    pub num_samples_in_first_channel: usize,
-    pub is_num_samples_identical: bool,
-    pub has_num_samples_changed: bool,
-    pub bad_frame_count: usize,
-}
-
-impl DigitiserData {
-    /// Create a new instance with default values.
-    pub fn new(
-        timestamp: Option<DateTime<Utc>>,
-        frame: u32,
-        num_channels_present: usize,
-        num_samples_in_first_channel: usize,
-        is_num_samples_identical: bool,
-    ) -> Self {
-        DigitiserData {
-            msg_count: 1,
-            msg_rate: 0 as f64,
-            last_msg_count: 1,
-            first_msg_timestamp: timestamp,
-            last_msg_timestamp: timestamp,
-            last_msg_frame: frame,
-            num_channels_present,
-            has_num_channels_changed: false,
-            num_samples_in_first_channel,
-            is_num_samples_identical,
-            has_num_samples_changed: false,
-            bad_frame_count: 0,
-        }
-    }
 }
 
 // Trace topic diagnostic tool
@@ -197,7 +156,7 @@ async fn update_message_rate(
 }
 
 /// Poll kafka messages and update digitiser data.
-async fn poll_kafka_msg(consumer: StreamConsumer, common_dig_data_map: DigitiserDataHashMap) {
+async fn poll_kafka_msg(consumer: StreamConsumer, mut common_dig_data_map: DigitiserDataHashMap) {
     loop {
         match consumer.recv().await {
             Err(e) => warn!("Kafka error: {}", e),
@@ -215,88 +174,10 @@ async fn poll_kafka_msg(consumer: StreamConsumer, common_dig_data_map: Digitiser
                     if digitizer_analog_trace_message_buffer_has_identifier(payload) {
                         match root_as_digitizer_analog_trace_message(payload) {
                             Ok(data) => {
-                                let frame_number = data.metadata().frame_number();
-
-                                let num_channels_present = match data.channels() {
-                                    Some(c) => c.len(),
-                                    None => 0,
-                                };
-
-                                let num_samples_in_first_channel = match data.channels() {
-                                    Some(c) => match c.get(0).voltage() {
-                                        Some(v) => v.len(),
-                                        None => 0,
-                                    },
-                                    None => 0,
-                                };
-
-                                let is_num_samples_identical = match data.channels() {
-                                    Some(c) => || -> bool {
-                                        for trace in c.iter() {
-                                            let num_samples = match trace.voltage() {
-                                                Some(v) => v.len(),
-                                                None => 0,
-                                            };
-
-                                            if num_samples != num_samples_in_first_channel {
-                                                return false;
-                                            }
-                                        }
-                                        true
-                                    }(),
-                                    None => false,
-                                };
-
-                                let timestamp = data
-                                    .metadata()
-                                    .timestamp()
-                                    .copied()
-                                    .and_then(|t| t.try_into().ok());
-
-                                let id = data.digitizer_id();
-                                {
-                                    let mut logged_data = common_dig_data_map
-                                        .lock()
-                                        .expect("sound be able to lock common data");
-                                    logged_data
-                                        .entry(id)
-                                        .and_modify(|d| {
-                                            d.msg_count += 1;
-
-                                            d.last_msg_timestamp = timestamp;
-                                            d.last_msg_frame = frame_number;
-
-                                            if timestamp.is_none() {
-                                                d.bad_frame_count += 1;
-                                            }
-
-                                            let num_channels = match data.channels() {
-                                                Some(c) => c.len(),
-                                                None => 0,
-                                            };
-                                            if !d.has_num_channels_changed {
-                                                d.has_num_channels_changed =
-                                                    num_channels != d.num_channels_present;
-                                            }
-                                            d.num_channels_present = num_channels;
-                                            if !d.has_num_channels_changed {
-                                                d.has_num_samples_changed =
-                                                    num_samples_in_first_channel
-                                                        != d.num_samples_in_first_channel;
-                                            }
-                                            d.num_samples_in_first_channel =
-                                                num_samples_in_first_channel;
-                                            d.is_num_samples_identical = is_num_samples_identical;
-                                        })
-                                        .or_insert(DigitiserData::new(
-                                            timestamp,
-                                            frame_number,
-                                            num_channels_present,
-                                            num_samples_in_first_channel,
-                                            is_num_samples_identical,
-                                        ));
-                                };
-
+                                process_digitizer_analog_trace_message(
+                                    &data,
+                                    &mut common_dig_data_map,
+                                );
                                 info!(
                                     "Trace packet: dig. ID: {}, metadata: {:?}",
                                     data.digitizer_id(),
@@ -316,4 +197,58 @@ async fn poll_kafka_msg(consumer: StreamConsumer, common_dig_data_map: Digitiser
             }
         };
     }
+}
+
+// Main Logic
+fn process_digitizer_analog_trace_message(
+    data: &DigitizerAnalogTraceMessage<'_>,
+    common_dig_data_map: &mut DigitiserDataHashMap,
+) {
+    let frame_number = data.metadata().frame_number();
+
+    let num_channels_present = data.channels().map(|c| c.len()).unwrap_or_default();
+
+    let num_samples_in_first_channel = data
+        .channels()
+        .map(|c| c.get(0).voltage().map(|c| c.len()).unwrap_or_default())
+        .unwrap_or_default();
+
+    let is_num_samples_identical = data
+        .channels()
+        .map(|c| {
+            c.iter().all(|trace| {
+                let num_samples = trace.voltage().map(|c| c.len()).unwrap_or_default();
+                num_samples == num_samples_in_first_channel
+            })
+        })
+        .unwrap_or(false);
+
+    let timestamp = data
+        .metadata()
+        .timestamp()
+        .copied()
+        .and_then(|t| t.try_into().ok());
+
+    let id = data.digitizer_id();
+
+    common_dig_data_map
+        .lock()
+        .expect("sound be able to lock common data")
+        .entry(id)
+        .and_modify(|d| {
+            d.update(
+                timestamp,
+                frame_number,
+                num_channels_present,
+                num_samples_in_first_channel,
+                is_num_samples_identical,
+            )
+        })
+        .or_insert(DigitiserData::new(
+            timestamp,
+            frame_number,
+            num_channels_present,
+            num_samples_in_first_channel,
+            is_num_samples_identical,
+        ));
 }

--- a/diagnostics/src/daq_trace/mod.rs
+++ b/diagnostics/src/daq_trace/mod.rs
@@ -249,14 +249,15 @@ fn process_digitizer_analog_trace_message(
                 num_samples_in_first_channel,
                 is_num_samples_identical,
             );
-            if let Some(voltage) = data
-                .channels()
-                .and_then(|c| c.get(d.channel_index).voltage())
-            {
-                let max = voltage.iter().max().unwrap_or(Intensity::MIN);
-                let min = voltage.iter().min().unwrap_or(Intensity::MAX);
-                d.channel_data.max = Intensity::max(d.channel_data.max, max);
-                d.channel_data.min = Intensity::min(d.channel_data.min, min);
+            if let Some(channels) = data.channels() {
+                let c = channels.get(d.channel_data.index);
+                d.channel_data.id = c.channel();
+                if let Some(voltage) = c.voltage() {
+                    let max = voltage.iter().max().unwrap_or(Intensity::MIN);
+                    let min = voltage.iter().min().unwrap_or(Intensity::MAX);
+                    d.channel_data.max = Intensity::max(d.channel_data.max, max);
+                    d.channel_data.min = Intensity::min(d.channel_data.min, min);
+                }
             }
         })
         .or_insert(DigitiserData::new(

--- a/diagnostics/src/daq_trace/ui.rs
+++ b/diagnostics/src/daq_trace/ui.rs
@@ -39,7 +39,10 @@ fn draw_help<B: Backend>(frame: &mut Frame<B>, chunk: Rect) {
 
 /// Draws the main table in a given chunk.
 fn draw_table<B: Backend>(frame: &mut Frame<B>, app: &mut App, chunk: Rect) {
-    let widths : Vec<Constraint> = DigitiserData::width_percentages().into_iter().map(Constraint::Percentage).collect();
+    let widths: Vec<Constraint> = DigitiserData::width_percentages()
+        .into_iter()
+        .map(Constraint::Percentage)
+        .collect();
     let table = Table::new(
         // Turn table data into rows with given formatting.
         app.table_body.iter().map(|item| {

--- a/diagnostics/src/daq_trace/ui.rs
+++ b/diagnostics/src/daq_trace/ui.rs
@@ -8,7 +8,7 @@ use ratatui::{
 };
 
 /// Draws the ui based on the current app state.
-pub fn ui<B: Backend>(frame: &mut Frame<B>, app: &mut App) {
+pub(crate) fn ui<B: Backend>(frame: &mut Frame<B>, app: &mut App) {
     // Split terminal into different-sized chunks.
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -23,7 +23,7 @@ pub fn ui<B: Backend>(frame: &mut Frame<B>, app: &mut App) {
 /// Draws a help box containing key binding information in a given chunk.
 fn draw_help<B: Backend>(frame: &mut Frame<B>, chunk: Rect) {
     let help = Paragraph::new(Text::styled(
-        "<UP>: Previous row | <DOWN>: Next row | <q>: Quit",
+        "<UP>: Previous row | <DOWN>: Next row | <LEFT>: Previous Channel | <RIGHT>: Next Channel | <q>: Quit",
         Style::default().add_modifier(Modifier::DIM),
     ))
     .alignment(Alignment::Center)

--- a/diagnostics/src/daq_trace/ui.rs
+++ b/diagnostics/src/daq_trace/ui.rs
@@ -1,4 +1,4 @@
-use super::app::App;
+use super::{app::App, data::DigitiserData};
 use ratatui::{
     prelude::{Alignment, Backend, Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
@@ -6,8 +6,6 @@ use ratatui::{
     widgets::{Block, Borders, Cell, Paragraph, Row, Table},
     Frame,
 };
-
-const NUM_COLUMNS: usize = 12;
 
 /// Draws the ui based on the current app state.
 pub fn ui<B: Backend>(frame: &mut Frame<B>, app: &mut App) {
@@ -41,7 +39,7 @@ fn draw_help<B: Backend>(frame: &mut Frame<B>, chunk: Rect) {
 
 /// Draws the main table in a given chunk.
 fn draw_table<B: Backend>(frame: &mut Frame<B>, app: &mut App, chunk: Rect) {
-    let widths = [Constraint::Percentage(100 / NUM_COLUMNS as u16); NUM_COLUMNS];
+    let widths : Vec<Constraint> = DigitiserData::width_percentages().into_iter().map(Constraint::Percentage).collect();
     let table = Table::new(
         // Turn table data into rows with given formatting.
         app.table_body.iter().map(|item| {


### PR DESCRIPTION
## Summary of changes

1. General refactoring to make code more idiomatic
2. Moved the constructor and display functionality of `DigitiserData` to its own file.
3. Reworked the column structure to group up related items (as described in the README).
4. Added `weights` options to the column widths, making some columns larger than others.
5. Introduced `Channel` column which monitors a single channel (adjustable with left/right keys) and displays channel id and sample range.

## Instruction for review/testing

General code review.
Test with command such as
```bash
cargo run --bin diagnostics daq-trace --broker 130.246.55.29:9092 --topic daq-traces-in --group vis-3
```
when a run is in progress from the chosen broker.
