### PR TITLE
Single producer thread event formation

### DIFF
--- a/trace-to-events/src/main.rs
+++ b/trace-to-events/src/main.rs
@@ -33,7 +33,7 @@ use supermusr_streaming_types::{
     FrameMetadata,
 };
 use tokio::sync::mpsc::{error::TrySendError, Receiver, Sender};
-use tracing::{debug, error, instrument, metadata::LevelFilter, trace, warn};
+use tracing::{debug, error, info, instrument, metadata::LevelFilter, trace, warn};
 
 #[derive(Debug, Parser)]
 #[clap(author, version, about)]
@@ -140,7 +140,6 @@ async fn main() -> anyhow::Result<()> {
         "Number of failures encountered"
     );
 
-    //let mut kafka_producer_thread_set = JoinSet::new();
     let sender = create_producer_task(args.send_eventlist_buffer_size);
 
     loop {
@@ -195,7 +194,7 @@ async fn produce_to_kafka(mut channel_recv: Receiver<DeliveryFuture>) {
                 }
             },
             None => {
-                error!("Send-Frame Receiver Error");
+                info!("Send-Frame channel closed");
                 return;
             }
         }

--- a/trace-to-events/src/main.rs
+++ b/trace-to-events/src/main.rs
@@ -157,12 +157,7 @@ async fn main() -> anyhow::Result<()> {
                     consumer.commit_message(&m, CommitMode::Async).unwrap();
                 }
                 Err(e) => warn!("Kafka error: {}", e)
-            }/*
-            join_next = kafka_producer_thread_set.join_next() => {
-                if let Some(Err(e)) = join_next {
-                    error!("Error Joining Kafka Producer Task: {e}");
-                }
-            }*/
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

The current event-formation component creates a new thread to produce each outgoing message resulting in the overhead associated with thread for each message. In this PR, the component creates a single persistent thread for producing messages to Kafka, and transfers processed traces from the main thread to this thread via a channel.

## Instruction for review/testing

Commentary on the new architecture is welcome. Is this a good change?

General code review.

Has been tested on simulated and Kafka data.