### PR TITLE
Changes structure of `Frame Completed` span in nexus writer

### DIFF
--- a/digitiser-aggregator/src/frame/cache.rs
+++ b/digitiser-aggregator/src/frame/cache.rs
@@ -83,7 +83,7 @@ where
         if self
             .frames
             .front()
-            .is_some_and(|frame| frame.is_complete() | frame.is_expired())
+            .is_some_and(|frame| frame.is_complete() || frame.is_expired())
         {
             let frame = self
                 .frames

--- a/digitiser-aggregator/src/frame/cache.rs
+++ b/digitiser-aggregator/src/frame/cache.rs
@@ -40,6 +40,7 @@ where
                 Some(frame) => {
                     frame.push(digitiser_id, data);
                     frame.push_veto_flags(metadata.veto_flags);
+                    frame.set_completion_status(&self.expected_digitisers);
                     frame
                 }
                 None => {
@@ -82,7 +83,7 @@ where
         if self
             .frames
             .front()
-            .is_some_and(|frame| frame.is_complete(&self.expected_digitisers) | frame.is_expired())
+            .is_some_and(|frame| frame.is_complete() | frame.is_expired())
         {
             let frame = self
                 .frames

--- a/digitiser-aggregator/src/frame/partial.rs
+++ b/digitiser-aggregator/src/frame/partial.rs
@@ -30,7 +30,7 @@ impl<D> PartialFrame<D> {
             digitiser_data: Default::default(),
         }
     }
-    
+
     pub(super) fn digitiser_ids(&self) -> Vec<DigitizerId> {
         let mut cache_digitiser_ids: Vec<DigitizerId> =
             self.digitiser_data.iter().map(|i| i.0).collect();

--- a/digitiser-aggregator/src/frame/partial.rs
+++ b/digitiser-aggregator/src/frame/partial.rs
@@ -101,7 +101,7 @@ impl<D> SpannedAggregator for PartialFrame<D> {
         #[cfg(not(test))] //   In test mode, the frame.span() are not initialised
         self.span()
             .get()?
-            .record("frame_is_expired", self.is_expired() & !self.is_complete());
+            .record("frame_is_expired", self.is_expired() && !self.is_complete());
         Ok(())
     }
 }

--- a/digitiser-aggregator/src/main.rs
+++ b/digitiser-aggregator/src/main.rs
@@ -272,8 +272,14 @@ async fn cache_poll(
     channel_send: &AggregatedFrameToBufferSender,
     cache: &mut FrameCache<EventData>,
 ) -> Result<(), TrySendAggregatedFrameError> {
-    let span = info_span!(target: "otel", "Frame Complete");
     while let Some(frame) = cache.poll() {
+        let span = info_span!(target: "otel", "Frame Completed");
+        span.follows_from(
+            frame
+                .span()
+                .get()
+                .expect("Span should exist, this should never fail"),
+        );
         let _guard = span.enter();
 
         // For each frame that is ready to send,

--- a/nexus-writer/src/main.rs
+++ b/nexus-writer/src/main.rs
@@ -120,8 +120,6 @@ async fn main() -> anyhow::Result<()> {
         args.otel_level
     ));
 
-    debug!("{args:?}");
-
     // Get topics to subscribe to from command line arguments.
     let topics_to_subscribe = {
         let mut topics_to_subscribe = [


### PR DESCRIPTION
## Summary of changes

- In `cache_poll`, the `Frame Completed` span now occurs for every frame dispatched from the cache. Allowing us to see how many are unqueued at the same time.
- Fixes a bug whereby complete frames in the queue are marked as expired because they were behind incomplete frames.
- Removed `debug!("{args}");` log statement.

## Instruction for review/testing

General code review.

Tested on simulated data.
