### PR TITLE
Close hdf5 file when resuming

### DIFF
--- a/nexus-writer/src/nexus/run.rs
+++ b/nexus-writer/src/nexus/run.rs
@@ -37,6 +37,8 @@ impl Run {
     pub(crate) fn resume_partial_run(local_path: &Path, filename: &str) -> anyhow::Result<Self> {
         let run = RunFile::open_runfile(local_path, filename)?;
         let parameters = run.extract_run_parameters()?;
+        run.close()?;
+
         Ok(Self {
             span: Default::default(),
             parameters,


### PR DESCRIPTION
## Summary of changes

Fixes two possible source of memory leakage:
 - Explicitly closes the hdf5 file after resuming a partial run
 - Explicitly closes the hdf5 file after an error occurs whilst reading or creating the datasets.

## Instruction for review/testing

- General code review.
- Advice on limiting unnecessary memory usage.
