### PR TITLE
Digitizer reporting in assembled messages

### DIFF
--- a/digitiser-aggregator/src/data/event.rs
+++ b/digitiser-aggregator/src/data/event.rs
@@ -1,6 +1,6 @@
 use super::{Accumulate, DigitiserData};
 use crate::frame::AggregatedFrame;
-use supermusr_common::{Channel, Intensity, Time};
+use supermusr_common::{Channel, DigitizerId, Intensity, Time};
 use supermusr_streaming_types::{
     aev2_frame_assembled_event_v2_generated::{
         finish_frame_assembled_event_list_message_buffer, FrameAssembledEventListMessage,
@@ -126,6 +126,8 @@ impl From<AggregatedFrame<EventData>> for Vec<u8> {
             time: Some(fbb.create_vector::<Time>(&frame.digitiser_data.time)),
             voltage: Some(fbb.create_vector::<Intensity>(&frame.digitiser_data.intensity)),
             channel: Some(fbb.create_vector::<Channel>(&frame.digitiser_data.channel)),
+            complete: frame.complete,
+            digitizers_present: Some(fbb.create_vector::<DigitizerId>(&frame.digitiser_ids)),
         };
         let message = FrameAssembledEventListMessage::create(&mut fbb, &message);
 
@@ -179,6 +181,8 @@ mod test {
                 time: Some(fbb.create_vector::<Time>(&[1, 2, 8, 9, 7])),
                 voltage: Some(fbb.create_vector::<Intensity>(&[2, 8, 8, 2, 7])),
                 channel: Some(fbb.create_vector::<Channel>(&[1, 3, 1, 0, 4])),
+                complete: true,
+                digitizers_present: Some(fbb.create_vector::<DigitizerId>(&[0, 1])),
             };
             let message = FrameAssembledEventListMessage::create(&mut fbb, &message);
 
@@ -197,6 +201,7 @@ mod test {
                     frame_number: 1337,
                     veto_flags: 4,
                 },
+                true,
                 vec![0, 1],
                 EventData {
                     time: vec![1, 2, 8, 9, 7],

--- a/digitiser-aggregator/src/frame/aggregated.rs
+++ b/digitiser-aggregator/src/frame/aggregated.rs
@@ -1,14 +1,15 @@
 use super::partial::PartialFrame;
 use crate::data::{Accumulate, DigitiserData};
-use supermusr_common::spanned::{SpanOnce, Spanned, SpannedMut};
-#[cfg(test)]
-use supermusr_common::DigitizerId;
+use supermusr_common::{
+    spanned::{SpanOnce, Spanned, SpannedMut},
+    DigitizerId,
+};
 use supermusr_streaming_types::FrameMetadata;
 
 pub(crate) struct AggregatedFrame<D> {
     span: SpanOnce,
     pub(crate) metadata: FrameMetadata,
-    #[cfg(test)]
+    pub(crate) complete: bool,
     pub(crate) digitiser_ids: Vec<DigitizerId>,
     pub(crate) digitiser_data: D,
 }
@@ -17,13 +18,14 @@ pub(crate) struct AggregatedFrame<D> {
 impl<D> AggregatedFrame<D> {
     pub(crate) fn new(
         metadata: FrameMetadata,
-        #[cfg(test)] digitiser_ids: Vec<DigitizerId>,
+        complete: bool,
+        digitiser_ids: Vec<DigitizerId>,
         digitiser_data: D,
     ) -> Self {
         Self {
             span: Default::default(),
             metadata,
-            #[cfg(test)]
+            complete,
             digitiser_ids,
             digitiser_data,
         }
@@ -41,7 +43,7 @@ where
                 .take()
                 .expect("partial frame should have a span"),
             metadata: partial.metadata.clone(),
-            #[cfg(test)]
+            complete: partial.is_complete(),
             digitiser_ids: partial.digitiser_ids(),
             digitiser_data: <DigitiserData<D> as Accumulate<D>>::accumulate(
                 &mut partial.digitiser_data,

--- a/schemas/aev2_frame_assembled_event_v2.fbs
+++ b/schemas/aev2_frame_assembled_event_v2.fbs
@@ -5,9 +5,12 @@ file_identifier "aev2";
 table FrameAssembledEventListMessage {
     metadata: FrameMetadataV2 (required);
 
-    time: [uint32];  // Time since start of frame in nanoseconds
+    time: [uint32];               // Time since start of frame in nanoseconds
     voltage: [uint16];
-    channel: [uint32];  // Channel number (note: not index)
+    channel: [uint32];            // Channel number (note: not index)
+
+    complete: bool;               // Flag indicating if this message is regarded as complete (i.e. all digitizers that should have contirbuted to it have done so)
+    digitizers_present: [uint8];  // IDs of digitizers that are represented in this assembled frame
 }
 
 root_type FrameAssembledEventListMessage;

--- a/simulator/src/integrated/build_messages.rs
+++ b/simulator/src/integrated/build_messages.rs
@@ -173,6 +173,8 @@ pub(crate) fn build_aggregated_event_list_message(
         time: Some(fbb.create_vector(&time)),
         voltage: Some(fbb.create_vector(&voltage)),
         channel: Some(fbb.create_vector(channels)),
+        complete: true,
+        digitizers_present: None,
     };
     let message = FrameAssembledEventListMessage::create(fbb, &message);
     finish_frame_assembled_event_list_message_buffer(fbb, message);


### PR DESCRIPTION
## Summary of changes

Adds two extra fields to the assembled frame flatbuffer messages, one to indicate if the frame is considered complete and another to list the digitisers that contributed data to this frame.

This data is already collected in the building of the partial frame, this just adds propagation of it to the assembled message.

## Instruction for review/testing

- Test using simulated data
- Pipeline should work as it always did
