### PR TITLE
Need to Join Completed Producer Threads in Trace to Events

### DIFF
--- a/trace-to-events/src/main.rs
+++ b/trace-to-events/src/main.rs
@@ -152,14 +152,9 @@ async fn main() -> anyhow::Result<()> {
                 }
                 Err(e) => warn!("Kafka error: {}", e)
             },
-            r = kafka_producer_thread_set.join_next() => {
-                if let Some(r) = r {
-                    match r {
-                        Ok(_) => {}
-                        Err(e) => {
-                            error!("{e}");
-                        }
-                    }
+            join_next = kafka_producer_thread_set.join_next() => {
+                if let Some(Err(e)) = join_next {
+                    error!("Error Joining Kafka Producer Task: {e}");
                 }
             }
         }


### PR DESCRIPTION
## Summary of changes

Producer threads created in the `trace-to-events` create were not being joined with the main thread, possibly causing excessive memory usage.

This PR introduces a `tokio::select` statement which joins completed threads without waiting for them.

## Instruction for review/testing

General code review.

Tested on simulated and hifi input.