### PR TITLE
Prevent out of order frames

### DIFF
--- a/digitiser-aggregator/Cargo.toml
+++ b/digitiser-aggregator/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+chrono.workspace = true
 clap.workspace = true
 metrics.workspace = true
 metrics-exporter-prometheus.workspace = true


### PR DESCRIPTION
## Summary of changes

In the aggregator: prevents new frames from being created whose timestamp is earlier than or equal to any that have previously been dispatched. That is, if a digitiser messages arrives late, then if it's frame is still in the cache, it is aggregated into that frame, otherwise it is discarded and a warning emitted.

Closes https://github.com/STFC-ICD-Research-and-Design/supermusr-data-pipeline/issues/288.

Note that we still assume that each frame's initial digitiser message appears in chronological order.

## Instruction for review/testing

General code review.
Has been tested on simulated data.