### PR TITLE
Allow simulator action to rewind the timestamp

### DIFF
--- a/simulator/src/integrated/simulation.rs
+++ b/simulator/src/integrated/simulation.rs
@@ -193,11 +193,14 @@ mod tests {
         ],
         "schedule": [
             { "send-run-start": { "name": { "text": "MyRun" }, "instrument": { "text": "MuSR" } } },
+            { "set-timestamp": "now" },
             { "wait-ms": 100 },
             { "frame-loop": {
                     "start": { "int": 0 },
                     "end": { "int": 99 },
                     "schedule": [
+                        { "set-timestamp": { "advance-by-ms" : 5} },
+                        { "set-timestamp": { "rewind-by-ms" : 5} }
                     ]
                 }
             }

--- a/simulator/src/integrated/simulation_engine/actions.rs
+++ b/simulator/src/integrated/simulation_engine/actions.rs
@@ -61,7 +61,7 @@ pub(crate) struct Loop<A> {
 pub(crate) enum Timestamp {
     Now,
     AdvanceByMs(usize),
-    RewindByMs(usize)
+    RewindByMs(usize),
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/simulator/src/integrated/simulation_engine/actions.rs
+++ b/simulator/src/integrated/simulation_engine/actions.rs
@@ -61,6 +61,7 @@ pub(crate) struct Loop<A> {
 pub(crate) enum Timestamp {
     Now,
     AdvanceByMs(usize),
+    RewindByMs(usize)
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/simulator/src/integrated/simulation_engine/engine.rs
+++ b/simulator/src/integrated/simulation_engine/engine.rs
@@ -85,6 +85,8 @@ pub(crate) enum SimulationEngineError {
     IntFloat(#[from] JsonIntError),
     #[error("checked_add_signed failed: {0}")]
     TimestampAdd(usize),
+    #[error("checked_sub_signed failed: {0}")]
+    TimestampSub(usize),
 }
 
 pub(crate) struct SimulationEngine<'a> {
@@ -128,6 +130,14 @@ fn set_timestamp(
                 .timestamp
                 .checked_add_signed(TimeDelta::milliseconds(*ms as i64))
                 .ok_or(SimulationEngineError::TimestampAdd(*ms))?
+        },
+        Timestamp::RewindByMs(ms) => {
+            engine.state.metadata.timestamp = engine
+                .state
+                .metadata
+                .timestamp
+                .checked_sub_signed(TimeDelta::milliseconds(*ms as i64))
+                .ok_or(SimulationEngineError::TimestampSub(*ms))?
         }
     }
     Ok(())

--- a/simulator/src/integrated/simulation_engine/engine.rs
+++ b/simulator/src/integrated/simulation_engine/engine.rs
@@ -130,7 +130,7 @@ fn set_timestamp(
                 .timestamp
                 .checked_add_signed(TimeDelta::milliseconds(*ms as i64))
                 .ok_or(SimulationEngineError::TimestampAdd(*ms))?
-        },
+        }
         Timestamp::RewindByMs(ms) => {
             engine.state.metadata.timestamp = engine
                 .state


### PR DESCRIPTION
## Summary of changes

Added action to the simulator to allow the frame timestamp to be rewound as well as advanced. This allows for more testing options.

## Instruction for review/testing

General code review.
Has been tested with simulated data.