### PR TITLE
Fix excessive memory usage in aggregator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ serde_json = { version = "1.0.132" }
 supermusr-common = { path = "./common" }
 supermusr-streaming-types = { path = "./streaming-types" }
 taos = { version = "0.10.27", default_features = false, features = ["ws"] }
-tokio = { version = "1.41", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1.41", features = ["macros", "rt-multi-thread", "sync"] }
 thiserror = "1.0.66"
 tracing = "0.1.40"
 tracing-opentelemetry = "0.23.0"

--- a/digitiser-aggregator/src/main.rs
+++ b/digitiser-aggregator/src/main.rs
@@ -33,7 +33,7 @@ use supermusr_streaming_types::{
     flatbuffers::InvalidFlatbuffer,
 };
 use tokio::sync::mpsc::{error::TrySendError, Receiver, Sender};
-use tracing::{debug, error, info_span, instrument, level_filters::LevelFilter, warn, Event};
+use tracing::{debug, error, info_span, instrument, level_filters::LevelFilter, warn};
 
 const PRODUCER_TIMEOUT: Timeout = Timeout::After(Duration::from_millis(100));
 
@@ -192,7 +192,7 @@ async fn process_kafka_message(
     channel_send: &AggregatedFrameToBufferSender,
     cache: &mut FrameCache<EventData>,
     msg: &BorrowedMessage<'_>,
-) -> Result<(),TrySendAggregatedFrameError> {
+) -> Result<(), TrySendAggregatedFrameError> {
     msg.headers().conditional_extract_to_current_span(use_otel);
 
     if let Some(payload) = msg.payload() {
@@ -243,7 +243,7 @@ async fn process_digitiser_event_list_message(
     channel_send: &AggregatedFrameToBufferSender,
     cache: &mut FrameCache<EventData>,
     msg: DigitizerEventListMessage<'_>,
-) -> Result<(),TrySendAggregatedFrameError> {
+) -> Result<(), TrySendAggregatedFrameError> {
     match msg.metadata().try_into() {
         Ok(metadata) => {
             debug!("Event packet: metadata: {:?}", msg.metadata());
@@ -271,7 +271,7 @@ async fn process_digitiser_event_list_message(
 async fn cache_poll(
     channel_send: &AggregatedFrameToBufferSender,
     cache: &mut FrameCache<EventData>,
-) -> Result<(),TrySendAggregatedFrameError> {
+) -> Result<(), TrySendAggregatedFrameError> {
     let span = info_span!(target: "otel", "Frame Complete");
     while let Some(frame) = cache.poll() {
         let _guard = span.enter();
@@ -290,7 +290,7 @@ async fn cache_poll(
                     error!("Send-Frame Buffer Full");
                 }
             }
-            return Err(e)
+            return Err(e);
         }
     }
     Ok(())


### PR DESCRIPTION
## Summary of changes

- Replaces `JoinSet` method of producing `frame_event_list` messages to Kakfa, with a dedicated long-running thread which is tasked with emitting frames to Kafka.
- Every call to `cache_poll` drains the cache of completed frames from the front, until an incomplete frame is reached, and sends them to the dedicated thread.
- Frames are emitted in the order they were begun (i.e. when its first digitiser event message arrived).

## Instruction for review/testing

General code review. This change been tested and verified with simulated data, and on HiFi.

Closes https://github.com/STFC-ICD-Research-and-Design/supermusr-data-pipeline/issues/265.