### PR TITLE
Add comma separated digitiser argument in aggregator

### DIFF
--- a/digitiser-aggregator/src/main.rs
+++ b/digitiser-aggregator/src/main.rs
@@ -64,8 +64,9 @@ struct Cli {
     output_topic: String,
 
     /// A list of expected digitiser IDs.
+    /// Can be passed as `-d0 -d1 ...` or `-d=0,1,...`
     /// A frame is only "complete" when a message has been received from each of these IDs.
-    #[clap(short, long)]
+    #[clap(short, long, value_delimiter=',')]
     digitiser_ids: Vec<DigitizerId>,
 
     /// Frame TTL in milliseconds.

--- a/digitiser-aggregator/src/main.rs
+++ b/digitiser-aggregator/src/main.rs
@@ -66,7 +66,7 @@ struct Cli {
     /// A list of expected digitiser IDs.
     /// Can be passed as `-d0 -d1 ...` or `-d=0,1,...`
     /// A frame is only "complete" when a message has been received from each of these IDs.
-    #[clap(short, long, value_delimiter=',')]
+    #[clap(short, long, value_delimiter = ',')]
     digitiser_ids: Vec<DigitizerId>,
 
     /// Frame TTL in milliseconds.


### PR DESCRIPTION
## Summary of changes

Enabled digitisers to be specified as a comma separated list in cli instead of as repeated arguments.
This is useful in docker compose.

## Instruction for review/testing

General code review.

Has been tested with simulated data.
