### PR TITLE
Remove use of async_trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3476,7 +3476,6 @@ name = "trace-archiver-tdengine"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "async-trait",
  "chrono",
  "clap",
  "itertools 0.13.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ edition = "2021"
 [workspace.dependencies]
 anyhow = "1.0"
 assert_approx_eq = "1.1.0"
-async-trait = "0.1.83"
 chrono = { version = "0.4.39", features = ["serde"] }
 clap = { version = "4.5", features = ["derive", "env"] }
 crossterm = "0.26.1"

--- a/trace-archiver-tdengine/Cargo.toml
+++ b/trace-archiver-tdengine/Cargo.toml
@@ -6,7 +6,6 @@ edition.workspace = true
 
 [dependencies]
 anyhow.workspace = true
-async-trait.workspace = true
 chrono.workspace = true
 clap.workspace = true
 itertools.workspace = true

--- a/trace-archiver-tdengine/src/tdengine/mod.rs
+++ b/trace-archiver-tdengine/src/tdengine/mod.rs
@@ -4,11 +4,9 @@ pub mod framedata;
 mod views;
 pub mod wrapper;
 
-use async_trait::async_trait;
 use error::{StatementErrorCode, TDEngineError, TraceMessageErrorCode};
 use supermusr_streaming_types::dat2_digitizer_analog_trace_v2_generated::DigitizerAnalogTraceMessage;
 
-#[async_trait]
 pub(crate) trait TimeSeriesEngine {
     async fn process_message(&mut self, msg: &DigitizerAnalogTraceMessage) -> anyhow::Result<()>;
     async fn post_message(&mut self) -> anyhow::Result<usize>;

--- a/trace-archiver-tdengine/src/tdengine/wrapper.rs
+++ b/trace-archiver-tdengine/src/tdengine/wrapper.rs
@@ -4,7 +4,6 @@ use super::{
     views::{create_column_views, create_frame_column_views},
     StatementErrorCode, TDEngineError, TimeSeriesEngine, TraceMessageErrorCode,
 };
-use async_trait::async_trait;
 use supermusr_streaming_types::dat2_digitizer_analog_trace_v2_generated::DigitizerAnalogTraceMessage;
 use taos::{AsyncBindable, AsyncQueryable, AsyncTBuilder, Stmt, Taos, TaosBuilder, Value};
 use tracing::debug;
@@ -130,7 +129,6 @@ impl TDEngine {
     }
 }
 
-#[async_trait]
 impl TimeSeriesEngine for TDEngine {
     /// Takes a reference to a ``DigitizerAnalogTraceMessage`` instance and extracts the relevant data from it.
     /// The user should then call ``post_message`` to send the data to the tdengine server.
@@ -141,7 +139,7 @@ impl TimeSeriesEngine for TDEngine {
     /// An emtpy result or an error arrising a malformed ``DigitizerAnalogTraceMessage`` parameter.
     async fn process_message(
         &mut self,
-        message: &DigitizerAnalogTraceMessage,
+        message: &DigitizerAnalogTraceMessage<'_>,
     ) -> anyhow::Result<()> {
         // Obtain the channel data, and error check
         self.error.test_metadata(message);


### PR DESCRIPTION
## Summary of changes

`async_trait` is no longer required for our direct use cases.

## Instruction for review/testing

- Code review
