### PR TITLE
Missing run stop prompts new run

### DIFF
--- a/nexus-writer/src/main.rs
+++ b/nexus-writer/src/main.rs
@@ -38,7 +38,7 @@ use supermusr_streaming_types::{
     FrameMetadata,
 };
 use tokio::time;
-use tracing::{debug, error, info_span, instrument, level_filters::LevelFilter, warn};
+use tracing::{debug, error, info_span, instrument, level_filters::LevelFilter, warn, warn_span};
 
 #[derive(Debug, Parser)]
 #[clap(author, version, about)]
@@ -382,7 +382,15 @@ fn process_run_stop_message(nexus_engine: &mut NexusEngine, payload: &[u8]) {
                     warn!("Run span linking failed {e}")
                 }
             }
-            Err(e) => warn!("Stop command ({data:?}) failed {e}"),
+            Err(e) => {
+                let _guard = warn_span!(
+                    "RunStop Error.",
+                    run_name = data.run_name(),
+                    stop_time = data.stop_time(),
+                )
+                .entered();
+                warn!("{e}");
+            }
         },
         Err(e) => {
             warn!("Failed to parse message: {}", e);

--- a/nexus-writer/src/nexus/engine.rs
+++ b/nexus-writer/src/nexus/engine.rs
@@ -104,12 +104,16 @@ impl NexusEngine {
     #[tracing::instrument(skip_all)]
     pub(crate) fn start_command(&mut self, data: RunStart<'_>) -> anyhow::Result<&mut Run> {
         //  If a run is already in progress, and is missing a run-stop
-        //  then call an emergency stop on the current run.
+        //  then call an abort run on the current run.
         if self.run_cache.back().is_some_and(|run| !run.has_run_stop()) {
             self.run_cache
                 .back_mut()
                 .expect("run_cache::back_mut should exist")
-                .set_emergency_stop(self.filename.as_deref(), &self.nexus_settings)?;
+                .set_aborted_run(
+                    self.filename.as_deref(),
+                    data.start_time(),
+                    &self.nexus_settings,
+                )?;
 
             let _guard = warn_span!(
                 "RunStart Error.",

--- a/nexus-writer/src/nexus/engine.rs
+++ b/nexus-writer/src/nexus/engine.rs
@@ -133,7 +133,7 @@ impl NexusEngine {
         self.run_cache
             .back_mut()
             .expect("run_cache::back_mut should exist")
-            .set_aborted_run(
+            .abort_run(
                 self.filename.as_deref(),
                 data.start_time(),
                 &self.nexus_settings,

--- a/nexus-writer/src/nexus/engine.rs
+++ b/nexus-writer/src/nexus/engine.rs
@@ -373,10 +373,12 @@ mod test {
 
         let start1 = create_start(&mut fbb, "Test1", 0).unwrap();
         nexus.start_command(start1).unwrap();
+        assert_eq!(nexus.get_num_cached_runs(), 1);
 
         fbb.reset();
         let start2 = create_start(&mut fbb, "Test2", 0).unwrap();
-        assert!(nexus.start_command(start2).is_err());
+        nexus.start_command(start2).unwrap();
+        assert_eq!(nexus.get_num_cached_runs(), 2);
     }
 
     #[test]

--- a/nexus-writer/src/nexus/hdf5_file/run_file.rs
+++ b/nexus-writer/src/nexus/hdf5_file/run_file.rs
@@ -325,9 +325,12 @@ impl RunFile {
         self.ensure_end_time_is_set(parameters, message)?;
         Ok(())
     }
-    
+
     #[tracing::instrument(skip_all, level = "trace", err(level = "warn"))]
-    pub(crate) fn set_emergency_stop_warning(&mut self, nexus_settings: &NexusSettings) -> anyhow::Result<()> {
+    pub(crate) fn set_emergency_stop_warning(
+        &mut self,
+        nexus_settings: &NexusSettings,
+    ) -> anyhow::Result<()> {
         self.logs.set_emergency_stop_warning(nexus_settings)?;
         Ok(())
     }

--- a/nexus-writer/src/nexus/hdf5_file/run_file.rs
+++ b/nexus-writer/src/nexus/hdf5_file/run_file.rs
@@ -325,6 +325,12 @@ impl RunFile {
         self.ensure_end_time_is_set(parameters, message)?;
         Ok(())
     }
+    
+    #[tracing::instrument(skip_all, level = "trace", err(level = "warn"))]
+    pub(crate) fn set_emergency_stop_warning(&mut self, nexus_settings: &NexusSettings) -> anyhow::Result<()> {
+        self.logs.set_emergency_stop_warning(nexus_settings)?;
+        Ok(())
+    }
 
     #[tracing::instrument(skip_all, level = "trace", err(level = "warn"))]
     pub(crate) fn close(self) -> anyhow::Result<()> {

--- a/nexus-writer/src/nexus/hdf5_file/run_file.rs
+++ b/nexus-writer/src/nexus/hdf5_file/run_file.rs
@@ -327,11 +327,13 @@ impl RunFile {
     }
 
     #[tracing::instrument(skip_all, level = "trace", err(level = "warn"))]
-    pub(crate) fn set_emergency_stop_warning(
+    pub(crate) fn set_aborted_run_warning(
         &mut self,
+        stop_time: i32,
         nexus_settings: &NexusSettings,
     ) -> anyhow::Result<()> {
-        self.logs.set_emergency_stop_warning(nexus_settings)?;
+        self.logs
+            .set_aborted_run_warning(stop_time, nexus_settings)?;
         Ok(())
     }
 

--- a/nexus-writer/src/nexus/hdf5_file/run_file_components/runlog_file.rs
+++ b/nexus-writer/src/nexus/hdf5_file/run_file_components/runlog_file.rs
@@ -66,18 +66,17 @@ impl RunLog {
         Ok(())
     }
 
-    
     #[tracing::instrument(skip_all, level = "trace", err(level = "warn"))]
     pub(crate) fn set_emergency_stop_warning(
         &mut self,
         nexus_settings: &NexusSettings,
     ) -> anyhow::Result<()> {
-        const LOG_NAME : &str = "SuperMuSR_DataPipeline_EmergencyRunStop";
+        const LOG_NAME: &str = "SuperMuSR_DataPipeline_EmergencyRunStop";
         let timeseries = self.parent.group(LOG_NAME).or_else(|err| {
-            let group = add_new_group_to(&self.parent, LOG_NAME, NX::LOG)
-                .map_err(|e| e.context(err))?;
+            let group =
+                add_new_group_to(&self.parent, LOG_NAME, NX::LOG).map_err(|e| e.context(err))?;
 
-            let time = create_resizable_dataset::<i32>(
+            let _time = create_resizable_dataset::<i32>(
                 &group,
                 "time",
                 0,
@@ -91,11 +90,13 @@ impl RunLog {
         })?;
         let timestamps = timeseries.dataset("time")?;
         let values = timeseries.dataset("value")?;
-        
+
         set_slice_to(&timestamps, &[0])?;
-        set_string_to(&values, "A missing or out-of-order RunStop caused this run to be halted.")?;
+        set_string_to(
+            &values,
+            "A missing or out-of-order RunStop caused this run to be halted.",
+        )?;
 
         Ok(())
     }
-    
 }

--- a/nexus-writer/src/nexus/hdf5_file/run_file_components/runlog_file.rs
+++ b/nexus-writer/src/nexus/hdf5_file/run_file_components/runlog_file.rs
@@ -67,8 +67,9 @@ impl RunLog {
     }
 
     #[tracing::instrument(skip_all, level = "trace", err(level = "warn"))]
-    pub(crate) fn set_emergency_stop_warning(
+    pub(crate) fn set_aborted_run_warning(
         &mut self,
+        stop_time: i32,
         nexus_settings: &NexusSettings,
     ) -> anyhow::Result<()> {
         const LOG_NAME: &str = "SuperMuSR_DataPipeline_EmergencyRunStop";
@@ -91,7 +92,7 @@ impl RunLog {
         let timestamps = timeseries.dataset("time")?;
         let values = timeseries.dataset("value")?;
 
-        set_slice_to(&timestamps, &[0])?;
+        set_slice_to(&timestamps, &[stop_time])?;
         set_string_to(
             &values,
             "A missing or out-of-order RunStop caused this run to be halted.",

--- a/nexus-writer/src/nexus/run.rs
+++ b/nexus-writer/src/nexus/run.rs
@@ -172,6 +172,29 @@ impl Run {
         Ok(())
     }
 
+    pub(crate) fn set_emergency_stop(
+        &mut self,
+        filename: Option<&Path>
+    ) -> anyhow::Result<()> {
+        self.parameters.set_emergency_stop()?;
+
+        if let Some(filename) = filename {
+            let mut hdf5 = RunFile::open_runfile(filename, &self.parameters.run_name)?;
+
+            hdf5.set_end_time(
+                &self
+                    .parameters
+                    .run_stop_parameters
+                    .as_ref()
+                    .expect("RunStopParameters exists") // This never panics
+                    .collect_until,
+            )?;
+            hdf5.
+            hdf5.close()?;
+        }
+        Ok(())
+    }
+
     pub(crate) fn is_message_timestamp_valid(&self, timestamp: &DateTime<Utc>) -> bool {
         self.parameters.is_message_timestamp_valid(timestamp)
     }

--- a/nexus-writer/src/nexus/run.rs
+++ b/nexus-writer/src/nexus/run.rs
@@ -174,7 +174,8 @@ impl Run {
 
     pub(crate) fn set_emergency_stop(
         &mut self,
-        filename: Option<&Path>
+        filename: Option<&Path>,
+        nexus_settings: &NexusSettings,
     ) -> anyhow::Result<()> {
         self.parameters.set_emergency_stop()?;
 
@@ -189,7 +190,7 @@ impl Run {
                     .expect("RunStopParameters exists") // This never panics
                     .collect_until,
             )?;
-            hdf5.
+            hdf5.set_emergency_stop_warning(nexus_settings)?;
             hdf5.close()?;
         }
         Ok(())

--- a/nexus-writer/src/nexus/run.rs
+++ b/nexus-writer/src/nexus/run.rs
@@ -172,7 +172,7 @@ impl Run {
         Ok(())
     }
 
-    pub(crate) fn set_aborted_run(
+    pub(crate) fn abort_run(
         &mut self,
         filename: Option<&Path>,
         absolute_stop_time_ms: u64,
@@ -192,7 +192,7 @@ impl Run {
 
             hdf5.set_end_time(&collect_until)?;
             let relative_stop_time_ms =
-                (self.parameters.collect_from - collect_until).num_milliseconds();
+                (collect_until - self.parameters.collect_from).num_milliseconds();
             if let Ok(relative_stop_time_ms) = relative_stop_time_ms.try_into() {
                 hdf5.set_aborted_run_warning(relative_stop_time_ms, nexus_settings)?;
             } else {

--- a/nexus-writer/src/nexus/run_parameters.rs
+++ b/nexus-writer/src/nexus/run_parameters.rs
@@ -64,6 +64,19 @@ impl RunParameters {
             }
         }
     }
+    
+    #[tracing::instrument(skip_all, level = "trace", err(level = "warn"))]
+    pub(crate) fn set_emergency_stop(&mut self) -> anyhow::Result<()> {
+        if self.run_stop_parameters.is_some() {
+            anyhow::bail!("RunStop already set");
+        } {
+            self.run_stop_parameters = Some(RunStopParameters {
+                collect_until: Utc::now(),
+                last_modified: Utc::now(),
+            });
+        }
+        Ok(())
+    }
 
     /// Returns true if timestamp is strictly after collect_from and,
     /// if run_stop_parameters exist then, if timestamp is strictly

--- a/nexus-writer/src/nexus/run_parameters.rs
+++ b/nexus-writer/src/nexus/run_parameters.rs
@@ -64,12 +64,13 @@ impl RunParameters {
             }
         }
     }
-    
+
     #[tracing::instrument(skip_all, level = "trace", err(level = "warn"))]
     pub(crate) fn set_emergency_stop(&mut self) -> anyhow::Result<()> {
         if self.run_stop_parameters.is_some() {
             anyhow::bail!("RunStop already set");
-        } {
+        }
+        {
             self.run_stop_parameters = Some(RunStopParameters {
                 collect_until: Utc::now(),
                 last_modified: Utc::now(),

--- a/nexus-writer/src/nexus/run_parameters.rs
+++ b/nexus-writer/src/nexus/run_parameters.rs
@@ -66,13 +66,16 @@ impl RunParameters {
     }
 
     #[tracing::instrument(skip_all, level = "trace", err(level = "warn"))]
-    pub(crate) fn set_emergency_stop(&mut self) -> anyhow::Result<()> {
+    pub(crate) fn set_aborted_run(&mut self, stop_time: u64) -> anyhow::Result<()> {
+        let collect_until = DateTime::<Utc>::from_timestamp_millis(stop_time.try_into()?).ok_or(
+            anyhow::anyhow!("Cannot create start_time from {0}", &stop_time),
+        )?;
         if self.run_stop_parameters.is_some() {
             anyhow::bail!("RunStop already set");
         }
         {
             self.run_stop_parameters = Some(RunStopParameters {
-                collect_until: Utc::now(),
+                collect_until,
                 last_modified: Utc::now(),
             });
         }


### PR DESCRIPTION
## Summary of changes

Adds "emergency_stop" function, so that when a RunStart is encountered whilst a run is currently running, the current run is halted and a new run begins.
If the new RunStart message has the same run_name field as the previous, this results in the previous run being overwritten.

## Instruction for review/testing

General code review.

Behaviour has been tested with simulated runs.
