### PR TITLE
Remove Magic Nix Cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,6 @@ jobs:
               - 'Cargo.lock'
 
       - uses: DeterminateSystems/nix-installer-action@v16
-      - uses: DeterminateSystems/magic-nix-cache-action@v8
 
       # Evaluate the devshell here so that the time reported for subsequent
       # steps that use it reflect what is actually done there.

--- a/.github/workflows/component.yml
+++ b/.github/workflows/component.yml
@@ -38,7 +38,6 @@ jobs:
               - "${{ inputs.component }}/**/*.rs"
 
       - uses: DeterminateSystems/nix-installer-action@v16
-      - uses: DeterminateSystems/magic-nix-cache-action@v8
 
       # Evaluate the devshell here so that the time reported for subsequent
       # steps that use it reflect what is actually done there.


### PR DESCRIPTION
## Summary of changes

See https://determinate.systems/posts/magic-nix-cache-free-tier-eol/.

Removes Nix Magic Cache before it will stop working.

## Instruction for review/testing

- code review
