### PR TITLE
Propagate incomplete frame data

### DIFF
--- a/nexus-writer/src/main.rs
+++ b/nexus-writer/src/main.rs
@@ -293,7 +293,7 @@ where
         metadata_veto_flags = tracing::field::Empty,
         metadata_protons_per_pulse = tracing::field::Empty,
         metadata_running = tracing::field::Empty,
-        frame_complete = tracing::field::Empty,
+        frame_is_complete = tracing::field::Empty,
     )
 )]
 fn process_frame_assembled_event_list_message(nexus_engine: &mut NexusEngine, payload: &[u8]) {
@@ -308,7 +308,7 @@ fn process_frame_assembled_event_list_message(nexus_engine: &mut NexusEngine, pa
                 .try_into()
                 .map(|metadata: FrameMetadata| {
                     record_metadata_fields_to_span!(metadata, tracing::Span::current());
-                    tracing::Span::current().record("frame_complete", data.complete());
+                    tracing::Span::current().record("frame_is_complete", data.complete());
                 })
                 .ok();
             match nexus_engine.process_event_list(&data) {
@@ -323,7 +323,7 @@ fn process_frame_assembled_event_list_message(nexus_engine: &mut NexusEngine, pa
                                 "metadata_veto_flags" = tracing::field::Empty,
                                 "metadata_protons_per_pulse" = tracing::field::Empty,
                                 "metadata_running" = tracing::field::Empty,
-                                "frame_complete" = data.complete(),
+                                "frame_is_complete" = data.complete(),
                             );
                             data.metadata()
                                 .try_into()

--- a/nexus-writer/src/main.rs
+++ b/nexus-writer/src/main.rs
@@ -293,6 +293,7 @@ where
         metadata_veto_flags = tracing::field::Empty,
         metadata_protons_per_pulse = tracing::field::Empty,
         metadata_running = tracing::field::Empty,
+        frame_complete = tracing::field::Empty,
     )
 )]
 fn process_frame_assembled_event_list_message(nexus_engine: &mut NexusEngine, payload: &[u8]) {
@@ -307,6 +308,7 @@ fn process_frame_assembled_event_list_message(nexus_engine: &mut NexusEngine, pa
                 .try_into()
                 .map(|metadata: FrameMetadata| {
                     record_metadata_fields_to_span!(metadata, tracing::Span::current());
+                    tracing::Span::current().record("frame_complete", data.complete());
                 })
                 .ok();
             match nexus_engine.process_event_list(&data) {
@@ -321,6 +323,7 @@ fn process_frame_assembled_event_list_message(nexus_engine: &mut NexusEngine, pa
                                 "metadata_veto_flags" = tracing::field::Empty,
                                 "metadata_protons_per_pulse" = tracing::field::Empty,
                                 "metadata_running" = tracing::field::Empty,
+                                "frame_complete" = data.complete(),
                             );
                             data.metadata()
                                 .try_into()

--- a/nexus-writer/src/nexus/engine.rs
+++ b/nexus-writer/src/nexus/engine.rs
@@ -210,7 +210,7 @@ impl NexusEngine {
             .iter_mut()
             .find(|run| run.is_message_timestamp_valid(&timestamp))
         {
-            run.push_message(self.local_path.as_deref(), message)?;
+            run.push_message(self.local_path.as_deref(), message, &self.nexus_settings)?;
             Some(run)
         } else {
             warn!("No run found for message with timestamp: {timestamp}");

--- a/nexus-writer/src/nexus/hdf5_file/run_file.rs
+++ b/nexus-writer/src/nexus/hdf5_file/run_file.rs
@@ -316,7 +316,24 @@ impl RunFile {
     pub(crate) fn push_message_to_runfile(
         &mut self,
         message: &FrameAssembledEventListMessage,
+        nexus_settings: &NexusSettings,
     ) -> anyhow::Result<()> {
+        if !message.complete() {
+            let time_zero = self
+                .contents
+                .lists
+                .get_time_zero(message)?;
+
+            self.contents.logs.push_incomplete_frame_log(
+                time_zero,
+                message
+                    .digitizers_present()
+                    .unwrap_or_default()
+                    .iter()
+                    .collect(),
+                nexus_settings,
+            )?;
+        }
         self.contents.lists.push_message_to_event_runfile(message)
     }
 

--- a/nexus-writer/src/nexus/hdf5_file/run_file.rs
+++ b/nexus-writer/src/nexus/hdf5_file/run_file.rs
@@ -318,11 +318,10 @@ impl RunFile {
         message: &FrameAssembledEventListMessage,
         nexus_settings: &NexusSettings,
     ) -> anyhow::Result<()> {
+        self.contents.lists.push_message_to_event_runfile(message)?;
+
         if !message.complete() {
-            let time_zero = self
-                .contents
-                .lists
-                .get_time_zero(message)?;
+            let time_zero = self.contents.lists.get_time_zero(message)?;
 
             self.contents.logs.push_incomplete_frame_log(
                 time_zero,
@@ -334,7 +333,7 @@ impl RunFile {
                 nexus_settings,
             )?;
         }
-        self.contents.lists.push_message_to_event_runfile(message)
+        Ok(())
     }
 
     fn try_read_scalar<T: H5Type>(dataset: &Dataset) -> anyhow::Result<T> {

--- a/nexus-writer/src/nexus/hdf5_file/run_file_components/event_run_file.rs
+++ b/nexus-writer/src/nexus/hdf5_file/run_file_components/event_run_file.rs
@@ -229,9 +229,10 @@ impl EventRun {
         Ok(())
     }
 
-    pub(crate) fn get_time_zero(&self, 
-        message: &FrameAssembledEventListMessage,) -> anyhow::Result<u64> {
-        
+    pub(crate) fn get_time_zero(
+        &self,
+        message: &FrameAssembledEventListMessage,
+    ) -> anyhow::Result<u64> {
         let timestamp: DateTime<Utc> = (*message
             .metadata()
             .timestamp()

--- a/nexus-writer/src/nexus/hdf5_file/run_file_components/runlog_file.rs
+++ b/nexus-writer/src/nexus/hdf5_file/run_file_components/runlog_file.rs
@@ -8,8 +8,10 @@ use crate::nexus::{
 };
 use hdf5::{
     types::{IntSize, TypeDescriptor},
-    Group, SimpleExtents,
+    Group, H5Type, SimpleExtents,
 };
+use ndarray::s;
+use supermusr_common::DigitizerId;
 use supermusr_streaming_types::ecs_f144_logdata_generated::f144_LogData;
 use tracing::debug;
 
@@ -97,6 +99,53 @@ impl RunLog {
 
         set_slice_to(&timestamps, &[stop_time])?;
         set_slice_to(&values, &[0])?; // This is a default value, I'm not sure if this field is needed
+
+        Ok(())
+    }
+
+    pub(crate) fn push_incomplete_frame_log(
+        &mut self,
+        event_time_zero: u64,
+        digitisers_present: Vec<DigitizerId>,
+        nexus_settings: &NexusSettings,
+    ) -> anyhow::Result<()> {
+        const LOGNAME: &str = "incomplete_frame_digitisers_present";
+        let timeseries = self.parent.group(LOGNAME).or_else(|err| {
+            debug!("Cannot find {LOGNAME}. Creating new group.");
+
+            let group =
+                add_new_group_to(&self.parent, LOGNAME, NX::LOG).map_err(|e| e.context(err))?;
+
+            let _time = create_resizable_dataset::<i32>(
+                &group,
+                "time",
+                0,
+                nexus_settings.runloglist_chunk_size,
+            )?;
+            get_dataset_builder(&hdf5::types::VarLenUnicode::type_descriptor(), &group)?
+                .shape(SimpleExtents::resizable(vec![0]))
+                .chunk(nexus_settings.runloglist_chunk_size)
+                .create("value")?;
+            Ok::<_, anyhow::Error>(group)
+        })?;
+        let timestamps = timeseries.dataset("time")?;
+        let values = timeseries.dataset("value")?;
+
+        let next_message_slice = s![timestamps.size()..(timestamps.size() + 1)];
+
+        timestamps.resize(timestamps.size() + 1)?;
+        timestamps.write_slice(&[event_time_zero], next_message_slice)?;
+
+        values.resize(values.size() + 1)?;
+        values.write_slice(
+            &[digitisers_present
+                .iter()
+                .map(DigitizerId::to_string)
+                .collect::<Vec<_>>()
+                .join(",")
+                .parse::<hdf5::types::VarLenUnicode>()?],
+            next_message_slice,
+        )?;
 
         Ok(())
     }

--- a/nexus-writer/src/nexus/run.rs
+++ b/nexus-writer/src/nexus/run.rs
@@ -130,10 +130,11 @@ impl Run {
         &mut self,
         local_path: Option<&Path>,
         message: &FrameAssembledEventListMessage,
+        nexus_settings: &NexusSettings,
     ) -> anyhow::Result<()> {
         if let Some(local_path) = local_path {
             let mut hdf5 = RunFile::open_runfile(local_path, &self.parameters.run_name)?;
-            hdf5.push_message_to_runfile(message)?;
+            hdf5.push_message_to_runfile(message, nexus_settings)?;
             hdf5.close()?;
         }
 


### PR DESCRIPTION
## Summary of changes

Writes the `complete` flag of each frame into the nexus file, as well as recording the digitisers present as a run log, in the case of `complete == false`.

Also modified the type of the time field in the runlogs: `i32` changed to `u64` as `i32` does not have the range for recording `ns` precision.

## Instruction for review/testing

General code review.
Has been tested with simulated data.

Please excuse the use of `anyhow`, will be changed later.
