### PR TITLE
Upgrade Rust version to 1.84

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1.0.134" }
 supermusr-common = { path = "./common" }
 supermusr-streaming-types = { path = "./streaming-types" }
-taos = { version = "0.10.27", default_features = false, features = ["ws"] }
+taos = { version = "0.10.27", default-features = false, features = ["ws"] }
 tokio = { version = "1.42", features = ["macros", "rt-multi-thread", "signal", "sync"] }
 thiserror = "1.0.69"
 tracing = "0.1.41"

--- a/common/src/tracer/otel_tracer.rs
+++ b/common/src/tracer/otel_tracer.rs
@@ -26,11 +26,13 @@ where
     for<'span> S: LookupSpan<'span>,
 {
     /// Initialises an OpenTelemetry service for the crate
-    /// #Arguments
+    ///
+    /// ## Arguments
     /// * `options` - The caller-specified options for the service
     /// * `service_name` - The name of the OpenTelemetry service to assign to the crate.
     /// * `module_name` - The name of the current module.
-    /// #Returns
+    ///
+    /// ## Returns
     /// If the tracer is set up correctly, an instance of OtelTracer containing the
     /// `tracing_opentelemetry` layer which can be added to the subscriber.
     /// If the operation fails, a TracerError is returned.

--- a/common/src/tracer/propagator.rs
+++ b/common/src/tracer/propagator.rs
@@ -8,7 +8,7 @@ use tracing_opentelemetry::OpenTelemetrySpanExt;
 
 struct HeaderInjector<'a>(pub &'a mut OwnedHeaders);
 
-impl<'a> Injector for HeaderInjector<'a> {
+impl Injector for HeaderInjector<'_> {
     fn set(&mut self, key: &str, value: String) {
         let mut new = OwnedHeaders::new().insert(rdkafka::message::Header {
             key,
@@ -29,7 +29,7 @@ impl<'a> Injector for HeaderInjector<'a> {
 
 struct HeaderExtractor<'a>(pub &'a BorrowedHeaders);
 
-impl<'a> Extractor for HeaderExtractor<'a> {
+impl Extractor for HeaderExtractor<'_> {
     fn get(&self, key: &str) -> Option<&str> {
         for i in 0..self.0.count() {
             if let Ok(val) = self.0.get_as::<str>(i) {

--- a/common/src/tracer/tracer_engine.rs
+++ b/common/src/tracer/tracer_engine.rs
@@ -30,11 +30,13 @@ pub struct TracerEngine {
 
 impl TracerEngine {
     /// Initialises the stdout tracer, and (if required) the OpenTelemetry service for the crate
-    /// #Arguments
+    ///
+    /// ## Arguments
     /// * `options` - The caller-specified instance of TracerOptions.
     /// * `service_name` - The name of the OpenTelemetry service to assign to the crate.
     /// * `module_name` - The name of the current module.
-    /// #Returns
+    ///
+    /// ## Returns
     /// An instance of TracerEngine
     pub fn new(options: TracerOptions, service_name: &str, module_name: &str) -> Self {
         let use_otel = options.otel_options.is_some();

--- a/flake.nix
+++ b/flake.nix
@@ -27,9 +27,9 @@
         };
 
         toolchain = fenix.packages.${system}.toolchainOf {
-          channel = "1.75";
-          date = "2023-12-28";
-          sha256 = "SXRtAuO4IqNOQq+nLbrsDFbVk+3aVA8NNpSZsKlVH/8=";
+          channel = "1.84";
+          date = "2025-01-09";
+          sha256 = "lMLAupxng4Fd9F1oDw8gx+qA0RuF7ou7xhNU8wgs0PU=";
         };
 
         naersk' = pkgs.callPackage naersk {

--- a/simulator/src/integrated/simulation_engine/actions.rs
+++ b/simulator/src/integrated/simulation_engine/actions.rs
@@ -80,7 +80,7 @@ pub(crate) struct TracingEvent {
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub(crate) enum Action {
-    Comment(String),
+    Comment(#[allow(unused)] String),
     TracingEvent(TracingEvent),
     WaitMs(usize),
     EnsureDelayMs(usize),
@@ -105,7 +105,7 @@ pub(crate) enum Action {
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub(crate) enum FrameAction {
-    Comment(String),
+    Comment(#[allow(unused)] String),
     WaitMs(usize),
     EnsureDelayMs(usize),
     TracingEvent(TracingEvent),
@@ -123,7 +123,7 @@ pub(crate) enum FrameAction {
 #[derive(Clone, Debug, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub(crate) enum DigitiserAction {
-    Comment(String),
+    Comment(#[allow(unused)] String),
     WaitMs(usize),
     EnsureDelayMs(usize),
     TracingEvent(TracingEvent),

--- a/trace-archiver-tdengine/src/tdengine/error.rs
+++ b/trace-archiver-tdengine/src/tdengine/error.rs
@@ -23,6 +23,7 @@ pub(crate) enum TraceMessageErrorCode {
 }
 
 #[derive(Debug)]
+#[allow(unused)]
 pub(crate) enum TDEngineError {
     TaosBuilder(RawError),
     TaosStmt(StatementErrorCode, RawError),

--- a/trace-archiver-tdengine/src/tdengine/wrapper.rs
+++ b/trace-archiver-tdengine/src/tdengine/wrapper.rs
@@ -57,7 +57,7 @@ impl TDEngine {
 
     pub(crate) async fn create_database(&self) -> Result<(), TDEngineError> {
         self.client
-            .exec(&format!(
+            .exec(format!(
                 "CREATE DATABASE IF NOT EXISTS {} PRECISION 'ns'",
                 self.database
             ))

--- a/trace-reader/src/loader.rs
+++ b/trace-reader/src/loader.rs
@@ -4,7 +4,6 @@ use std::{
     io::{Error, ErrorKind, Read, Seek, SeekFrom},
     mem::size_of,
     path::PathBuf,
-    usize,
 };
 
 #[derive(Default, Debug)]

--- a/trace-reader/src/processing.rs
+++ b/trace-reader/src/processing.rs
@@ -70,6 +70,7 @@ pub(crate) fn create_channel<'a>(
 /// * `digitizer_id` - The id of the digitizer to use.
 /// * `measurements_per_frame` - The number of measurements to simulate in each channel.
 /// * `num_channels` - The number of channels to simulate.
+///
 /// #Returns
 /// A string result, or an error.
 pub(crate) fn create_message(

--- a/trace-to-events/src/pulse_detection/datatype/eventpoint.rs
+++ b/trace-to-events/src/pulse_detection/datatype/eventpoint.rs
@@ -7,8 +7,6 @@ pub(crate) trait EventPoint: Debug + Clone {
 
     fn get_time(&self) -> Self::TimeType;
     fn get_data(&self) -> &Self::EventType;
-    fn get_data_mut(&mut self) -> &mut Self::EventType;
-    fn take_data(self) -> Self::EventType;
 }
 
 impl<T, E> EventPoint for (T, E)
@@ -25,13 +23,5 @@ where
 
     fn get_data(&self) -> &E {
         &self.1
-    }
-
-    fn get_data_mut(&mut self) -> &mut E {
-        &mut self.1
-    }
-
-    fn take_data(self) -> E {
-        self.1
     }
 }

--- a/trace-to-events/src/pulse_detection/datatype/tracepoint.rs
+++ b/trace-to-events/src/pulse_detection/datatype/tracepoint.rs
@@ -6,21 +6,21 @@ use super::{eventdata::Empty, EventData, Temporal, TraceValue};
 pub(crate) trait TracePoint: Clone {
     /// The type which represents the time of the data point.
     /// This should be trivially copyable (usually a scalar).
-    type TimeType: Temporal;
+    type Time: Temporal;
 
     /// The type which contains the value of the data point.
-    type ValueType: TraceValue;
+    type Value: TraceValue;
 
-    type DataType: EventData;
+    type Data: EventData;
 
     /// Returns the time of the data point.
-    fn get_time(&self) -> Self::TimeType;
+    fn get_time(&self) -> Self::Time;
 
     /// Returns an immutable reference to the value of the data point.
-    fn get_value(&self) -> &Self::ValueType;
+    fn get_value(&self) -> &Self::Value;
 
     /// Take ownership of a clone of the value without destructing the data point.
-    fn clone_value(&self) -> Self::ValueType {
+    fn clone_value(&self) -> Self::Value {
         self.get_value().clone()
     }
 }
@@ -35,19 +35,19 @@ where
     X: Temporal,
     Y: TraceValue,
 {
-    type TimeType = X;
-    type ValueType = Y;
-    type DataType = Empty;
+    type Time = X;
+    type Value = Y;
+    type Data = Empty;
 
-    fn get_time(&self) -> Self::TimeType {
+    fn get_time(&self) -> Self::Time {
         self.0
     }
 
-    fn get_value(&self) -> &Self::ValueType {
+    fn get_value(&self) -> &Self::Value {
         &self.1
     }
 
-    fn clone_value(&self) -> Self::ValueType {
+    fn clone_value(&self) -> Self::Value {
         self.get_value().clone()
     }
 }

--- a/trace-to-events/src/pulse_detection/datatype/tracepoint.rs
+++ b/trace-to-events/src/pulse_detection/datatype/tracepoint.rs
@@ -3,24 +3,23 @@ use super::{eventdata::Empty, EventData, Temporal, TraceValue};
 /// An abstraction of the types that are processed by the various filters
 /// To implement TracePoint a type must contain time data, a value,
 /// and a parameter (which is used for applying feedback).
-/// *Associated Types
-/// - TimeType: the type which represents the time of the data point.
-/// This should be trivially copyable (usually a scalar).
-/// - ValueType: the type which contains the value of the data point.
-/// * Methods
-/// - get_time(): returns the time of the data point.
-/// - get_value(): returns an immutable reference to the value of the data point.
-/// - take_value(): destructs the data point and gives the caller ownership of the value.
-/// - clone_value(): allows the user to take ownership of a clone of the value without
-/// destructing the data point.
 pub(crate) trait TracePoint: Clone {
+    /// The type which represents the time of the data point.
+    /// This should be trivially copyable (usually a scalar).
     type TimeType: Temporal;
+
+    /// The type which contains the value of the data point.
     type ValueType: TraceValue;
+
     type DataType: EventData;
 
+    /// Returns the time of the data point.
     fn get_time(&self) -> Self::TimeType;
+
+    /// Returns an immutable reference to the value of the data point.
     fn get_value(&self) -> &Self::ValueType;
 
+    /// Take ownership of a clone of the value without destructing the data point.
     fn clone_value(&self) -> Self::ValueType {
         self.get_value().clone()
     }

--- a/trace-to-events/src/pulse_detection/datatype/tracepoint.rs
+++ b/trace-to-events/src/pulse_detection/datatype/tracepoint.rs
@@ -20,7 +20,6 @@ pub(crate) trait TracePoint: Clone {
 
     fn get_time(&self) -> Self::TimeType;
     fn get_value(&self) -> &Self::ValueType;
-    fn take_value(self) -> Self::ValueType;
 
     fn clone_value(&self) -> Self::ValueType {
         self.get_value().clone()
@@ -47,10 +46,6 @@ where
 
     fn get_value(&self) -> &Self::ValueType {
         &self.1
-    }
-
-    fn take_value(self) -> Self::ValueType {
-        self.1
     }
 
     fn clone_value(&self) -> Self::ValueType {

--- a/trace-to-events/src/pulse_detection/datatype/tracevalue.rs
+++ b/trace-to-events/src/pulse_detection/datatype/tracevalue.rs
@@ -16,21 +16,10 @@ use std::{
 /// - take_value(): destructs the data point and gives the caller ownership of the value.
 pub(crate) trait TraceValue: Default + Clone + Debug + Display {
     type ContentType: Default + Clone + Debug + Display;
-
-    fn get_value(&self) -> &Self::ContentType;
-    fn take_value(self) -> Self::ContentType;
 }
 
 impl TraceValue for Real {
     type ContentType = Real;
-
-    fn get_value(&self) -> &Self::ContentType {
-        self
-    }
-
-    fn take_value(self) -> Self::ContentType {
-        self
-    }
 }
 
 /// This type allows the use of static arrays of TraceValue types as TraceValues
@@ -93,14 +82,6 @@ where
 
 impl<const N: usize, T: TraceValue + Copy> TraceValue for TraceArray<N, T> {
     type ContentType = TraceArray<N, T>;
-
-    fn get_value(&self) -> &Self::ContentType {
-        self
-    }
-
-    fn take_value(self) -> Self::ContentType {
-        self
-    }
 }
 
 /// In practice arrays of Real types are mostly used.
@@ -132,12 +113,4 @@ impl Display for Stats {
 
 impl TraceValue for Stats {
     type ContentType = Stats;
-
-    fn get_value(&self) -> &Self::ContentType {
-        self
-    }
-
-    fn take_value(self) -> Self::ContentType {
-        self
-    }
 }

--- a/trace-to-events/src/pulse_detection/detectors/mod.rs
+++ b/trace-to-events/src/pulse_detection/detectors/mod.rs
@@ -5,12 +5,12 @@ use super::{pulse::TimeValue, EventData, EventPoint, Pulse, Real, RealArray, Tra
 
 pub(crate) trait Detector: Default + Clone {
     type TracePointType: TracePoint;
-    type EventPointType: EventPoint<TimeType = <Self::TracePointType as TracePoint>::TimeType>;
+    type EventPointType: EventPoint<TimeType = <Self::TracePointType as TracePoint>::Time>;
 
     fn signal(
         &mut self,
-        time: <Self::TracePointType as TracePoint>::TimeType,
-        value: <Self::TracePointType as TracePoint>::ValueType,
+        time: <Self::TracePointType as TracePoint>::Time,
+        value: <Self::TracePointType as TracePoint>::Value,
     ) -> Option<Self::EventPointType>;
 
     fn finish(&mut self) -> Option<Self::EventPointType>;

--- a/trace-to-events/src/pulse_detection/detectors/mod.rs
+++ b/trace-to-events/src/pulse_detection/detectors/mod.rs
@@ -1,10 +1,7 @@
 pub mod advanced_muon_detector;
 pub mod threshold_detector;
 
-use super::{
-    pulse::{TimeValue, TimeValueOptional},
-    EventData, EventPoint, Pulse, Real, RealArray, TracePoint,
-};
+use super::{pulse::TimeValue, EventData, EventPoint, Pulse, Real, RealArray, TracePoint};
 
 pub(crate) trait Detector: Default + Clone {
     type TracePointType: TracePoint;

--- a/trace-to-events/src/pulse_detection/detectors/threshold_detector.rs
+++ b/trace-to-events/src/pulse_detection/detectors/threshold_detector.rs
@@ -1,4 +1,4 @@
-use super::{Assembler, Detector, EventData, Pulse, Real, TimeValueOptional};
+use super::{Detector, EventData, Real};
 use std::fmt::Display;
 
 #[derive(Default, Debug, Clone, PartialEq)]
@@ -114,27 +114,6 @@ impl Detector for ThresholdDetector {
                     pulse_height: self.max_pulse_height,
                 },
             )
-        })
-    }
-}
-
-#[derive(Default, Clone)]
-pub(crate) struct ThresholdAssembler {}
-
-impl Assembler for ThresholdAssembler {
-    type DetectorType = ThresholdDetector;
-
-    fn assemble_pulses(
-        &mut self,
-        source: <Self::DetectorType as Detector>::EventPointType,
-    ) -> Option<Pulse> {
-        let (time, Data { pulse_height }) = source;
-        Some(Pulse {
-            start: TimeValueOptional {
-                time: Some(time),
-                value: Some(pulse_height),
-            },
-            ..Default::default()
         })
     }
 }

--- a/trace-to-events/src/pulse_detection/window/mod.rs
+++ b/trace-to-events/src/pulse_detection/window/mod.rs
@@ -51,10 +51,7 @@ impl<I, W> Iterator for WindowIter<I, W>
 where
     I: Iterator,
     I::Item: TracePoint,
-    W: Window<
-        TimeType = <I::Item as TracePoint>::TimeType,
-        InputType = <I::Item as TracePoint>::ValueType,
-    >,
+    W: Window<TimeType = <I::Item as TracePoint>::Time, InputType = <I::Item as TracePoint>::Value>,
 {
     type Item = (W::TimeType, W::OutputType);
 


### PR DESCRIPTION
## Summary of changes

Moves to Rust 1.84.
Something higher than 1.80 was required to move to the maintained fork of `hdf5`.

This also addresses a few new warnings generated.

## Instruction for review/testing

- basic test with simulated data
- review modified code