### PR TITLE
Add nexus writer move completed file feature

### DIFF
--- a/nexus-writer/src/main.rs
+++ b/nexus-writer/src/main.rs
@@ -145,8 +145,8 @@ async fn main() -> anyhow::Result<()> {
         &topics_to_subscribe,
     );
 
-    let nexus_settings = NexusSettings::new(args.frame_list_chunk_size, args.event_list_chunk_size);
-    let mut nexus_engine = NexusEngine::new(Some(&args.file_name), nexus_settings);
+    let nexus_settings = NexusSettings::new(args.frame_list_chunk_size, args.event_list_chunk_size, args.archive_name.as_deref());
+    let mut nexus_engine = NexusEngine::new(Some(args.file_name.as_path()), nexus_settings);
 
     let mut nexus_write_interval =
         tokio::time::interval(time::Duration::from_millis(args.cache_poll_interval_ms));
@@ -177,7 +177,7 @@ async fn main() -> anyhow::Result<()> {
     loop {
         tokio::select! {
             _ = nexus_write_interval.tick() => {
-                nexus_engine.flush(&Duration::try_milliseconds(args.cache_run_ttl_ms).expect("Conversion is possible"), args.archive_name.as_deref());
+                nexus_engine.flush(&Duration::try_milliseconds(args.cache_run_ttl_ms).expect("Conversion is possible"));
             }
             event = consumer.recv() => {
                 match event {

--- a/nexus-writer/src/main.rs
+++ b/nexus-writer/src/main.rs
@@ -145,7 +145,11 @@ async fn main() -> anyhow::Result<()> {
         &topics_to_subscribe,
     );
 
-    let nexus_settings = NexusSettings::new(args.frame_list_chunk_size, args.event_list_chunk_size, args.archive_name.as_deref());
+    let nexus_settings = NexusSettings::new(
+        args.frame_list_chunk_size,
+        args.event_list_chunk_size,
+        args.archive_name.as_deref(),
+    );
     let mut nexus_engine = NexusEngine::new(Some(args.file_name.as_path()), nexus_settings);
 
     let mut nexus_write_interval =

--- a/nexus-writer/src/main.rs
+++ b/nexus-writer/src/main.rs
@@ -182,6 +182,7 @@ async fn main() -> anyhow::Result<()> {
         tokio::select! {
             _ = nexus_write_interval.tick() => {
                 nexus_engine.flush(&Duration::try_milliseconds(args.cache_run_ttl_ms).expect("Conversion is possible"));
+                nexus_engine.flush_move_cache().await;
             }
             event = consumer.recv() => {
                 match event {

--- a/nexus-writer/src/main.rs
+++ b/nexus-writer/src/main.rs
@@ -70,9 +70,13 @@ struct Cli {
     #[clap(long)]
     frame_event_topic: String,
 
-    /// Path to the NeXus file to be read
+    /// Path of the NeXus file to be written
     #[clap(long)]
     file_name: PathBuf,
+
+    /// Path the NeXus file will be moved to once completed. If not present, no move takes place.
+    #[clap(long)]
+    archive_name: Option<PathBuf>,
 
     /// How often in milliseconds expired runs are checked for and removed
     #[clap(long, default_value = "200")]
@@ -173,7 +177,7 @@ async fn main() -> anyhow::Result<()> {
     loop {
         tokio::select! {
             _ = nexus_write_interval.tick() => {
-                nexus_engine.flush(&Duration::try_milliseconds(args.cache_run_ttl_ms).expect("Conversion is possible"));
+                nexus_engine.flush(&Duration::try_milliseconds(args.cache_run_ttl_ms).expect("Conversion is possible"), args.archive_name.as_deref());
             }
             event = consumer.recv() => {
                 match event {

--- a/nexus-writer/src/nexus/engine.rs
+++ b/nexus-writer/src/nexus/engine.rs
@@ -20,6 +20,7 @@ pub(crate) struct NexusEngine {
     run_cache: VecDeque<Run>,
     run_number: u32,
     nexus_settings: NexusSettings,
+    run_move_cache: Vec<Run>,
 }
 
 impl NexusEngine {
@@ -30,6 +31,7 @@ impl NexusEngine {
             run_cache: Default::default(),
             run_number: 0,
             nexus_settings,
+            run_move_cache: Default::default(),
         }
     }
 
@@ -165,24 +167,45 @@ impl NexusEngine {
 
     #[tracing::instrument(skip_all, level = "debug")]
     pub(crate) fn flush(&mut self, delay: &Duration) {
-        self.run_cache.retain(|run| {
-            if run.has_completed(delay) {
-                if let Err(e) = run.end_span() {
-                    warn!("Run span drop failed {e}")
-                }
-                if let Some((file_name, archive_name)) = Option::zip(
-                    self.filename.as_ref(),
-                    self.nexus_settings.archive_path.as_ref(),
-                ) {
-                    if let Err(e) = run.move_to_archive(file_name, archive_name) {
-                        warn!("Move to Archive Error: {e}");
-                    }
-                }
-                false
-            } else {
-                true
+        // Get Indices of all completed run
+        let removed_indices: Vec<_> = self
+            .run_cache
+            .iter()
+            .enumerate()
+            .filter_map(|(index, run)| run.has_completed(delay).then_some(index))
+            .collect();
+
+        // Remove all runs found to be completed, and place them in self.run_move_cache
+        for index in removed_indices {
+            let run = self
+                .run_cache
+                .remove(index)
+                .expect("Index should be within bounds");
+            if let Err(e) = run.end_span() {
+                warn!("Run span drop failed {e}")
             }
-        });
+            self.run_move_cache.push(run);
+        }
+    }
+
+    /// If an additional archive location is set by the user,
+    /// then completed runs placed in the vector `self.run_move_cache`
+    /// have their nexus files asynchonously moved to that location.
+    /// Afterwhich the runs are dropped.
+    #[tracing::instrument(skip_all, level = "debug")]
+    pub(crate) async fn flush_move_cache(&mut self) {
+        if let Some((file_name, archive_name)) = Option::zip(
+            self.filename.as_ref(),
+            self.nexus_settings.archive_path.as_ref(),
+        ) {
+            for run in self.run_move_cache.iter() {
+                match run.move_to_archive(file_name, archive_name) {
+                    Ok(move_to_archive) => move_to_archive.await,
+                    Err(e) => warn!("Error Moving to Archive {e}"),
+                }
+            }
+        }
+        self.run_move_cache.clear();
     }
 }
 

--- a/nexus-writer/src/nexus/engine.rs
+++ b/nexus-writer/src/nexus/engine.rs
@@ -3,8 +3,7 @@ use chrono::{DateTime, Duration, Utc};
 #[cfg(test)]
 use std::collections::vec_deque;
 use std::{
-    collections::VecDeque,
-    path::{Path, PathBuf},
+    collections::VecDeque, path::{Path, PathBuf}
 };
 use supermusr_common::spanned::SpannedAggregator;
 use supermusr_streaming_types::{
@@ -19,7 +18,7 @@ pub(crate) struct NexusEngine {
     filename: Option<PathBuf>,
     run_cache: VecDeque<Run>,
     run_number: u32,
-    nexus_settings: NexusSettings,
+    nexus_settings: NexusSettings
 }
 
 impl NexusEngine {
@@ -29,7 +28,7 @@ impl NexusEngine {
             filename: filename.map(ToOwned::to_owned),
             run_cache: Default::default(),
             run_number: 0,
-            nexus_settings,
+            nexus_settings
         }
     }
 

--- a/nexus-writer/src/nexus/engine.rs
+++ b/nexus-writer/src/nexus/engine.rs
@@ -3,7 +3,8 @@ use chrono::{DateTime, Duration, Utc};
 #[cfg(test)]
 use std::collections::vec_deque;
 use std::{
-    collections::VecDeque, path::{Path, PathBuf}
+    collections::VecDeque,
+    path::{Path, PathBuf},
 };
 use supermusr_common::spanned::SpannedAggregator;
 use supermusr_streaming_types::{
@@ -18,7 +19,7 @@ pub(crate) struct NexusEngine {
     filename: Option<PathBuf>,
     run_cache: VecDeque<Run>,
     run_number: u32,
-    nexus_settings: NexusSettings
+    nexus_settings: NexusSettings,
 }
 
 impl NexusEngine {
@@ -28,7 +29,7 @@ impl NexusEngine {
             filename: filename.map(ToOwned::to_owned),
             run_cache: Default::default(),
             run_number: 0,
-            nexus_settings
+            nexus_settings,
         }
     }
 
@@ -169,7 +170,10 @@ impl NexusEngine {
                 if let Err(e) = run.end_span() {
                     warn!("Run span drop failed {e}")
                 }
-                if let Some((file_name, archive_name)) = Option::zip(self.filename.as_ref(), self.nexus_settings.archive_path.as_ref()) {
+                if let Some((file_name, archive_name)) = Option::zip(
+                    self.filename.as_ref(),
+                    self.nexus_settings.archive_path.as_ref(),
+                ) {
                     if let Err(e) = run.move_to_archive(file_name, archive_name) {
                         warn!("Move to Archive Error: {e}");
                     }
@@ -373,7 +377,10 @@ pub(crate) struct NexusSettings {
 }
 
 impl NexusSettings {
-    pub(crate) fn new(framelist_chunk_size: usize, eventlist_chunk_size: usize, archive_path: Option<&Path>
+    pub(crate) fn new(
+        framelist_chunk_size: usize,
+        eventlist_chunk_size: usize,
+        archive_path: Option<&Path>,
     ) -> Self {
         Self {
             framelist_chunk_size,

--- a/nexus-writer/src/nexus/run.rs
+++ b/nexus-writer/src/nexus/run.rs
@@ -1,6 +1,6 @@
 use super::{hdf5_file::RunFile, NexusSettings, RunParameters};
 use chrono::{DateTime, Duration, Utc};
-use std::{fs::{create_dir_all, File}, io::{self, Read, Write}, path::Path};
+use std::{fs::create_dir_all, io, path::Path, process::Command};
 use supermusr_common::spanned::{SpanOnce, SpanOnceError, Spanned, SpannedAggregator, SpannedMut};
 use supermusr_streaming_types::{
     aev2_frame_assembled_event_v2_generated::FrameAssembledEventListMessage,
@@ -39,7 +39,20 @@ impl Run {
 
     pub(crate) fn move_to_archive(&self, file_name: &Path, archive_name : &Path) -> io::Result<()> {
         create_dir_all(archive_name)?;
-        let mut data : Vec<u8> = Vec::new();
+        let from_path = {
+            let mut filename = file_name.to_owned();
+            filename.push(&self.parameters.run_name);
+            filename.set_extension("nxs");
+            filename
+        };
+        let to_path = {
+            let mut filename = archive_name.to_owned();
+            filename.push(&self.parameters.run_name);
+            filename.set_extension("nxs");
+            filename
+        };
+        Command::new("mv").arg(from_path).arg(to_path).spawn()?;
+        /*let mut data : Vec<u8> = Vec::new();
         {
             let mut filename = file_name.to_owned();
             filename.push(&self.parameters.run_name);
@@ -54,7 +67,7 @@ impl Run {
             filename.push(&self.parameters.run_name);
             filename.set_extension("nxs");
             File::create(filename)?.write_all(&data)?;
-        };
+        };*/
         Ok(())
     }
 

--- a/nexus-writer/src/nexus/run.rs
+++ b/nexus-writer/src/nexus/run.rs
@@ -1,6 +1,6 @@
 use super::{hdf5_file::RunFile, NexusSettings, RunParameters};
 use chrono::{DateTime, Duration, Utc};
-use std::path::Path;
+use std::{fs::{create_dir_all, File}, io::{self, Read, Write}, path::Path};
 use supermusr_common::spanned::{SpanOnce, SpanOnceError, Spanned, SpannedAggregator, SpannedMut};
 use supermusr_streaming_types::{
     aev2_frame_assembled_event_v2_generated::FrameAssembledEventListMessage,
@@ -35,6 +35,27 @@ impl Run {
     }
     pub(crate) fn parameters(&self) -> &RunParameters {
         &self.parameters
+    }
+
+    pub(crate) fn move_to_archive(&self, file_name: &Path, archive_name : &Path) -> io::Result<()> {
+        create_dir_all(archive_name)?;
+        let mut data : Vec<u8> = Vec::new();
+        {
+            let mut filename = file_name.to_owned();
+            filename.push(&self.parameters.run_name);
+            filename.set_extension("nxs");
+            {
+                File::open(filename.clone())?.read_to_end(&mut data)?;
+            }
+            std::fs::remove_file(filename)?;
+        }
+        {
+            let mut filename = archive_name.to_owned();
+            filename.push(&self.parameters.run_name);
+            filename.set_extension("nxs");
+            File::create(filename)?.write_all(&data)?;
+        };
+        Ok(())
     }
 
     #[tracing::instrument(skip_all, level = "debug", err(level = "warn"))]

--- a/nexus-writer/src/nexus/run.rs
+++ b/nexus-writer/src/nexus/run.rs
@@ -1,6 +1,6 @@
 use super::{hdf5_file::RunFile, NexusSettings, RunParameters};
 use chrono::{DateTime, Duration, Utc};
-use std::{fs::create_dir_all, io, path::Path};
+use std::{fs::create_dir_all, future::Future, io, path::Path};
 use supermusr_common::spanned::{SpanOnce, SpanOnceError, Spanned, SpannedAggregator, SpannedMut};
 use supermusr_streaming_types::{
     aev2_frame_assembled_event_v2_generated::FrameAssembledEventListMessage,
@@ -42,7 +42,7 @@ impl Run {
         &self,
         file_name: &Path,
         archive_name: &Path,
-    ) -> io::Result<tokio::task::JoinHandle<()>> {
+    ) -> io::Result<impl Future<Output = ()>> {
         create_dir_all(archive_name)?;
         let from_path = {
             let mut filename = file_name.to_owned();
@@ -68,7 +68,7 @@ impl Run {
                 }
             });
         };
-        Ok(tokio::spawn(future))
+        Ok(future)
     }
 
     #[tracing::instrument(skip_all, level = "debug", err(level = "warn"))]

--- a/nexus-writer/src/nexus/run.rs
+++ b/nexus-writer/src/nexus/run.rs
@@ -38,7 +38,11 @@ impl Run {
     }
 
     #[tracing::instrument(skip_all, level = "info")]
-    pub(crate) fn move_to_archive(&self, file_name: &Path, archive_name : &Path) -> io::Result<tokio::task::JoinHandle<()>> {
+    pub(crate) fn move_to_archive(
+        &self,
+        file_name: &Path,
+        archive_name: &Path,
+    ) -> io::Result<tokio::task::JoinHandle<()>> {
         create_dir_all(archive_name)?;
         let from_path = {
             let mut filename = file_name.to_owned();
@@ -55,9 +59,9 @@ impl Run {
         let span = tracing::Span::current();
         let future = async move {
             info_span!(parent: &span, "move-async").in_scope(|| {
-                match std::fs::copy(from_path.as_path(),to_path) {
+                match std::fs::copy(from_path.as_path(), to_path) {
                     Ok(bytes) => info!("File Move Succesful. {bytes} byte(s) moved."),
-                    Err(e) => warn!("File Move Error {e}")
+                    Err(e) => warn!("File Move Error {e}"),
                 }
                 if let Err(e) = std::fs::remove_file(from_path) {
                     warn!("Error removing temporary file: {e}");

--- a/nexus-writer/src/nexus/run.rs
+++ b/nexus-writer/src/nexus/run.rs
@@ -54,7 +54,7 @@ impl Run {
         };
         let span = tracing::Span::current();
         let future = async move {
-            info_span!(parent: &span, "Move").in_scope(|| {
+            info_span!(parent: &span, "move-async").in_scope(|| {
                 match std::fs::copy(from_path.as_path(),to_path) {
                     Ok(bytes) => info!("File Move Succesful. {bytes} byte(s) moved."),
                     Err(e) => warn!("File Move Error {e}")

--- a/nexus-writer/src/nexus/run.rs
+++ b/nexus-writer/src/nexus/run.rs
@@ -1,13 +1,13 @@
 use super::{hdf5_file::RunFile, NexusSettings, RunParameters};
 use chrono::{DateTime, Duration, Utc};
-use std::{fs::create_dir_all, io, path::Path, process::Command};
+use std::{fs::create_dir_all, io, path::Path};
 use supermusr_common::spanned::{SpanOnce, SpanOnceError, Spanned, SpannedAggregator, SpannedMut};
 use supermusr_streaming_types::{
     aev2_frame_assembled_event_v2_generated::FrameAssembledEventListMessage,
     ecs_6s4t_run_stop_generated::RunStop, ecs_al00_alarm_generated::Alarm,
     ecs_f144_logdata_generated::f144_LogData, ecs_se00_data_generated::se00_SampleEnvironmentData,
 };
-use tracing::{info_span, Span};
+use tracing::{info, info_span, warn, Span};
 
 pub(crate) struct Run {
     span: SpanOnce,
@@ -37,7 +37,8 @@ impl Run {
         &self.parameters
     }
 
-    pub(crate) fn move_to_archive(&self, file_name: &Path, archive_name : &Path) -> io::Result<()> {
+    #[tracing::instrument(skip_all, level = "info")]
+    pub(crate) fn move_to_archive(&self, file_name: &Path, archive_name : &Path) -> io::Result<tokio::task::JoinHandle<()>> {
         create_dir_all(archive_name)?;
         let from_path = {
             let mut filename = file_name.to_owned();
@@ -51,24 +52,19 @@ impl Run {
             filename.set_extension("nxs");
             filename
         };
-        Command::new("mv").arg(from_path).arg(to_path).spawn()?;
-        /*let mut data : Vec<u8> = Vec::new();
-        {
-            let mut filename = file_name.to_owned();
-            filename.push(&self.parameters.run_name);
-            filename.set_extension("nxs");
-            {
-                File::open(filename.clone())?.read_to_end(&mut data)?;
-            }
-            std::fs::remove_file(filename)?;
-        }
-        {
-            let mut filename = archive_name.to_owned();
-            filename.push(&self.parameters.run_name);
-            filename.set_extension("nxs");
-            File::create(filename)?.write_all(&data)?;
-        };*/
-        Ok(())
+        let span = tracing::Span::current();
+        let future = async move {
+            info_span!(parent: &span, "Move").in_scope(|| {
+                match std::fs::copy(from_path.as_path(),to_path) {
+                    Ok(bytes) => info!("File Move Succesful. {bytes} byte(s) moved."),
+                    Err(e) => warn!("File Move Error {e}")
+                }
+                if let Err(e) = std::fs::remove_file(from_path) {
+                    warn!("Error removing temporary file: {e}");
+                }
+            });
+        };
+        Ok(tokio::spawn(future))
     }
 
     #[tracing::instrument(skip_all, level = "debug", err(level = "warn"))]


### PR DESCRIPTION
## Summary of changes

Added a feature to nexus-writer to allow the nexus file to be moved from a temporary location to another, when the run is determined to be completed by nexus-writer.
The move is performed async to prevent other runs from being blocked.

## Instruction for review/testing

General code quality review (full testing requires pipeline simulation).

Closes https://github.com/STFC-ICD-Research-and-Design/supermusr-data-pipeline/issues/262.