### PR TITLE
Added configuration option

### DIFF
--- a/nexus-writer/src/main.rs
+++ b/nexus-writer/src/main.rs
@@ -4,7 +4,7 @@ use chrono::Duration;
 use clap::Parser;
 use metrics::counter;
 use metrics_exporter_prometheus::PrometheusBuilder;
-use nexus::{NexusEngine, NexusSettings};
+use nexus::{NexusConfiguration, NexusEngine, NexusSettings};
 use rdkafka::{
     consumer::{CommitMode, Consumer},
     message::{BorrowedMessage, Message},
@@ -69,6 +69,10 @@ struct Cli {
     /// Topic to publish frame assembled event messages to
     #[clap(long)]
     frame_event_topic: String,
+
+    /// Optional configuration options to include in the nexus file
+    #[clap(long)]
+    configuration_options: Option<String>,
 
     /// Path of the NeXus file to be written
     #[clap(long)]
@@ -150,7 +154,14 @@ async fn main() -> anyhow::Result<()> {
         args.event_list_chunk_size,
         args.archive_name.as_deref(),
     );
-    let mut nexus_engine = NexusEngine::new(Some(args.file_name.as_path()), nexus_settings);
+
+    let nexus_configuration = NexusConfiguration::new(args.configuration_options);
+
+    let mut nexus_engine = NexusEngine::new(
+        Some(args.file_name.as_path()),
+        nexus_settings,
+        nexus_configuration,
+    );
 
     let mut nexus_write_interval =
         tokio::time::interval(time::Duration::from_millis(args.cache_poll_interval_ms));

--- a/nexus-writer/src/nexus/mod.rs
+++ b/nexus-writer/src/nexus/mod.rs
@@ -3,7 +3,7 @@ mod hdf5_file;
 mod run;
 mod run_parameters;
 
-pub(crate) use engine::{NexusEngine, NexusSettings};
+pub(crate) use engine::{NexusConfiguration, NexusEngine, NexusSettings};
 pub(crate) use run::Run;
 pub(crate) use run_parameters::RunParameters;
 

--- a/nexus-writer/src/nexus/run.rs
+++ b/nexus-writer/src/nexus/run.rs
@@ -1,4 +1,4 @@
-use super::{hdf5_file::RunFile, NexusSettings, RunParameters};
+use super::{hdf5_file::RunFile, NexusConfiguration, NexusSettings, RunParameters};
 use chrono::{DateTime, Duration, Utc};
 use std::{fs::create_dir_all, future::Future, io, path::Path};
 use supermusr_common::spanned::{SpanOnce, SpanOnceError, Spanned, SpannedAggregator, SpannedMut};
@@ -21,10 +21,11 @@ impl Run {
         filename: Option<&Path>,
         parameters: RunParameters,
         nexus_settings: &NexusSettings,
+        nexus_configuration: &NexusConfiguration,
     ) -> anyhow::Result<Self> {
         if let Some(filename) = filename {
             let mut hdf5 = RunFile::new_runfile(filename, &parameters.run_name, nexus_settings)?;
-            hdf5.init(&parameters)?;
+            hdf5.init(&parameters, nexus_configuration)?;
             hdf5.close()?;
         }
         Ok(Self {
@@ -33,6 +34,7 @@ impl Run {
             num_frames: usize::default(),
         })
     }
+
     pub(crate) fn parameters(&self) -> &RunParameters {
         &self.parameters
     }


### PR DESCRIPTION
## Summary of changes

Adds an optional cli option in nexus-writer "configuration-options" which allows a string of text to be written in the resulting Nexus File in the attribute "raw_data_1/detector_1/program_name/configuration".

Here, parameters such as the event detection threshold should be stored.

## Instruction for review/testing

General code review.

Has been tested with simulated data.
