### PR TITLE
Otel Tag Option

### DIFF
--- a/common/src/tracer/otel_tracer.rs
+++ b/common/src/tracer/otel_tracer.rs
@@ -12,7 +12,7 @@ use tracing_subscriber::{
 pub(super) struct OtelOptions<'a> {
     pub(super) endpoint: &'a str,
     pub(super) level_filter: LevelFilter,
-    pub(super) namespace: Option<String>,
+    pub(super) namespace: String,
 }
 
 /// Create this object to initialise the Open Telemetry Tracer
@@ -46,7 +46,7 @@ where
         let service_name = opentelemetry::KeyValue::new("service.name", service_name.to_owned());
         let service_namespace = opentelemetry::KeyValue::new(
             "service.namespace",
-            options.namespace.unwrap_or_default(),
+            options.namespace,
         );
 
         let otlp_config = opentelemetry_sdk::trace::Config::default().with_resource(

--- a/common/src/tracer/otel_tracer.rs
+++ b/common/src/tracer/otel_tracer.rs
@@ -43,18 +43,16 @@ where
             .tonic()
             .with_endpoint(options.endpoint);
 
-        let service_name = opentelemetry::KeyValue::new("service.name", service_name.to_owned());
-
-        let otlp_resource =
-            opentelemetry_sdk::Resource::new(if let Some(pipeline_tag) = options.pipeline_tag {
-                vec![
-                    service_name,
-                    opentelemetry::KeyValue::new("pipeline.tag", pipeline_tag),
-                ]
-            } else {
-                vec![service_name]
-            });
-        let otlp_config = opentelemetry_sdk::trace::Config::default().with_resource(otlp_resource);
+        let otlp_config = opentelemetry_sdk::trace::Config::default().with_resource(
+            opentelemetry_sdk::Resource::new(vec![opentelemetry::KeyValue::new(
+                "service.name",
+                format!(
+                    "{}{}",
+                    options.pipeline_tag.unwrap_or_default(),
+                    service_name
+                ),
+            )]),
+        );
 
         opentelemetry::global::set_text_map_propagator(
             opentelemetry_sdk::propagation::TraceContextPropagator::new(),

--- a/common/src/tracer/otel_tracer.rs
+++ b/common/src/tracer/otel_tracer.rs
@@ -43,15 +43,14 @@ where
             .tonic()
             .with_endpoint(options.endpoint);
 
+        let service_name = opentelemetry::KeyValue::new("service.name", service_name.to_owned());
+        let service_namespace = opentelemetry::KeyValue::new(
+            "service.namespace",
+            options.pipeline_tag.unwrap_or_default(),
+        );
+
         let otlp_config = opentelemetry_sdk::trace::Config::default().with_resource(
-            opentelemetry_sdk::Resource::new(vec![opentelemetry::KeyValue::new(
-                "service.name",
-                format!(
-                    "{}{}",
-                    options.pipeline_tag.unwrap_or_default(),
-                    service_name
-                ),
-            )]),
+            opentelemetry_sdk::Resource::new(vec![service_name, service_namespace]),
         );
 
         opentelemetry::global::set_text_map_propagator(

--- a/common/src/tracer/otel_tracer.rs
+++ b/common/src/tracer/otel_tracer.rs
@@ -12,7 +12,7 @@ use tracing_subscriber::{
 pub(super) struct OtelOptions<'a> {
     pub(super) endpoint: &'a str,
     pub(super) level_filter: LevelFilter,
-    pub(super) pipeline_tag: Option<String>,
+    pub(super) namespace: Option<String>,
 }
 
 /// Create this object to initialise the Open Telemetry Tracer
@@ -46,7 +46,7 @@ where
         let service_name = opentelemetry::KeyValue::new("service.name", service_name.to_owned());
         let service_namespace = opentelemetry::KeyValue::new(
             "service.namespace",
-            options.pipeline_tag.unwrap_or_default(),
+            options.namespace.unwrap_or_default(),
         );
 
         let otlp_config = opentelemetry_sdk::trace::Config::default().with_resource(

--- a/common/src/tracer/otel_tracer.rs
+++ b/common/src/tracer/otel_tracer.rs
@@ -37,28 +37,23 @@ where
     pub(super) fn new(
         options: OtelOptions,
         service_name: &str,
-        module_name: &str
+        module_name: &str,
     ) -> Result<Self, TraceError> {
         let otlp_exporter = opentelemetry_otlp::new_exporter()
             .tonic()
             .with_endpoint(options.endpoint);
 
-        let service_name = opentelemetry::KeyValue::new(
-            "service.name",
-            service_name.to_owned(),
-        );
+        let service_name = opentelemetry::KeyValue::new("service.name", service_name.to_owned());
 
-        let otlp_resource = opentelemetry_sdk::Resource::new(
-            if let Some(pipeline_tag) = options.pipeline_tag {
-                vec![service_name,
-                opentelemetry::KeyValue::new(
-                    "pipeline.tag",
-                    pipeline_tag,
-                )]
+        let otlp_resource =
+            opentelemetry_sdk::Resource::new(if let Some(pipeline_tag) = options.pipeline_tag {
+                vec![
+                    service_name,
+                    opentelemetry::KeyValue::new("pipeline.tag", pipeline_tag),
+                ]
             } else {
                 vec![service_name]
-            }
-        );
+            });
         let otlp_config = opentelemetry_sdk::trace::Config::default().with_resource(otlp_resource);
 
         opentelemetry::global::set_text_map_propagator(

--- a/common/src/tracer/otel_tracer.rs
+++ b/common/src/tracer/otel_tracer.rs
@@ -44,10 +44,8 @@ where
             .with_endpoint(options.endpoint);
 
         let service_name = opentelemetry::KeyValue::new("service.name", service_name.to_owned());
-        let service_namespace = opentelemetry::KeyValue::new(
-            "service.namespace",
-            options.namespace,
-        );
+        let service_namespace =
+            opentelemetry::KeyValue::new("service.namespace", options.namespace);
 
         let otlp_config = opentelemetry_sdk::trace::Config::default().with_resource(
             opentelemetry_sdk::Resource::new(vec![service_name, service_namespace]),

--- a/common/src/tracer/tracer_engine.rs
+++ b/common/src/tracer/tracer_engine.rs
@@ -12,7 +12,7 @@ impl<'a> TracerOptions<'a> {
     pub fn new(
         endpoint: Option<&'a str>,
         level_filter: LevelFilter,
-        namespace: Option<String>,
+        namespace: String,
     ) -> Self {
         Self {
             otel_options: endpoint.map(|endpoint| OtelOptions {

--- a/common/src/tracer/tracer_engine.rs
+++ b/common/src/tracer/tracer_engine.rs
@@ -12,13 +12,13 @@ impl<'a> TracerOptions<'a> {
     pub fn new(
         endpoint: Option<&'a str>,
         level_filter: LevelFilter,
-        pipeline_tag: Option<String>,
+        namespace: Option<String>,
     ) -> Self {
         Self {
             otel_options: endpoint.map(|endpoint| OtelOptions {
                 endpoint,
                 level_filter,
-                pipeline_tag,
+                namespace,
             }),
         }
     }

--- a/common/src/tracer/tracer_engine.rs
+++ b/common/src/tracer/tracer_engine.rs
@@ -9,11 +9,7 @@ pub struct TracerOptions<'a> {
 }
 
 impl<'a> TracerOptions<'a> {
-    pub fn new(
-        endpoint: Option<&'a str>,
-        level_filter: LevelFilter,
-        namespace: String,
-    ) -> Self {
+    pub fn new(endpoint: Option<&'a str>, level_filter: LevelFilter, namespace: String) -> Self {
         Self {
             otel_options: endpoint.map(|endpoint| OtelOptions {
                 endpoint,

--- a/common/src/tracer/tracer_engine.rs
+++ b/common/src/tracer/tracer_engine.rs
@@ -9,12 +9,16 @@ pub struct TracerOptions<'a> {
 }
 
 impl<'a> TracerOptions<'a> {
-    pub fn new(endpoint: Option<&'a str>, level_filter: LevelFilter, pipeline_tag: Option<String>) -> Self {
+    pub fn new(
+        endpoint: Option<&'a str>,
+        level_filter: LevelFilter,
+        pipeline_tag: Option<String>,
+    ) -> Self {
         Self {
             otel_options: endpoint.map(|endpoint| OtelOptions {
                 endpoint,
                 level_filter,
-                pipeline_tag
+                pipeline_tag,
             }),
         }
     }

--- a/common/src/tracer/tracer_engine.rs
+++ b/common/src/tracer/tracer_engine.rs
@@ -9,11 +9,12 @@ pub struct TracerOptions<'a> {
 }
 
 impl<'a> TracerOptions<'a> {
-    pub fn new(endpoint: Option<&'a str>, level_filter: LevelFilter) -> Self {
+    pub fn new(endpoint: Option<&'a str>, level_filter: LevelFilter, pipeline_tag: Option<String>) -> Self {
         Self {
             otel_options: endpoint.map(|endpoint| OtelOptions {
                 endpoint,
                 level_filter,
+                pipeline_tag
             }),
         }
     }

--- a/digitiser-aggregator/src/main.rs
+++ b/digitiser-aggregator/src/main.rs
@@ -86,6 +86,10 @@ struct Cli {
     /// The reporting level to use for OpenTelemetry
     #[clap(long, default_value = "info")]
     otel_level: LevelFilter,
+
+    /// All OpenTelemetry Tags are appended with this string, if given. Can be used to track different instances of the pipeline running in parallel.
+    #[clap(long)]
+    otel_pipeline_tag: Option<String>,
 }
 
 type AggregatedFrameToBufferSender = Sender<AggregatedFrame<EventData>>;
@@ -97,7 +101,8 @@ async fn main() -> anyhow::Result<()> {
 
     let tracer = init_tracer!(TracerOptions::new(
         args.otel_endpoint.as_deref(),
-        args.otel_level
+        args.otel_level,
+        args.otel_pipeline_tag
     ));
 
     let kafka_opts = args.common_kafka_options;

--- a/digitiser-aggregator/src/main.rs
+++ b/digitiser-aggregator/src/main.rs
@@ -89,7 +89,7 @@ struct Cli {
 
     /// All OpenTelemetry Tags are appended with this string, if given. Can be used to track different instances of the pipeline running in parallel.
     #[clap(long)]
-    otel_pipeline_tag: Option<String>,
+    otel_namespace: Option<String>,
 }
 
 type AggregatedFrameToBufferSender = Sender<AggregatedFrame<EventData>>;
@@ -102,7 +102,7 @@ async fn main() -> anyhow::Result<()> {
     let tracer = init_tracer!(TracerOptions::new(
         args.otel_endpoint.as_deref(),
         args.otel_level,
-        args.otel_pipeline_tag
+        args.otel_namespace
     ));
 
     let kafka_opts = args.common_kafka_options;

--- a/digitiser-aggregator/src/main.rs
+++ b/digitiser-aggregator/src/main.rs
@@ -87,9 +87,9 @@ struct Cli {
     #[clap(long, default_value = "info")]
     otel_level: LevelFilter,
 
-    /// All OpenTelemetry Tags are appended with this string, if given. Can be used to track different instances of the pipeline running in parallel.
-    #[clap(long)]
-    otel_namespace: Option<String>,
+    /// All OpenTelemetry spans are emitted with this as the "service.namespace" property. Can be used to track different instances of the pipeline running in parallel.
+    #[clap(long, default_value = "")]
+    otel_namespace: String,
 }
 
 type AggregatedFrameToBufferSender = Sender<AggregatedFrame<EventData>>;

--- a/nexus-writer/src/main.rs
+++ b/nexus-writer/src/main.rs
@@ -98,9 +98,9 @@ struct Cli {
     #[clap(long, default_value = "info")]
     otel_level: LevelFilter,
 
-    /// All OpenTelemetry Tags are appended with this string, if given. Can be used to track different instances of the pipeline running in parallel.
-    #[clap(long)]
-    otel_namespace: Option<String>,
+    /// All OpenTelemetry spans are emitted with this as the "service.namespace" property. Can be used to track different instances of the pipeline running in parallel.
+    #[clap(long, default_value = "")]
+    otel_namespace: String,
 
     /// Endpoint on which OpenMetrics flavour metrics are available
     #[clap(long, default_value = "127.0.0.1:9090")]

--- a/nexus-writer/src/main.rs
+++ b/nexus-writer/src/main.rs
@@ -100,7 +100,7 @@ struct Cli {
 
     /// All OpenTelemetry Tags are appended with this string, if given. Can be used to track different instances of the pipeline running in parallel.
     #[clap(long)]
-    otel_pipeline_tag: Option<String>,
+    otel_namespace: Option<String>,
 
     /// Endpoint on which OpenMetrics flavour metrics are available
     #[clap(long, default_value = "127.0.0.1:9090")]
@@ -124,7 +124,7 @@ async fn main() -> anyhow::Result<()> {
     let tracer = init_tracer!(TracerOptions::new(
         args.otel_endpoint.as_deref(),
         args.otel_level,
-        args.otel_pipeline_tag
+        args.otel_namespace
     ));
 
     // Get topics to subscribe to from command line arguments.

--- a/nexus-writer/src/main.rs
+++ b/nexus-writer/src/main.rs
@@ -94,6 +94,10 @@ struct Cli {
     #[clap(long, default_value = "info")]
     otel_level: LevelFilter,
 
+    /// All OpenTelemetry Tags are appended with this string, if given. Can be used to track different instances of the pipeline running in parallel.
+    #[clap(long)]
+    otel_pipeline_tag: Option<String>,
+
     /// Endpoint on which OpenMetrics flavour metrics are available
     #[clap(long, default_value = "127.0.0.1:9090")]
     observability_address: SocketAddr,
@@ -111,12 +115,13 @@ struct Cli {
 async fn main() -> anyhow::Result<()> {
     let args = Cli::parse();
 
+    debug!("{args:?}");
+
     let tracer = init_tracer!(TracerOptions::new(
         args.otel_endpoint.as_deref(),
-        args.otel_level
+        args.otel_level,
+        args.otel_pipeline_tag
     ));
-
-    debug!("{args:?}");
 
     // Get topics to subscribe to from command line arguments.
     let topics_to_subscribe = {

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -54,9 +54,9 @@ struct Cli {
     #[clap(long, default_value = "info")]
     otel_level: LevelFilter,
 
-    /// All OpenTelemetry Tags are appended with this string, if given. Can be used to track different instances of the pipeline running in parallel.
-    #[clap(long)]
-    otel_pipeline_tag: Option<String>,
+    /// All OpenTelemetry spans are emitted with this as the "service.namespace" property. Can be used to track different instances of the pipeline running in parallel.
+    #[clap(long, default_value = "")]
+    otel_namespace: String,
 
     #[command(subcommand)]
     mode: Mode,
@@ -179,7 +179,7 @@ async fn main() -> anyhow::Result<()> {
     let tracer = init_tracer!(TracerOptions::new(
         cli.otel_endpoint.as_deref(),
         cli.otel_level,
-        cli.otel_pipeline_tag
+        cli.otel_namespace
     ));
 
     let kafka_opts = &cli.common_kafka_options;

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -53,7 +53,7 @@ struct Cli {
     /// The reporting level to use for OpenTelemetry
     #[clap(long, default_value = "info")]
     otel_level: LevelFilter,
-    
+
     /// All OpenTelemetry Tags are appended with this string, if given. Can be used to track different instances of the pipeline running in parallel.
     #[clap(long)]
     otel_pipeline_tag: Option<String>,

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -53,6 +53,10 @@ struct Cli {
     /// The reporting level to use for OpenTelemetry
     #[clap(long, default_value = "info")]
     otel_level: LevelFilter,
+    
+    /// All OpenTelemetry Tags are appended with this string, if given. Can be used to track different instances of the pipeline running in parallel.
+    #[clap(long)]
+    otel_pipeline_tag: Option<String>,
 
     #[command(subcommand)]
     mode: Mode,
@@ -174,7 +178,8 @@ async fn main() -> anyhow::Result<()> {
 
     let tracer = init_tracer!(TracerOptions::new(
         cli.otel_endpoint.as_deref(),
-        cli.otel_level
+        cli.otel_level,
+        cli.otel_pipeline_tag
     ));
 
     let kafka_opts = &cli.common_kafka_options;

--- a/trace-to-events/src/main.rs
+++ b/trace-to-events/src/main.rs
@@ -77,6 +77,10 @@ struct Cli {
     #[clap(long, default_value = "info")]
     otel_level: LevelFilter,
 
+    /// All OpenTelemetry Tags are appended with this string, if given. Can be used to track different instances of the pipeline running in parallel.
+    #[clap(long)]
+    otel_pipeline_tag: Option<String>,
+
     #[command(subcommand)]
     pub(crate) mode: Mode,
 }
@@ -87,7 +91,8 @@ async fn main() -> anyhow::Result<()> {
 
     let tracer = init_tracer!(TracerOptions::new(
         args.otel_endpoint.as_deref(),
-        args.otel_level
+        args.otel_level,
+        args.otel_pipeline_tag.clone()
     ));
 
     let kafka_opts = &args.common_kafka_options;

--- a/trace-to-events/src/main.rs
+++ b/trace-to-events/src/main.rs
@@ -79,7 +79,7 @@ struct Cli {
 
     /// All OpenTelemetry Tags are appended with this string, if given. Can be used to track different instances of the pipeline running in parallel.
     #[clap(long)]
-    otel_pipeline_tag: Option<String>,
+    otel_namespace: Option<String>,
 
     #[command(subcommand)]
     pub(crate) mode: Mode,
@@ -92,7 +92,7 @@ async fn main() -> anyhow::Result<()> {
     let tracer = init_tracer!(TracerOptions::new(
         args.otel_endpoint.as_deref(),
         args.otel_level,
-        args.otel_pipeline_tag.clone()
+        args.otel_namespace.clone()
     ));
 
     let kafka_opts = &args.common_kafka_options;

--- a/trace-to-events/src/main.rs
+++ b/trace-to-events/src/main.rs
@@ -77,9 +77,9 @@ struct Cli {
     #[clap(long, default_value = "info")]
     otel_level: LevelFilter,
 
-    /// All OpenTelemetry Tags are appended with this string, if given. Can be used to track different instances of the pipeline running in parallel.
-    #[clap(long)]
-    otel_namespace: Option<String>,
+    /// All OpenTelemetry spans are emitted with this as the "service.namespace" property. Can be used to track different instances of the pipeline running in parallel.
+    #[clap(long, default_value = "")]
+    otel_namespace: String,
 
     #[command(subcommand)]
     pub(crate) mode: Mode,


### PR DESCRIPTION
## Summary of changes

Adds extra command line option, which prepends the "service.name" field for OpenTelemetry with an optional string. Useful for distinguishing telemetry from different instances of the pipeline running in parallel.

## Instruction for review/testing

General code review.

Tested on simulated data.
