### PR TITLE
Nexus Writer: Make Frame Times Relative to Run Start instead of First Received Frame

### DIFF
--- a/nexus-writer/src/nexus/hdf5_file/run_file.rs
+++ b/nexus-writer/src/nexus/hdf5_file/run_file.rs
@@ -221,6 +221,8 @@ impl RunFile {
         set_string_to(&self.source_name, "MuSR")?;
         set_string_to(&self.source_type, "")?;
         set_string_to(&self.source_probe, "")?;
+
+        self.lists.init(&parameters.collect_from)?;
         Ok(())
     }
 

--- a/nexus-writer/src/nexus/hdf5_file/run_file_components/event_run_file.rs
+++ b/nexus-writer/src/nexus/hdf5_file/run_file_components/event_run_file.rs
@@ -24,6 +24,7 @@ pub(crate) struct EventRun {
     pulse_height: Dataset,
     event_time_offset: Dataset,
 }
+
 impl EventRun {
     #[tracing::instrument(skip_all, level = "trace")]
     pub(crate) fn new_event_runfile(

--- a/nexus-writer/src/nexus/hdf5_file/run_file_components/event_run_file.rs
+++ b/nexus-writer/src/nexus/hdf5_file/run_file_components/event_run_file.rs
@@ -2,12 +2,11 @@ use crate::nexus::{
     hdf5_file::{add_attribute_to, add_new_group_to, create_resizable_dataset},
     nexus_class as NX, NexusSettings,
 };
-use chrono::{DateTime, Duration, Utc};
+use chrono::{DateTime, Utc};
 use hdf5::{types::VarLenUnicode, Dataset, Group};
 use ndarray::s;
 use supermusr_common::{Channel, Time};
 use supermusr_streaming_types::aev2_frame_assembled_event_v2_generated::FrameAssembledEventListMessage;
-use tracing::debug;
 
 #[derive(Debug)]
 pub(crate) struct EventRun {
@@ -25,7 +24,6 @@ pub(crate) struct EventRun {
     pulse_height: Dataset,
     event_time_offset: Dataset,
 }
-
 impl EventRun {
     #[tracing::instrument(skip_all, level = "trace")]
     pub(crate) fn new_event_runfile(
@@ -121,6 +119,13 @@ impl EventRun {
         })
     }
 
+    #[tracing::instrument(skip_all, level = "trace", err(level = "warn"))]
+    pub(crate) fn init(&mut self, offset: &DateTime<Utc>) -> anyhow::Result<()> {
+        self.offset = Some(*offset);
+        add_attribute_to(&self.event_time_zero, "offset", &offset.to_rfc3339())?;
+        Ok(())
+    }
+
     #[tracing::instrument(
         skip_all,
         level = "trace",
@@ -145,19 +150,12 @@ impl EventRun {
             .ok_or(anyhow::anyhow!("Message timestamp missing."))?)
         .try_into()?;
 
-        let time_zero = {
-            if let Some(offset) = self.offset {
-                debug!("Offset found");
-                timestamp - offset
-            } else {
-                add_attribute_to(&self.event_time_zero, "offset", &timestamp.to_rfc3339())?;
-                self.offset = Some(timestamp);
-                debug!("New offset set");
-                Duration::zero()
-            }
-        }
-        .num_nanoseconds()
-        .ok_or(anyhow::anyhow!("event_time_zero cannot be calculated."))?
+        // Recalculate time_zero of the frame to be relative to the offset value
+        // (set at the start of the run).
+        let time_zero = self
+            .offset
+            .and_then(|offset| (timestamp - offset).num_nanoseconds())
+            .ok_or(anyhow::anyhow!("event_time_zero cannot be calculated."))?
             as u64;
 
         self.event_time_zero.resize(self.num_messages + 1)?;


### PR DESCRIPTION
## Summary of changes

Applies to Nexus Writer.

In the cases where frames arrive out of order, it is possible for `event_time_zero` to be 'negative'. As `event_time_zero` is unsigned this results in integer wrap around, giving misleading results. This follows from the `offset` attribute (which is used to calculate `event_time_zero`) being set to the time of the first frame message.

This PR instead sets `offset` to the time of the run start. As any frames before this time are not considered part of the run, this change should make `event_time_zero` robust to wrap around errors.

## Instruction for review/testing

General code review.

The change has been tested and verified on simulated data.