### PR TITLE
Add discarded flag to digitiser aggregator spans

### DIFF
--- a/digitiser-aggregator/src/frame/cache.rs
+++ b/digitiser-aggregator/src/frame/cache.rs
@@ -33,11 +33,11 @@ where
         digitiser_id: DigitizerId,
         metadata: &FrameMetadata,
         data: D,
-    ) -> bool {
+    ) -> Result<(), ()> {
         if let Some(latest_timestamp_dispatched) = self.latest_timestamp_dispatched {
             if metadata.timestamp <= latest_timestamp_dispatched {
                 warn!("Frame's timestamp earlier than or equal to the latest frame dispatched: {0} <= {1}", metadata.timestamp, latest_timestamp_dispatched);
-                return false;
+                return Err(());
             }
         }
         let frame = {
@@ -86,7 +86,7 @@ where
             warn!("Frame span linking failed {e}")
         }
 
-        true
+        Ok(())
     }
 
     pub(crate) fn poll(&mut self) -> Option<AggregatedFrame<D>> {

--- a/digitiser-aggregator/src/frame/cache.rs
+++ b/digitiser-aggregator/src/frame/cache.rs
@@ -139,20 +139,28 @@ mod test {
         assert!(cache.poll().is_none());
 
         assert_eq!(cache.get_num_partial_frames(), 0);
-        assert!(cache.push(0, &frame_1, EventData::dummy_data(0, 5, &[0, 1, 2])).is_ok());
+        assert!(cache
+            .push(0, &frame_1, EventData::dummy_data(0, 5, &[0, 1, 2]))
+            .is_ok());
         assert_eq!(cache.get_num_partial_frames(), 1);
 
         assert!(cache.poll().is_none());
 
-        assert!(cache.push(1, &frame_1, EventData::dummy_data(0, 5, &[3, 4, 5])).is_ok());
+        assert!(cache
+            .push(1, &frame_1, EventData::dummy_data(0, 5, &[3, 4, 5]))
+            .is_ok());
 
         assert!(cache.poll().is_none());
 
-        assert!(cache.push(4, &frame_1, EventData::dummy_data(0, 5, &[6, 7, 8])).is_ok());
+        assert!(cache
+            .push(4, &frame_1, EventData::dummy_data(0, 5, &[6, 7, 8]))
+            .is_ok());
 
         assert!(cache.poll().is_none());
 
-        assert!(cache.push(8, &frame_1, EventData::dummy_data(0, 5, &[9, 10, 11])).is_ok());
+        assert!(cache
+            .push(8, &frame_1, EventData::dummy_data(0, 5, &[9, 10, 11]))
+            .is_ok());
 
         {
             let frame = cache.poll().unwrap();
@@ -200,15 +208,21 @@ mod test {
 
         assert!(cache.poll().is_none());
 
-        assert!(cache.push(0, &frame_1, EventData::dummy_data(0, 5, &[0, 1, 2])).is_ok());
+        assert!(cache
+            .push(0, &frame_1, EventData::dummy_data(0, 5, &[0, 1, 2]))
+            .is_ok());
 
         assert!(cache.poll().is_none());
 
-        assert!(cache.push(1, &frame_1, EventData::dummy_data(0, 5, &[3, 4, 5])).is_ok());
+        assert!(cache
+            .push(1, &frame_1, EventData::dummy_data(0, 5, &[3, 4, 5]))
+            .is_ok());
 
         assert!(cache.poll().is_none());
 
-        assert!(cache.push(8, &frame_1, EventData::dummy_data(0, 5, &[9, 10, 11])).is_ok());
+        assert!(cache
+            .push(8, &frame_1, EventData::dummy_data(0, 5, &[9, 10, 11]))
+            .is_ok());
 
         assert!(cache.poll().is_none());
 
@@ -254,19 +268,25 @@ mod test {
             frame_number: 1728,
             veto_flags: 4,
         };
-        assert!(cache.push(0, &frame_1, EventData::dummy_data(0, 5, &[0, 1, 2])).is_ok());
-        assert!(cache.push(1, &frame_1, EventData::dummy_data(0, 5, &[3, 4, 5])).is_ok());
-        assert!(cache.push(8, &frame_1, EventData::dummy_data(0, 5, &[9, 10, 11])).is_ok());
+        assert!(cache
+            .push(0, &frame_1, EventData::dummy_data(0, 5, &[0, 1, 2]))
+            .is_ok());
+        assert!(cache
+            .push(1, &frame_1, EventData::dummy_data(0, 5, &[3, 4, 5]))
+            .is_ok());
+        assert!(cache
+            .push(8, &frame_1, EventData::dummy_data(0, 5, &[9, 10, 11]))
+            .is_ok());
 
         tokio::time::sleep(Duration::from_millis(105)).await;
 
         let _ = cache.poll().unwrap();
-        
+
         //  This call to push should return an error
-        assert!(cache.push(4, &frame_1, EventData::dummy_data(0, 5, &[6, 7, 8])).is_err());
+        assert!(cache
+            .push(4, &frame_1, EventData::dummy_data(0, 5, &[6, 7, 8]))
+            .is_err());
     }
-
-
 
     #[test]
     fn test_metadata_equality() {
@@ -296,11 +316,15 @@ mod test {
         assert_eq!(cache.frames.len(), 0);
         assert!(cache.poll().is_none());
 
-        assert!(cache.push(1, &frame_1, EventData::dummy_data(0, 5, &[0, 1, 2])).is_ok());
+        assert!(cache
+            .push(1, &frame_1, EventData::dummy_data(0, 5, &[0, 1, 2]))
+            .is_ok());
         assert_eq!(cache.frames.len(), 1);
         assert!(cache.poll().is_none());
 
-        assert!(cache.push(2, &frame_2, EventData::dummy_data(0, 5, &[0, 1, 2])).is_ok());
+        assert!(cache
+            .push(2, &frame_2, EventData::dummy_data(0, 5, &[0, 1, 2]))
+            .is_ok());
         assert_eq!(cache.frames.len(), 1);
         assert!(cache.poll().is_some());
     }

--- a/digitiser-aggregator/src/frame/cache.rs
+++ b/digitiser-aggregator/src/frame/cache.rs
@@ -33,11 +33,11 @@ where
         digitiser_id: DigitizerId,
         metadata: &FrameMetadata,
         data: D,
-    ) {
+    ) -> bool {
         if let Some(latest_timestamp_dispatched) = self.latest_timestamp_dispatched {
             if metadata.timestamp <= latest_timestamp_dispatched {
                 warn!("Frame's timestamp earlier than or equal to the latest frame dispatched: {0} <= {1}", metadata.timestamp, latest_timestamp_dispatched);
-                return;
+                return false;
             }
         }
         let frame = {
@@ -85,6 +85,8 @@ where
         }) {
             warn!("Frame span linking failed {e}")
         }
+
+        true
     }
 
     pub(crate) fn poll(&mut self) -> Option<AggregatedFrame<D>> {

--- a/digitiser-aggregator/src/frame/cache.rs
+++ b/digitiser-aggregator/src/frame/cache.rs
@@ -139,20 +139,20 @@ mod test {
         assert!(cache.poll().is_none());
 
         assert_eq!(cache.get_num_partial_frames(), 0);
-        cache.push(0, &frame_1, EventData::dummy_data(0, 5, &[0, 1, 2]));
+        let _ = cache.push(0, &frame_1, EventData::dummy_data(0, 5, &[0, 1, 2]));
         assert_eq!(cache.get_num_partial_frames(), 1);
 
         assert!(cache.poll().is_none());
 
-        cache.push(1, &frame_1, EventData::dummy_data(0, 5, &[3, 4, 5]));
+        let _ = cache.push(1, &frame_1, EventData::dummy_data(0, 5, &[3, 4, 5]));
 
         assert!(cache.poll().is_none());
 
-        cache.push(4, &frame_1, EventData::dummy_data(0, 5, &[6, 7, 8]));
+        let _ = cache.push(4, &frame_1, EventData::dummy_data(0, 5, &[6, 7, 8]));
 
         assert!(cache.poll().is_none());
 
-        cache.push(8, &frame_1, EventData::dummy_data(0, 5, &[9, 10, 11]));
+        let _ = cache.push(8, &frame_1, EventData::dummy_data(0, 5, &[9, 10, 11]));
 
         {
             let frame = cache.poll().unwrap();
@@ -200,15 +200,15 @@ mod test {
 
         assert!(cache.poll().is_none());
 
-        cache.push(0, &frame_1, EventData::dummy_data(0, 5, &[0, 1, 2]));
+        let _ = cache.push(0, &frame_1, EventData::dummy_data(0, 5, &[0, 1, 2]));
 
         assert!(cache.poll().is_none());
 
-        cache.push(1, &frame_1, EventData::dummy_data(0, 5, &[3, 4, 5]));
+        let _ = cache.push(1, &frame_1, EventData::dummy_data(0, 5, &[3, 4, 5]));
 
         assert!(cache.poll().is_none());
 
-        cache.push(8, &frame_1, EventData::dummy_data(0, 5, &[9, 10, 11]));
+        let _ = cache.push(8, &frame_1, EventData::dummy_data(0, 5, &[9, 10, 11]));
 
         assert!(cache.poll().is_none());
 
@@ -270,11 +270,11 @@ mod test {
         assert_eq!(cache.frames.len(), 0);
         assert!(cache.poll().is_none());
 
-        cache.push(1, &frame_1, EventData::dummy_data(0, 5, &[0, 1, 2]));
+        let _ = cache.push(1, &frame_1, EventData::dummy_data(0, 5, &[0, 1, 2]));
         assert_eq!(cache.frames.len(), 1);
         assert!(cache.poll().is_none());
 
-        cache.push(2, &frame_2, EventData::dummy_data(0, 5, &[0, 1, 2]));
+        let _ = cache.push(2, &frame_2, EventData::dummy_data(0, 5, &[0, 1, 2]));
         assert_eq!(cache.frames.len(), 1);
         assert!(cache.poll().is_some());
     }

--- a/digitiser-aggregator/src/main.rs
+++ b/digitiser-aggregator/src/main.rs
@@ -273,7 +273,7 @@ async fn process_digitiser_event_list_message(
             let success = cache.push(msg.digitizer_id(), &metadata, msg.into());
 
             record_metadata_fields_to_span!(&metadata, tracing::Span::current());
-            tracing::Span::current().record("added_to_frame", success);
+            tracing::Span::current().record("is_discarded", !success);
 
             cache_poll(channel_send, cache).await?;
         }

--- a/digitiser-aggregator/src/main.rs
+++ b/digitiser-aggregator/src/main.rs
@@ -270,10 +270,12 @@ async fn process_digitiser_event_list_message(
             debug!("Event packet: metadata: {:?}", msg.metadata());
 
             // Push the current digitiser message to the frame cache, possibly creating a new partial frame
-            let success = cache.push(msg.digitizer_id(), &metadata, msg.into());
+            let is_discarded = cache
+                .push(msg.digitizer_id(), &metadata, msg.into())
+                .is_err();
 
             record_metadata_fields_to_span!(&metadata, tracing::Span::current());
-            tracing::Span::current().record("is_discarded", !success);
+            tracing::Span::current().record("is_discarded", is_discarded);
 
             cache_poll(channel_send, cache).await?;
         }

--- a/digitiser-aggregator/src/main.rs
+++ b/digitiser-aggregator/src/main.rs
@@ -258,7 +258,7 @@ async fn process_kafka_message(
     metadata_protons_per_pulse = tracing::field::Empty,
     metadata_running = tracing::field::Empty,
     num_cached_frames = cache.get_num_partial_frames(),
-    added_to_frame,
+    is_discarded,
 ))]
 async fn process_digitiser_event_list_message(
     channel_send: &AggregatedFrameToBufferSender,


### PR DESCRIPTION
## Summary of changes

Minor code change to allow OpenTelemetry to record when a digitiser message is discarded by the aggregator for being irreparably out of chronological order.

## Instruction for review/testing

General code check.
Has been tested with simulated and HiFi data.
