### PR TITLE
Set open telemetry levels via an environment variable

### DIFF
--- a/common/src/tracer/mod.rs
+++ b/common/src/tracer/mod.rs
@@ -13,7 +13,7 @@ pub use tracer_engine::{TracerEngine, TracerOptions};
 #[macro_export]
 macro_rules! init_tracer {
     ($options:expr) => {{
-        let tracer = TracerEngine::new($options, env!("CARGO_BIN_NAME"), module_path!());
+        let tracer = TracerEngine::new($options, env!("CARGO_BIN_NAME"));
         // This is called here (in the macro) rather than as part of `TracerEngine::new`
         // to ensure the warning is emitted in the correct module.
         if tracer.use_otel() {

--- a/common/src/tracer/otel_tracer.rs
+++ b/common/src/tracer/otel_tracer.rs
@@ -56,12 +56,12 @@ where
 
         let filter = match EnvFilter::builder()
             .with_default_directive(LevelFilter::OFF.into())
-            .with_env_var("OTEL_LOG")
+            .with_env_var("OTEL_LEVEL")
             .from_env()
         {
             Ok(filter) => filter,
             Err(e) => {
-                warn!("Invalid directive(s) in OTEL_LOG: {e}");
+                warn!("Invalid directive(s) in OTEL_LEVEL: {e}");
                 EnvFilter::default()
             }
         };

--- a/common/src/tracer/otel_tracer.rs
+++ b/common/src/tracer/otel_tracer.rs
@@ -4,14 +4,13 @@ use opentelemetry_sdk::trace::Tracer;
 use tracing::{level_filters::LevelFilter, warn};
 use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::{
-    filter::{self, Filtered, Targets},
+    filter::Filtered,
     registry::LookupSpan,
     EnvFilter, Layer,
 };
 
 pub(super) struct OtelOptions<'a> {
     pub(super) endpoint: &'a str,
-    pub(super) level_filter: LevelFilter,
     pub(super) namespace: String,
 }
 
@@ -38,8 +37,7 @@ where
     /// If the operation fails, a TracerError is returned.
     pub(super) fn new(
         options: OtelOptions,
-        service_name: &str,
-        module_name: &str,
+        service_name: &str
     ) -> Result<Self, TraceError> {
         let otlp_exporter = opentelemetry_otlp::new_exporter()
             .tonic()

--- a/common/src/tracer/otel_tracer.rs
+++ b/common/src/tracer/otel_tracer.rs
@@ -3,11 +3,7 @@ use opentelemetry_otlp::WithExportConfig;
 use opentelemetry_sdk::trace::Tracer;
 use tracing::{level_filters::LevelFilter, warn};
 use tracing_opentelemetry::OpenTelemetryLayer;
-use tracing_subscriber::{
-    filter::Filtered,
-    registry::LookupSpan,
-    EnvFilter, Layer,
-};
+use tracing_subscriber::{filter::Filtered, registry::LookupSpan, EnvFilter, Layer};
 
 pub(super) struct OtelOptions<'a> {
     pub(super) endpoint: &'a str,
@@ -35,10 +31,7 @@ where
     /// If the tracer is set up correctly, an instance of OtelTracer containing the
     /// `tracing_opentelemetry` layer which can be added to the subscriber.
     /// If the operation fails, a TracerError is returned.
-    pub(super) fn new(
-        options: OtelOptions,
-        service_name: &str
-    ) -> Result<Self, TraceError> {
+    pub(super) fn new(options: OtelOptions, service_name: &str) -> Result<Self, TraceError> {
         let otlp_exporter = opentelemetry_otlp::new_exporter()
             .tonic()
             .with_endpoint(options.endpoint);

--- a/common/src/tracer/otel_tracer.rs
+++ b/common/src/tracer/otel_tracer.rs
@@ -4,7 +4,9 @@ use opentelemetry_sdk::trace::Tracer;
 use tracing::{level_filters::LevelFilter, warn};
 use tracing_opentelemetry::OpenTelemetryLayer;
 use tracing_subscriber::{
-    filter::{self, Filtered, Targets}, registry::LookupSpan, EnvFilter, Layer
+    filter::{self, Filtered, Targets},
+    registry::LookupSpan,
+    EnvFilter, Layer,
 };
 
 pub(super) struct OtelOptions<'a> {
@@ -64,7 +66,8 @@ where
         let filter = match EnvFilter::builder()
             .with_default_directive(LevelFilter::OFF.into())
             .with_env_var("OTEL_LOG")
-            .from_env() {
+            .from_env()
+        {
             Ok(filter) => filter,
             Err(e) => {
                 warn!("Invalid directive(s) in OTEL_LOG: {e}");

--- a/common/src/tracer/otel_tracer.rs
+++ b/common/src/tracer/otel_tracer.rs
@@ -71,12 +71,6 @@ where
                 EnvFilter::default()
             }
         };
-        /*
-                filter::Targets::new()
-                    .with_default(LevelFilter::OFF)
-                    .with_target(module_name, options.level_filter)
-                    .with_target("otel", options.level_filter); */
-
         let layer = tracing_opentelemetry::layer()
             .with_tracer(tracer)
             .with_filter(filter);

--- a/common/src/tracer/tracer_engine.rs
+++ b/common/src/tracer/tracer_engine.rs
@@ -45,12 +45,12 @@ impl TracerEngine {
         // if options.otel_options is provided then attempt to setup OtelTracer
         let (otel_tracer, otel_setup_error) = options
             .otel_options
-            .map(|otel_options| {
-                match OtelTracer::<_>::new(otel_options, service_name) {
+            .map(
+                |otel_options| match OtelTracer::<_>::new(otel_options, service_name) {
                     Ok(otel_tracer) => (Some(otel_tracer), None),
                     Err(e) => (None, Some(e)),
-                }
-            })
+                },
+            )
             .unwrap_or((None, None));
         // If otel_tracer did not work, update the use_otel variable
         let use_otel = use_otel && otel_tracer.is_some();

--- a/common/src/tracer/tracer_engine.rs
+++ b/common/src/tracer/tracer_engine.rs
@@ -1,6 +1,6 @@
 use super::otel_tracer::{OtelOptions, OtelTracer};
 use opentelemetry::{global::Error, trace::TraceError};
-use tracing::{level_filters::LevelFilter, Span};
+use tracing::Span;
 use tracing_opentelemetry::OpenTelemetrySpanExt;
 use tracing_subscriber::{layer::SubscriberExt, EnvFilter, Layer};
 
@@ -9,11 +9,10 @@ pub struct TracerOptions<'a> {
 }
 
 impl<'a> TracerOptions<'a> {
-    pub fn new(endpoint: Option<&'a str>, level_filter: LevelFilter, namespace: String) -> Self {
+    pub fn new(endpoint: Option<&'a str>, namespace: String) -> Self {
         Self {
             otel_options: endpoint.map(|endpoint| OtelOptions {
                 endpoint,
-                level_filter,
                 namespace,
             }),
         }
@@ -38,7 +37,7 @@ impl TracerEngine {
     ///
     /// ## Returns
     /// An instance of TracerEngine
-    pub fn new(options: TracerOptions, service_name: &str, module_name: &str) -> Self {
+    pub fn new(options: TracerOptions, service_name: &str) -> Self {
         let use_otel = options.otel_options.is_some();
 
         let stdout_tracer = tracing_subscriber::fmt::layer().with_writer(std::io::stdout);
@@ -47,7 +46,7 @@ impl TracerEngine {
         let (otel_tracer, otel_setup_error) = options
             .otel_options
             .map(|otel_options| {
-                match OtelTracer::<_>::new(otel_options, service_name, module_name) {
+                match OtelTracer::<_>::new(otel_options, service_name) {
                     Ok(otel_tracer) => (Some(otel_tracer), None),
                     Err(e) => (None, Some(e)),
                 }

--- a/common/src/tracer/tracer_engine.rs
+++ b/common/src/tracer/tracer_engine.rs
@@ -41,8 +41,7 @@ impl TracerEngine {
     pub fn new(options: TracerOptions, service_name: &str, module_name: &str) -> Self {
         let use_otel = options.otel_options.is_some();
 
-        let stdout_tracer = tracing_subscriber::fmt::layer()
-            .with_writer(std::io::stdout);
+        let stdout_tracer = tracing_subscriber::fmt::layer().with_writer(std::io::stdout);
 
         // if options.otel_options is provided then attempt to setup OtelTracer
         let (otel_tracer, otel_setup_error) = options

--- a/common/src/tracer/tracer_engine.rs
+++ b/common/src/tracer/tracer_engine.rs
@@ -41,7 +41,8 @@ impl TracerEngine {
     pub fn new(options: TracerOptions, service_name: &str, module_name: &str) -> Self {
         let use_otel = options.otel_options.is_some();
 
-        let stdout_tracer = tracing_subscriber::fmt::layer().with_writer(std::io::stdout);
+        let stdout_tracer = tracing_subscriber::fmt::layer()
+            .with_writer(std::io::stdout);
 
         // if options.otel_options is provided then attempt to setup OtelTracer
         let (otel_tracer, otel_setup_error) = options

--- a/digitiser-aggregator/src/frame/cache.rs
+++ b/digitiser-aggregator/src/frame/cache.rs
@@ -71,8 +71,7 @@ where
 
         // Link this span with the frame aggregator span associated with `frame`
         if let Err(e) = frame.link_current_span(|| {
-            let span = info_span!(target: "otel",
-                "Digitiser Event List",
+            let span = info_span!("Digitiser Event List",
                 "metadata_timestamp" = tracing::field::Empty,
                 "metadata_frame_number" = tracing::field::Empty,
                 "metadata_period_number" = tracing::field::Empty,

--- a/digitiser-aggregator/src/frame/cache.rs
+++ b/digitiser-aggregator/src/frame/cache.rs
@@ -71,7 +71,8 @@ where
 
         // Link this span with the frame aggregator span associated with `frame`
         if let Err(e) = frame.link_current_span(|| {
-            let span = info_span!("Digitiser Event List",
+            let span = info_span!(
+                "Digitiser Event List",
                 "metadata_timestamp" = tracing::field::Empty,
                 "metadata_frame_number" = tracing::field::Empty,
                 "metadata_period_number" = tracing::field::Empty,

--- a/digitiser-aggregator/src/frame/cache.rs
+++ b/digitiser-aggregator/src/frame/cache.rs
@@ -73,6 +73,7 @@ where
         if let Err(e) = frame.link_current_span(|| {
             let span = info_span!(
                 "Digitiser Event List",
+                digitiser_id = digitiser_id,
                 "metadata_timestamp" = tracing::field::Empty,
                 "metadata_frame_number" = tracing::field::Empty,
                 "metadata_period_number" = tracing::field::Empty,

--- a/digitiser-aggregator/src/frame/partial.rs
+++ b/digitiser-aggregator/src/frame/partial.rs
@@ -1,7 +1,6 @@
 use crate::data::DigitiserData;
 use std::time::Duration;
 use supermusr_common::{
-    record_metadata_fields_to_span,
     spanned::{SpanOnce, SpanOnceError, Spanned, SpannedAggregator, SpannedMut},
     DigitizerId,
 };

--- a/digitiser-aggregator/src/frame/partial.rs
+++ b/digitiser-aggregator/src/frame/partial.rs
@@ -92,7 +92,6 @@ impl<D> SpannedAggregator for PartialFrame<D> {
     ) -> Result<(), SpanOnceError> {
         let span = self.span.get()?.in_scope(aggregated_span_fn);
         span.follows_from(tracing::Span::current());
-        record_metadata_fields_to_span!(&self.metadata, span);
         Ok(())
     }
 

--- a/digitiser-aggregator/src/frame/partial.rs
+++ b/digitiser-aggregator/src/frame/partial.rs
@@ -75,16 +75,15 @@ impl<D> SpannedMut for PartialFrame<D> {
 
 impl<D> SpannedAggregator for PartialFrame<D> {
     fn span_init(&mut self) -> Result<(), SpanOnceError> {
-        self.span
-            .init(info_span!(parent: None, "Frame",
-                "metadata_timestamp" = self.metadata.timestamp.to_rfc3339(),
-                "metadata_frame_number" = self.metadata.frame_number,
-                "metadata_period_number" = self.metadata.period_number,
-                "metadata_veto_flags" = self.metadata.veto_flags,
-                "metadata_protons_per_pulse" = self.metadata.protons_per_pulse,
-                "metadata_running" = self.metadata.running,
-                "frame_is_expired" = tracing::field::Empty,
-            ))
+        self.span.init(info_span!(parent: None, "Frame",
+            "metadata_timestamp" = self.metadata.timestamp.to_rfc3339(),
+            "metadata_frame_number" = self.metadata.frame_number,
+            "metadata_period_number" = self.metadata.period_number,
+            "metadata_veto_flags" = self.metadata.veto_flags,
+            "metadata_protons_per_pulse" = self.metadata.protons_per_pulse,
+            "metadata_running" = self.metadata.running,
+            "frame_is_expired" = tracing::field::Empty,
+        ))
     }
 
     fn link_current_span<F: Fn() -> Span>(

--- a/digitiser-aggregator/src/frame/partial.rs
+++ b/digitiser-aggregator/src/frame/partial.rs
@@ -76,7 +76,7 @@ impl<D> SpannedMut for PartialFrame<D> {
 impl<D> SpannedAggregator for PartialFrame<D> {
     fn span_init(&mut self) -> Result<(), SpanOnceError> {
         self.span
-            .init(info_span!(target: "otel", parent: None, "Frame",
+            .init(info_span!(parent: None, "Frame",
                 "metadata_timestamp" = self.metadata.timestamp.to_rfc3339(),
                 "metadata_frame_number" = self.metadata.frame_number,
                 "metadata_period_number" = self.metadata.period_number,

--- a/digitiser-aggregator/src/main.rs
+++ b/digitiser-aggregator/src/main.rs
@@ -199,7 +199,7 @@ async fn main() -> anyhow::Result<()> {
 }
 
 ///  This function wraps the `root_as_digitizer_event_list_message` function, allowing it to be instrumented.
-#[instrument(skip_all, target = "otel")]
+#[instrument(skip_all, level = "trace", target = "otel", err(level = "WARN"))]
 fn spanned_root_as_digitizer_event_list_message(
     payload: &[u8],
 ) -> Result<DigitizerEventListMessage<'_>, InvalidFlatbuffer> {

--- a/digitiser-aggregator/src/main.rs
+++ b/digitiser-aggregator/src/main.rs
@@ -293,7 +293,7 @@ async fn cache_poll(
     cache: &mut FrameCache<EventData>,
 ) -> Result<(), SendAggregatedFrameError> {
     while let Some(frame) = cache.poll() {
-        let span = info_span!(target: "otel", "Frame Completed");
+        let span = info_span!("Frame Completed");
         span.follows_from(
             frame
                 .span()
@@ -364,7 +364,7 @@ async fn produce_to_kafka(
     }
 }
 
-#[tracing::instrument(skip_all, target = "otel", name = "Closing", level = "info", fields(capacity = channel_recv.capacity(), max_capacity = channel_recv.max_capacity()))]
+#[tracing::instrument(skip_all, name = "Closing", level = "info", fields(capacity = channel_recv.capacity(), max_capacity = channel_recv.max_capacity()))]
 async fn close_and_flush_producer_channel(
     use_otel: bool,
     channel_recv: &mut Receiver<AggregatedFrame<EventData>>,
@@ -379,7 +379,7 @@ async fn close_and_flush_producer_channel(
     }
 }
 
-#[tracing::instrument(skip_all, target = "otel", name = "Flush Frame")]
+#[tracing::instrument(skip_all, name = "Flush Frame")]
 async fn flush_frame(
     use_otel: bool,
     frame: AggregatedFrame<EventData>,

--- a/digitiser-aggregator/src/main.rs
+++ b/digitiser-aggregator/src/main.rs
@@ -199,7 +199,7 @@ async fn main() -> anyhow::Result<()> {
 }
 
 ///  This function wraps the `root_as_digitizer_event_list_message` function, allowing it to be instrumented.
-#[instrument(skip_all, level = "trace", target = "otel", err(level = "WARN"))]
+#[instrument(skip_all, level = "trace", err(level = "WARN"))]
 fn spanned_root_as_digitizer_event_list_message(
     payload: &[u8],
 ) -> Result<DigitizerEventListMessage<'_>, InvalidFlatbuffer> {

--- a/digitiser-aggregator/src/main.rs
+++ b/digitiser-aggregator/src/main.rs
@@ -92,10 +92,6 @@ struct Cli {
     #[clap(long)]
     otel_endpoint: Option<String>,
 
-    /// The reporting level to use for OpenTelemetry
-    #[clap(long, default_value = "info")]
-    otel_level: LevelFilter,
-
     /// All OpenTelemetry spans are emitted with this as the "service.namespace" property. Can be used to track different instances of the pipeline running in parallel.
     #[clap(long, default_value = "")]
     otel_namespace: String,
@@ -107,7 +103,6 @@ async fn main() -> anyhow::Result<()> {
 
     let tracer = init_tracer!(TracerOptions::new(
         args.otel_endpoint.as_deref(),
-        args.otel_level,
         args.otel_namespace
     ));
 

--- a/digitiser-aggregator/src/main.rs
+++ b/digitiser-aggregator/src/main.rs
@@ -38,7 +38,7 @@ use tokio::{
     sync::mpsc::{error::SendError, Receiver, Sender},
     task::JoinHandle,
 };
-use tracing::{debug, error, info, info_span, instrument, level_filters::LevelFilter, warn};
+use tracing::{debug, error, info, info_span, instrument, warn};
 
 const PRODUCER_TIMEOUT: Timeout = Timeout::After(Duration::from_millis(100));
 

--- a/nexus-writer/src/main.rs
+++ b/nexus-writer/src/main.rs
@@ -41,7 +41,7 @@ use tokio::{
     signal::unix::{signal, SignalKind},
     time,
 };
-use tracing::{debug, error, info_span, instrument, level_filters::LevelFilter, warn, warn_span};
+use tracing::{debug, error, info_span, instrument, warn, warn_span};
 
 #[derive(Debug, Parser)]
 #[clap(author, version, about)]
@@ -97,10 +97,6 @@ struct Cli {
     #[clap(long)]
     otel_endpoint: Option<String>,
 
-    /// The reporting level to use for OpenTelemetry
-    #[clap(long, default_value = "info")]
-    otel_level: LevelFilter,
-
     /// All OpenTelemetry spans are emitted with this as the "service.namespace" property. Can be used to track different instances of the pipeline running in parallel.
     #[clap(long, default_value = "")]
     otel_namespace: String,
@@ -126,7 +122,6 @@ async fn main() -> anyhow::Result<()> {
 
     let tracer = init_tracer!(TracerOptions::new(
         args.otel_endpoint.as_deref(),
-        args.otel_level,
         args.otel_namespace
     ));
 

--- a/nexus-writer/src/main.rs
+++ b/nexus-writer/src/main.rs
@@ -315,7 +315,8 @@ fn process_frame_assembled_event_list_message(nexus_engine: &mut NexusEngine, pa
                 Ok(run) => {
                     if let Some(run) = run {
                         if let Err(e) = run.link_current_span(|| {
-                            let span = info_span!("Frame Event List",
+                            let span = info_span!(
+                                "Frame Event List",
                                 "metadata_timestamp" = tracing::field::Empty,
                                 "metadata_frame_number" = tracing::field::Empty,
                                 "metadata_period_number" = tracing::field::Empty,
@@ -361,8 +362,10 @@ fn process_run_start_message(nexus_engine: &mut NexusEngine, payload: &[u8]) {
         Ok(data) => match nexus_engine.start_command(data) {
             Ok(run) => {
                 if let Err(e) = run.link_current_span(|| {
-                    info_span!("Run Start Command",
-                    "Start" = run.parameters().collect_from.to_string())
+                    info_span!(
+                        "Run Start Command",
+                        "Start" = run.parameters().collect_from.to_string()
+                    )
                 }) {
                     warn!("Run span linking failed {e}")
                 }
@@ -391,11 +394,13 @@ fn process_run_stop_message(nexus_engine: &mut NexusEngine, payload: &[u8]) {
         Ok(data) => match nexus_engine.stop_command(data) {
             Ok(run) => {
                 if let Err(e) = run.link_current_span(|| {
-                    info_span!("Run Stop Command",
-                        "Stop" = run.parameters()
+                    info_span!(
+                        "Run Stop Command",
+                        "Stop" = run
+                            .parameters()
                             .run_stop_parameters
                             .as_ref()
-                            .map(|s|s.collect_until.to_rfc3339())
+                            .map(|s| s.collect_until.to_rfc3339())
                             .unwrap_or_default()
                     )
                 }) {
@@ -436,9 +441,7 @@ fn process_sample_environment_message(nexus_engine: &mut NexusEngine, payload: &
         Ok(data) => match nexus_engine.sample_envionment(data) {
             Ok(run) => {
                 if let Some(run) = run {
-                    if let Err(e) = run
-                        .link_current_span(|| info_span!("Sample Environment Log"))
-                    {
+                    if let Err(e) = run.link_current_span(|| info_span!("Sample Environment Log")) {
                         warn!("Run span linking failed {e}")
                     }
                 }
@@ -496,9 +499,7 @@ fn process_logdata_message(nexus_engine: &mut NexusEngine, payload: &[u8]) {
         Ok(data) => match nexus_engine.logdata(&data) {
             Ok(run) => {
                 if let Some(run) = run {
-                    if let Err(e) =
-                        run.link_current_span(|| info_span!("Run Log Data"))
-                    {
+                    if let Err(e) = run.link_current_span(|| info_span!("Run Log Data")) {
                         warn!("Run span linking failed {e}")
                     }
                 }

--- a/nexus-writer/src/main.rs
+++ b/nexus-writer/src/main.rs
@@ -277,7 +277,7 @@ fn process_payload(nexus_engine: &mut NexusEngine, message_topic: &str, payload:
     }
 }
 
-#[instrument(skip_all, level = "trace", target = "otel", err(level = "WARN"))]
+#[instrument(skip_all, level = "trace", err(level = "WARN"))]
 fn spanned_root_as<'a, R, F>(f: F, payload: &'a [u8]) -> Result<R, InvalidFlatbuffer>
 where
     F: Fn(&'a [u8]) -> Result<R, InvalidFlatbuffer>,
@@ -315,8 +315,7 @@ fn process_frame_assembled_event_list_message(nexus_engine: &mut NexusEngine, pa
                 Ok(run) => {
                     if let Some(run) = run {
                         if let Err(e) = run.link_current_span(|| {
-                            let span = info_span!(target: "otel",
-                                "Frame Event List",
+                            let span = info_span!("Frame Event List",
                                 "metadata_timestamp" = tracing::field::Empty,
                                 "metadata_frame_number" = tracing::field::Empty,
                                 "metadata_period_number" = tracing::field::Empty,
@@ -362,8 +361,7 @@ fn process_run_start_message(nexus_engine: &mut NexusEngine, payload: &[u8]) {
         Ok(data) => match nexus_engine.start_command(data) {
             Ok(run) => {
                 if let Err(e) = run.link_current_span(|| {
-                    info_span!(target: "otel",
-                    "Run Start Command",
+                    info_span!("Run Start Command",
                     "Start" = run.parameters().collect_from.to_string())
                 }) {
                     warn!("Run span linking failed {e}")
@@ -393,8 +391,7 @@ fn process_run_stop_message(nexus_engine: &mut NexusEngine, payload: &[u8]) {
         Ok(data) => match nexus_engine.stop_command(data) {
             Ok(run) => {
                 if let Err(e) = run.link_current_span(|| {
-                    info_span!(target: "otel",
-                        "Run Stop Command",
+                    info_span!("Run Stop Command",
                         "Stop" = run.parameters()
                             .run_stop_parameters
                             .as_ref()
@@ -440,7 +437,7 @@ fn process_sample_environment_message(nexus_engine: &mut NexusEngine, payload: &
             Ok(run) => {
                 if let Some(run) = run {
                     if let Err(e) = run
-                        .link_current_span(|| info_span!(target: "otel", "Sample Environment Log"))
+                        .link_current_span(|| info_span!("Sample Environment Log"))
                     {
                         warn!("Run span linking failed {e}")
                     }
@@ -470,7 +467,7 @@ fn process_alarm_message(nexus_engine: &mut NexusEngine, payload: &[u8]) {
         Ok(data) => match nexus_engine.alarm(data) {
             Ok(run) => {
                 if let Some(run) = run {
-                    if let Err(e) = run.link_current_span(|| info_span!(target: "otel", "Alarm")) {
+                    if let Err(e) = run.link_current_span(|| info_span!("Alarm")) {
                         warn!("Run span linking failed {e}")
                     }
                 }
@@ -500,7 +497,7 @@ fn process_logdata_message(nexus_engine: &mut NexusEngine, payload: &[u8]) {
             Ok(run) => {
                 if let Some(run) = run {
                     if let Err(e) =
-                        run.link_current_span(|| info_span!(target: "otel", "Run Log Data"))
+                        run.link_current_span(|| info_span!("Run Log Data"))
                     {
                         warn!("Run span linking failed {e}")
                     }

--- a/nexus-writer/src/main.rs
+++ b/nexus-writer/src/main.rs
@@ -277,7 +277,7 @@ fn process_payload(nexus_engine: &mut NexusEngine, message_topic: &str, payload:
     }
 }
 
-#[instrument(skip_all, target = "otel")]
+#[instrument(skip_all, level = "trace", target = "otel", err(level = "WARN"))]
 fn spanned_root_as<'a, R, F>(f: F, payload: &'a [u8]) -> Result<R, InvalidFlatbuffer>
 where
     F: Fn(&'a [u8]) -> Result<R, InvalidFlatbuffer>,

--- a/nexus-writer/src/nexus/engine.rs
+++ b/nexus-writer/src/nexus/engine.rs
@@ -185,7 +185,6 @@ impl NexusEngine {
     }
 
     #[tracing::instrument(skip_all,
-        target = "otel",
         fields(
             metadata_timestamp = tracing::field::Empty,
             metadata_frame_number = message.metadata().frame_number(),

--- a/nexus-writer/src/nexus/run.rs
+++ b/nexus-writer/src/nexus/run.rs
@@ -232,7 +232,7 @@ impl SpannedMut for Run {
 
 impl SpannedAggregator for Run {
     fn span_init(&mut self) -> Result<(), SpanOnceError> {
-        let span = info_span!(target: "otel", parent: None,
+        let span = info_span!(parent: None,
             "Run",
             "run_name" = self.parameters.run_name.as_str(),
             "instrument_name" = self.parameters.instrument_name.as_str(),

--- a/simulator/src/integrated/build_messages.rs
+++ b/simulator/src/integrated/build_messages.rs
@@ -59,7 +59,7 @@ pub(crate) fn build_trace_message(
     let channels = channels
         .iter()
         .map(|&channel| {
-            info_span!(target: "otel", "channel", channel = channel).in_scope(|| {
+            info_span!("channel", channel = channel).in_scope(|| {
                 let trace = cache.extract_one(selection_mode)?;
 
                 tracing::Span::current()
@@ -107,7 +107,7 @@ pub(crate) fn build_digitiser_event_list_message(
             .iter()
             .zip(event_lists)
             .for_each(|(c, event_list)| {
-                info_span!(target: "otel", "channel", channel = c).in_scope(|| {
+                info_span!("channel", channel = c).in_scope(|| {
                     tracing::Span::current()
                         .follows_from(event_list.span().get().expect("Span exists"));
                     event_list.pulses.iter().for_each(|p| {
@@ -152,7 +152,7 @@ pub(crate) fn build_aggregated_event_list_message(
             .iter()
             .zip(event_lists)
             .for_each(|(c, event_list)| {
-                info_span!(target: "otel", "channel", channel = c).in_scope(|| {
+                info_span!("channel", channel = c).in_scope(|| {
                     tracing::Span::current()
                         .follows_from(event_list.span().get().expect("Span exists"));
                     event_list.pulses.iter().for_each(|p| {

--- a/simulator/src/integrated/mod.rs
+++ b/simulator/src/integrated/mod.rs
@@ -38,7 +38,7 @@ pub(crate) enum ConfiguredError {
     IO(#[from] std::io::Error),
 }
 
-#[tracing::instrument(skip_all, target = "otel", err(level = "error"))]
+#[tracing::instrument(skip_all, err(level = "error"))]
 pub(crate) async fn run_configured_simulation(
     use_otel: bool,
     producer: &FutureProducer,

--- a/simulator/src/integrated/send_messages.rs
+++ b/simulator/src/integrated/send_messages.rs
@@ -110,7 +110,7 @@ fn get_time_since_epoch_ns(timestamp: &DateTime<Utc>) -> Result<i64, SendError> 
         .ok_or(SendError::TimestampToNanos(*timestamp))
 }
 
-#[tracing::instrument(skip_all, target = "otel", err(level = "error"))]
+#[tracing::instrument(skip_all, err(level = "error"))]
 pub(crate) fn send_run_start_command(
     externals: &mut SimulationEngineExternals,
     status: &SendRunStart,
@@ -139,7 +139,7 @@ pub(crate) fn send_run_start_command(
     Ok(())
 }
 
-#[tracing::instrument(skip_all, target = "otel", err(level = "error"))]
+#[tracing::instrument(skip_all, err(level = "error"))]
 pub(crate) fn send_run_stop_command(
     externals: &mut SimulationEngineExternals,
     status: &SendRunStop,
@@ -167,7 +167,7 @@ pub(crate) fn send_run_stop_command(
     Ok(())
 }
 
-#[tracing::instrument(skip_all, target = "otel", err(level = "error"))]
+#[tracing::instrument(skip_all, err(level = "error"))]
 pub(crate) fn send_run_log_command(
     externals: &mut SimulationEngineExternals,
     timestamp: &DateTime<Utc>,
@@ -198,7 +198,7 @@ pub(crate) fn send_run_log_command(
     Ok(())
 }
 
-#[tracing::instrument(skip_all, target = "otel", err(level = "error"))]
+#[tracing::instrument(skip_all, err(level = "error"))]
 pub(crate) fn send_se_log_command(
     externals: &mut SimulationEngineExternals,
     timestamp: &DateTime<Utc>,
@@ -254,7 +254,7 @@ pub(crate) fn send_se_log_command(
     Ok(())
 }
 
-#[tracing::instrument(skip_all, target = "otel", err(level = "error"))]
+#[tracing::instrument(skip_all, err(level = "error"))]
 pub(crate) fn send_alarm_command(
     externals: &mut SimulationEngineExternals,
     timestamp: &DateTime<Utc>,
@@ -284,7 +284,7 @@ pub(crate) fn send_alarm_command(
     Ok(())
 }
 
-#[tracing::instrument(skip_all, target = "otel", fields(digitizer_id = digitizer_id))]
+#[tracing::instrument(skip_all, fields(digitizer_id = digitizer_id))]
 pub(crate) fn send_digitiser_trace_message(
     externals: &mut SimulationEngineExternals,
     sample_rate: u64,
@@ -320,7 +320,7 @@ pub(crate) fn send_digitiser_trace_message(
     Ok(())
 }
 
-#[tracing::instrument(skip_all, target = "otel", fields(digitizer_id = digitizer_id))]
+#[tracing::instrument(skip_all, fields(digitizer_id = digitizer_id))]
 pub(crate) fn send_digitiser_event_list_message(
     externals: &mut SimulationEngineExternals,
     cache: &mut VecDeque<EventList<'_>>,
@@ -354,7 +354,7 @@ pub(crate) fn send_digitiser_event_list_message(
     Ok(())
 }
 
-#[tracing::instrument(skip_all, target = "otel")]
+#[tracing::instrument(skip_all)]
 pub(crate) fn send_aggregated_frame_event_list_message(
     externals: &mut SimulationEngineExternals,
     cache: &mut VecDeque<EventList<'_>>,

--- a/simulator/src/integrated/simulation.rs
+++ b/simulator/src/integrated/simulation.rs
@@ -53,7 +53,7 @@ pub(crate) enum SimulationError {
 }
 
 impl Simulation {
-    #[instrument(skip_all, target = "otel", level = "debug", err(level = "error"))]
+    #[instrument(skip_all, level = "debug", err(level = "error"))]
     pub(crate) fn get_random_pulse_template(
         &self,
         source: &EventListTemplate,
@@ -77,7 +77,7 @@ impl Simulation {
         )
     }
 
-    #[instrument(skip_all, target = "otel", err(level = "error"))]
+    #[instrument(skip_all, err(level = "error"))]
     pub(crate) fn generate_event_lists(
         &self,
         index: usize,
@@ -109,7 +109,7 @@ impl Simulation {
         Ok(vec)
     }
 
-    #[instrument(skip_all, target = "otel", level = "debug", err(level = "error"))]
+    #[instrument(skip_all, level = "debug", err(level = "error"))]
     pub(crate) fn generate_traces<'a>(
         &'a self,
         event_lists: &'a [EventList],

--- a/simulator/src/integrated/simulation_elements/digitiser_config.rs
+++ b/simulator/src/integrated/simulation_elements/digitiser_config.rs
@@ -26,7 +26,7 @@ pub(crate) enum DigitiserConfig {
 }
 
 impl DigitiserConfig {
-    #[instrument(skip_all, target = "otel")]
+    #[instrument(skip_all)]
     pub(crate) fn generate_channels(&self) -> Result<Vec<Channel>, JsonIntError> {
         let channels = match self {
             DigitiserConfig::AutoAggregatedFrame { num_channels } => {
@@ -46,7 +46,7 @@ impl DigitiserConfig {
         Ok(channels)
     }
 
-    #[instrument(skip_all, target = "otel")]
+    #[instrument(skip_all)]
     pub(crate) fn generate_digitisers(
         &self,
     ) -> Result<Vec<SimulationEngineDigitiser>, JsonIntError> {

--- a/simulator/src/integrated/simulation_elements/event_list.rs
+++ b/simulator/src/integrated/simulation_elements/event_list.rs
@@ -99,12 +99,7 @@ pub(crate) struct EventList<'a> {
 }
 
 impl<'a> EventList<'a> {
-    #[instrument(
-        skip_all,
-        level = "debug",
-        "New Event List",
-        err(level = "error")
-    )]
+    #[instrument(skip_all, level = "debug", "New Event List", err(level = "error"))]
     pub(crate) fn new(
         simulator: &Simulation,
         frame_number: FrameNumber,

--- a/simulator/src/integrated/simulation_elements/event_list.rs
+++ b/simulator/src/integrated/simulation_elements/event_list.rs
@@ -31,7 +31,6 @@ impl Trace {
             .get()
             .expect("Span should be initialised, this never fails")
         ],
-        target = "otel",
         name = "New Trace",
         err(level = "error")
     )]
@@ -103,7 +102,6 @@ impl<'a> EventList<'a> {
     #[instrument(
         skip_all,
         level = "debug",
-        target = "otel",
         "New Event List",
         err(level = "error")
     )]

--- a/simulator/src/integrated/simulation_engine/engine.rs
+++ b/simulator/src/integrated/simulation_engine/engine.rs
@@ -55,7 +55,7 @@ pub(crate) struct SimulationEngineDigitiser {
 }
 
 impl SimulationEngineDigitiser {
-    #[instrument(skip_all, target = "otel", name = "digitiser", fields(digitiser_id = id))]
+    #[instrument(skip_all, name = "digitiser", fields(digitiser_id = id))]
     pub(crate) fn new(id: DigitizerId, channel_indices: Vec<usize>) -> Self {
         SimulationEngineDigitiser {
             id,
@@ -116,7 +116,7 @@ impl<'a> SimulationEngine<'a> {
     }
 }
 
-#[instrument(skip_all, level = "debug", target = "otel", err(level = "error"))]
+#[instrument(skip_all, level = "debug", err(level = "error"))]
 fn set_timestamp(
     engine: &mut SimulationEngine,
     timestamp: &Timestamp,
@@ -143,12 +143,12 @@ fn set_timestamp(
     Ok(())
 }
 
-#[instrument(skip_all, level = "debug", target = "otel")]
+#[instrument(skip_all, level = "debug")]
 fn wait_ms(ms: usize) {
     sleep(Duration::from_millis(ms as u64));
 }
 
-#[instrument(skip_all, level = "debug", target = "otel")]
+#[instrument(skip_all, level = "debug")]
 fn ensure_delay_ms(ms: usize, delay_from: &mut DateTime<Utc>) {
     let duration = TimeDelta::milliseconds(ms as i64);
     if Utc::now() - *delay_from < duration {
@@ -157,7 +157,7 @@ fn ensure_delay_ms(ms: usize, delay_from: &mut DateTime<Utc>) {
     *delay_from = Utc::now();
 }
 
-#[instrument(skip_all, level = "debug", target = "otel", err(level = "error"))]
+#[instrument(skip_all, level = "debug", err(level = "error"))]
 fn generate_trace_push_to_cache(
     engine: &mut SimulationEngine,
     generate_trace: &GenerateTrace,
@@ -174,7 +174,7 @@ fn generate_trace_push_to_cache(
     Ok(())
 }
 
-#[instrument(skip_all, level = "debug", target = "otel", err(level = "error"))]
+#[instrument(skip_all, level = "debug", err(level = "error"))]
 fn generate_trace_fbb_push_to_cache(
     sample_rate: u64,
     trace_cache_fbb: &mut VecDeque<FlatBufferBuilder<'_>>,
@@ -208,7 +208,7 @@ fn generate_trace_fbb_push_to_cache(
     Ok(())
 }
 
-#[instrument(skip_all, level = "debug", target = "otel", err(level = "error"))]
+#[instrument(skip_all, level = "debug", err(level = "error"))]
 fn generate_event_lists_push_to_cache(
     engine: &mut SimulationEngine,
     generate_event: &GenerateEventList,
@@ -222,7 +222,7 @@ fn generate_event_lists_push_to_cache(
     Ok(())
 }
 
-#[instrument(skip_all, level = "debug", target = "otel")]
+#[instrument(skip_all, level = "debug")]
 fn tracing_event(event: &TracingEvent) {
     match event.level {
         TracingLevel::Info => info!(event.message),
@@ -230,7 +230,7 @@ fn tracing_event(event: &TracingEvent) {
     }
 }
 
-#[tracing::instrument(skip_all, level = "debug", target = "otel", fields(num_actions = engine.simulation.schedule.len()), err(level = "error"))]
+#[tracing::instrument(skip_all, level = "debug", fields(num_actions = engine.simulation.schedule.len()), err(level = "error"))]
 pub(crate) fn run_schedule(engine: &mut SimulationEngine) -> Result<(), SimulationEngineError> {
     for action in engine.simulation.schedule.iter() {
         match action {
@@ -298,7 +298,7 @@ pub(crate) fn run_schedule(engine: &mut SimulationEngine) -> Result<(), Simulati
 }
 
 #[tracing::instrument(
-    skip_all, level = "debug", target = "otel",
+    skip_all, level = "debug"
     fields(
         frame_number = engine.state.metadata.frame_number,
         num_actions = frame_actions.len()
@@ -350,7 +350,7 @@ fn run_frame(
     Ok(())
 }
 
-#[tracing::instrument(skip_all, level = "debug", target = "otel",
+#[tracing::instrument(skip_all, level = "debug"
     fields(
         frame_number = engine.state.metadata.frame_number,
         digitiser_id = engine.digitiser_ids[engine.state.digitiser_index].id,

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -37,7 +37,7 @@ use supermusr_streaming_types::{
     frame_metadata_v2_generated::{FrameMetadataV2, FrameMetadataV2Args, GpsTime},
 };
 use tokio::time;
-use tracing::{debug, error, info, level_filters::LevelFilter, warn};
+use tracing::{debug, error, info, warn};
 
 #[derive(Clone, Parser)]
 #[clap(author, version, about)]
@@ -49,10 +49,6 @@ struct Cli {
     /// If set, then OpenTelemetry data is sent to the URL specified, otherwise the standard tracing subscriber is used
     #[clap(long)]
     otel_endpoint: Option<String>,
-
-    /// The reporting level to use for OpenTelemetry
-    #[clap(long, default_value = "info")]
-    otel_level: LevelFilter,
 
     /// All OpenTelemetry spans are emitted with this as the "service.namespace" property. Can be used to track different instances of the pipeline running in parallel.
     #[clap(long, default_value = "")]
@@ -178,7 +174,6 @@ async fn main() -> anyhow::Result<()> {
 
     let tracer = init_tracer!(TracerOptions::new(
         cli.otel_endpoint.as_deref(),
-        cli.otel_level,
         cli.otel_namespace
     ));
 

--- a/trace-to-events/src/channels.rs
+++ b/trace-to-events/src/channels.rs
@@ -1,0 +1,201 @@
+use crate::{
+    parameters::{
+        AdvancedMuonDetectorParameters, DetectorSettings, FixedThresholdDiscriminatorParameters,
+        Mode, Polarity,
+    }, processing::get_save_file_name, pulse_detection::{
+        advanced_muon_detector::{AdvancedMuonAssembler, AdvancedMuonDetector},
+        threshold_detector::{ThresholdDetector, ThresholdDuration},
+        window::{Baseline, FiniteDifferences, SmoothingWindow, WindowFilter},
+        AssembleFilter, EventFilter, Real, SaveToFileFilter,
+    }
+};
+use std::path::Path;
+use supermusr_common::{Intensity, Time};
+use supermusr_streaming_types::{
+    dat2_digitizer_analog_trace_v2_generated::ChannelTrace,
+    frame_metadata_v2_generated::FrameMetadataV2
+};
+
+#[tracing::instrument(skip_all, fields(channel = trace.channel(), num_pulses))]
+pub(crate) fn find_channel_events(
+    metadata: &FrameMetadataV2,
+    trace: &ChannelTrace,
+    sample_time: Real,
+    detector_settings: &DetectorSettings,
+    save_options: Option<&Path>,
+) -> (Vec<Time>, Vec<Intensity>) {
+    let result = match &detector_settings.mode {
+        Mode::FixedThresholdDiscriminator(parameters) => find_fixed_threshold_events(
+            metadata,
+            trace,
+            sample_time,
+            detector_settings.polarity,
+            detector_settings.baseline as Real,
+            parameters,
+            save_options,
+        ),
+        Mode::AdvancedMuonDetector(parameters) => find_advanced_events(
+            metadata,
+            trace,
+            sample_time,
+            detector_settings.polarity,
+            detector_settings.baseline as Real,
+            parameters,
+            save_options,
+        ),
+    };
+    tracing::Span::current().record("num_pulses", result.0.len());
+    result
+}
+
+#[tracing::instrument(skip_all, level = "trace")]
+fn find_fixed_threshold_events(
+    metadata: &FrameMetadataV2,
+    trace: &ChannelTrace,
+    sample_time: Real,
+    polarity: &Polarity,
+    baseline: Real,
+    parameters: &FixedThresholdDiscriminatorParameters,
+    save_path: Option<&Path>,
+) -> (Vec<Time>, Vec<Intensity>) {
+    let sign = match polarity {
+        Polarity::Positive => 1.0,
+        Polarity::Negative => -1.0,
+    };
+    let raw = trace
+        .voltage()
+        .unwrap()
+        .into_iter()
+        .enumerate()
+        .map(|(i, v)| (i as Real * sample_time, sign * (v as Real - baseline)));
+
+    let pulses = raw
+        .clone()
+        .events(ThresholdDetector::new(&ThresholdDuration {
+            threshold: parameters.threshold,
+            duration: parameters.duration,
+            cool_off: parameters.cool_off,
+        }));
+
+    if let Some(save_path) = save_path {
+        raw.clone()
+            .save_to_file(&get_save_file_name(
+                save_path,
+                metadata.frame_number(),
+                trace.channel(),
+                "raw",
+            ))
+            .unwrap();
+
+        pulses
+            .clone()
+            .save_to_file(&get_save_file_name(
+                save_path,
+                metadata.frame_number(),
+                trace.channel(),
+                "pulses",
+            ))
+            .unwrap();
+    }
+
+    let mut time = Vec::<Time>::new();
+    let mut voltage = Vec::<Intensity>::new();
+    for pulse in pulses {
+        time.push(pulse.0 as Time);
+        voltage.push(pulse.1.pulse_height as Intensity);
+    }
+    (time, voltage)
+}
+
+#[tracing::instrument(skip_all, level = "trace")]
+fn find_advanced_events(
+    metadata: &FrameMetadataV2,
+    trace: &ChannelTrace,
+    sample_time: Real,
+    polarity: &Polarity,
+    baseline: Real,
+    parameters: &AdvancedMuonDetectorParameters,
+    save_path: Option<&Path>,
+) -> (Vec<Time>, Vec<Intensity>) {
+    let sign = match polarity {
+        Polarity::Positive => 1.0,
+        Polarity::Negative => -1.0,
+    };
+    let raw = trace
+        .voltage()
+        .unwrap()
+        .into_iter()
+        .enumerate()
+        .map(|(i, v)| (i as Real * sample_time, sign * (v as Real - baseline)));
+
+    let smoothed = raw
+        .clone()
+        .window(Baseline::new(parameters.baseline_length.unwrap_or(0), 0.1))
+        .window(SmoothingWindow::new(
+            parameters.smoothing_window_size.unwrap_or(1),
+        ))
+        .map(|(i, stats)| (i, stats.mean));
+
+    let events = smoothed
+        .clone()
+        .window(FiniteDifferences::<2>::new())
+        .events(AdvancedMuonDetector::new(
+            parameters.muon_onset,
+            parameters.muon_fall,
+            parameters.muon_termination,
+            parameters.duration,
+        ));
+
+    let pulses = events
+        .clone()
+        .assemble(AdvancedMuonAssembler::default())
+        .filter(|pulse| {
+            Option::zip(parameters.min_amplitude, pulse.peak.value)
+                .map(|(min, val)| min <= val)
+                .unwrap_or(true)
+        })
+        .filter(|pulse| {
+            Option::zip(parameters.max_amplitude, pulse.peak.value)
+                .map(|(max, val)| max >= val)
+                .unwrap_or(true)
+        });
+
+    if let Some(save_path) = save_path {
+        raw.clone()
+            .save_to_file(&get_save_file_name(
+                save_path,
+                metadata.frame_number(),
+                trace.channel(),
+                "raw",
+            ))
+            .unwrap();
+
+        smoothed
+            .clone()
+            .save_to_file(&get_save_file_name(
+                save_path,
+                metadata.frame_number(),
+                trace.channel(),
+                "smoothed",
+            ))
+            .unwrap();
+
+        pulses
+            .clone()
+            .save_to_file(&get_save_file_name(
+                save_path,
+                metadata.frame_number(),
+                trace.channel(),
+                "pulses",
+            ))
+            .unwrap();
+    }
+
+    let mut time = Vec::<Time>::new();
+    let mut voltage = Vec::<Intensity>::new();
+    for pulse in pulses {
+        time.push(pulse.steepest_rise.time.unwrap_or_default() as Time);
+        voltage.push(pulse.peak.value.unwrap_or_default() as Intensity);
+    }
+    (time, voltage)
+}

--- a/trace-to-events/src/channels.rs
+++ b/trace-to-events/src/channels.rs
@@ -2,18 +2,20 @@ use crate::{
     parameters::{
         AdvancedMuonDetectorParameters, DetectorSettings, FixedThresholdDiscriminatorParameters,
         Mode, Polarity,
-    }, processing::get_save_file_name, pulse_detection::{
+    },
+    processing::get_save_file_name,
+    pulse_detection::{
         advanced_muon_detector::{AdvancedMuonAssembler, AdvancedMuonDetector},
         threshold_detector::{ThresholdDetector, ThresholdDuration},
         window::{Baseline, FiniteDifferences, SmoothingWindow, WindowFilter},
         AssembleFilter, EventFilter, Real, SaveToFileFilter,
-    }
+    },
 };
 use std::path::Path;
 use supermusr_common::{Intensity, Time};
 use supermusr_streaming_types::{
     dat2_digitizer_analog_trace_v2_generated::ChannelTrace,
-    frame_metadata_v2_generated::FrameMetadataV2
+    frame_metadata_v2_generated::FrameMetadataV2,
 };
 
 #[tracing::instrument(skip_all, fields(channel = trace.channel(), num_pulses))]

--- a/trace-to-events/src/main.rs
+++ b/trace-to-events/src/main.rs
@@ -39,7 +39,7 @@ use tokio::{
     sync::mpsc::{error::TrySendError, Receiver, Sender},
     task::JoinHandle,
 };
-use tracing::{debug, error, info, instrument, metadata::LevelFilter, trace, warn};
+use tracing::{debug, error, info, instrument, trace, warn};
 
 type DigitiserEventListToBufferSender = Sender<DeliveryFuture>;
 type TrySendDigitiserEventListError = TrySendError<DeliveryFuture>;
@@ -87,10 +87,6 @@ struct Cli {
     #[clap(long)]
     otel_endpoint: Option<String>,
 
-    /// If OpenTelemetry is used then it uses the following tracing level
-    #[clap(long, default_value = "info")]
-    otel_level: LevelFilter,
-
     /// All OpenTelemetry spans are emitted with this as the "service.namespace" property. Can be used to track different instances of the pipeline running in parallel.
     #[clap(long, default_value = "")]
     otel_namespace: String,
@@ -105,7 +101,6 @@ async fn main() -> anyhow::Result<()> {
 
     let tracer = init_tracer!(TracerOptions::new(
         args.otel_endpoint.as_deref(),
-        args.otel_level,
         args.otel_namespace.clone()
     ));
 

--- a/trace-to-events/src/main.rs
+++ b/trace-to-events/src/main.rs
@@ -179,14 +179,14 @@ async fn main() -> anyhow::Result<()> {
     }
 }
 
-#[instrument(skip_all, level = "trace", target = "otel", err(level = "WARN"))]
+#[instrument(skip_all, level = "trace", err(level = "WARN"))]
 fn spanned_root_as_digitizer_analog_trace_message(
     payload: &[u8],
 ) -> Result<DigitizerAnalogTraceMessage<'_>, InvalidFlatbuffer> {
     root_as_digitizer_analog_trace_message(payload)
 }
 
-#[instrument(skip_all, target = "otel", fields(kafka_message_timestamp_ms = m.timestamp().to_millis()))]
+#[instrument(skip_all, fields(kafka_message_timestamp_ms = m.timestamp().to_millis()))]
 fn process_kafka_message(
     tracer: &TracerEngine,
     args: &Cli,
@@ -242,7 +242,6 @@ fn process_kafka_message(
 
 #[instrument(
     skip_all,
-    target = "otel",
     fields(
         digitiser_id = thing.digitizer_id(),
         metadata_timestamp = tracing::field::Empty,
@@ -355,7 +354,7 @@ async fn produce_eventlist_to_kafka(future: DeliveryFuture) {
     }
 }
 
-#[tracing::instrument(skip_all, target = "otel", name = "Closing", level = "info", fields(capactity = channel_recv.capacity(), max_capactity = channel_recv.max_capacity()))]
+#[tracing::instrument(skip_all, name = "Closing", level = "info", fields(capactity = channel_recv.capacity(), max_capactity = channel_recv.max_capacity()))]
 async fn close_and_flush_producer_channel(
     channel_recv: &mut Receiver<DeliveryFuture>,
 ) -> Option<()> {
@@ -367,7 +366,7 @@ async fn close_and_flush_producer_channel(
     }
 }
 
-#[tracing::instrument(skip_all, target = "otel", name = "Flush Eventlist")]
+#[tracing::instrument(skip_all, name = "Flush Eventlist")]
 async fn flush_eventlist(future: DeliveryFuture) -> Option<()> {
     produce_eventlist_to_kafka(future).await;
     Some(())

--- a/trace-to-events/src/main.rs
+++ b/trace-to-events/src/main.rs
@@ -1,3 +1,4 @@
+mod channels;
 mod parameters;
 mod processing;
 mod pulse_detection;
@@ -178,7 +179,7 @@ async fn main() -> anyhow::Result<()> {
     }
 }
 
-#[instrument(skip_all, target = "otel", err(level = "WARN"))]
+#[instrument(skip_all, level = "trace", target = "otel", err(level = "WARN"))]
 fn spanned_root_as_digitizer_analog_trace_message(
     payload: &[u8],
 ) -> Result<DigitizerAnalogTraceMessage<'_>, InvalidFlatbuffer> {

--- a/trace-to-events/src/processing.rs
+++ b/trace-to-events/src/processing.rs
@@ -34,7 +34,7 @@ pub(crate) fn get_save_file_name(
     }
 }
 
-#[tracing::instrument(skip_all, fields(num_pulses = tracing::field::Empty))]
+#[tracing::instrument(skip_all, fields(num_total_pulses = tracing::field::Empty))]
 pub(crate) fn process<'a>(
     fbb: &mut FlatBufferBuilder<'a>,
     trace: &'a DigitizerAnalogTraceMessage,
@@ -107,7 +107,7 @@ pub(crate) fn process<'a>(
     let message = DigitizerEventListMessage::create(fbb, &message);
     finish_digitizer_event_list_message_buffer(fbb, message);
 
-    tracing::Span::current().record("num_pulses", events.channel.len());
+    tracing::Span::current().record("num_total_pulses", events.channel.len());
 }
 
 #[cfg(test)]

--- a/trace-to-events/src/processing.rs
+++ b/trace-to-events/src/processing.rs
@@ -1,23 +1,14 @@
 use crate::{
-    parameters::{
-        AdvancedMuonDetectorParameters, DetectorSettings, FixedThresholdDiscriminatorParameters,
-        Mode, Polarity,
-    },
-    pulse_detection::{
-        advanced_muon_detector::{AdvancedMuonAssembler, AdvancedMuonDetector},
-        threshold_detector::{ThresholdDetector, ThresholdDuration},
-        window::{Baseline, FiniteDifferences, SmoothingWindow, WindowFilter},
-        AssembleFilter, EventFilter, Real, SaveToFileFilter,
-    },
+    channels::find_channel_events, parameters::DetectorSettings, pulse_detection::Real
 };
 use rayon::prelude::*;
 use std::path::{Path, PathBuf};
 use supermusr_common::{
     spanned::{SpanWrapper, Spanned},
-    Channel, EventData, FrameNumber, Intensity, Time,
+    Channel, EventData, FrameNumber
 };
 use supermusr_streaming_types::{
-    dat2_digitizer_analog_trace_v2_generated::{ChannelTrace, DigitizerAnalogTraceMessage},
+    dat2_digitizer_analog_trace_v2_generated::DigitizerAnalogTraceMessage,
     dev2_digitizer_event_v2_generated::{
         finish_digitizer_event_list_message_buffer, DigitizerEventListMessage,
         DigitizerEventListMessageArgs,
@@ -27,191 +18,7 @@ use supermusr_streaming_types::{
 };
 use tracing::info;
 
-#[tracing::instrument(skip_all, fields(channel = trace.channel(), num_pulses))]
-fn find_channel_events(
-    metadata: &FrameMetadataV2,
-    trace: &ChannelTrace,
-    sample_time: Real,
-    detector_settings: &DetectorSettings,
-    save_options: Option<&Path>,
-) -> (Vec<Time>, Vec<Intensity>) {
-    let result = match &detector_settings.mode {
-        Mode::FixedThresholdDiscriminator(parameters) => find_fixed_threshold_events(
-            metadata,
-            trace,
-            sample_time,
-            detector_settings.polarity,
-            detector_settings.baseline as Real,
-            parameters,
-            save_options,
-        ),
-        Mode::AdvancedMuonDetector(parameters) => find_advanced_events(
-            metadata,
-            trace,
-            sample_time,
-            detector_settings.polarity,
-            detector_settings.baseline as Real,
-            parameters,
-            save_options,
-        ),
-    };
-    tracing::Span::current().record("num_pulses", result.0.len());
-    result
-}
-
-#[tracing::instrument(skip_all, level = "trace")]
-fn find_fixed_threshold_events(
-    metadata: &FrameMetadataV2,
-    trace: &ChannelTrace,
-    sample_time: Real,
-    polarity: &Polarity,
-    baseline: Real,
-    parameters: &FixedThresholdDiscriminatorParameters,
-    save_path: Option<&Path>,
-) -> (Vec<Time>, Vec<Intensity>) {
-    let sign = match polarity {
-        Polarity::Positive => 1.0,
-        Polarity::Negative => -1.0,
-    };
-    let raw = trace
-        .voltage()
-        .unwrap()
-        .into_iter()
-        .enumerate()
-        .map(|(i, v)| (i as Real * sample_time, sign * (v as Real - baseline)));
-
-    let pulses = raw
-        .clone()
-        .events(ThresholdDetector::new(&ThresholdDuration {
-            threshold: parameters.threshold,
-            duration: parameters.duration,
-            cool_off: parameters.cool_off,
-        }));
-
-    if let Some(save_path) = save_path {
-        raw.clone()
-            .save_to_file(&get_save_file_name(
-                save_path,
-                metadata.frame_number(),
-                trace.channel(),
-                "raw",
-            ))
-            .unwrap();
-
-        pulses
-            .clone()
-            .save_to_file(&get_save_file_name(
-                save_path,
-                metadata.frame_number(),
-                trace.channel(),
-                "pulses",
-            ))
-            .unwrap();
-    }
-
-    let mut time = Vec::<Time>::new();
-    let mut voltage = Vec::<Intensity>::new();
-    for pulse in pulses {
-        time.push(pulse.0 as Time);
-        voltage.push(pulse.1.pulse_height as Intensity);
-    }
-    (time, voltage)
-}
-
-#[tracing::instrument(skip_all, level = "trace")]
-fn find_advanced_events(
-    metadata: &FrameMetadataV2,
-    trace: &ChannelTrace,
-    sample_time: Real,
-    polarity: &Polarity,
-    baseline: Real,
-    parameters: &AdvancedMuonDetectorParameters,
-    save_path: Option<&Path>,
-) -> (Vec<Time>, Vec<Intensity>) {
-    let sign = match polarity {
-        Polarity::Positive => 1.0,
-        Polarity::Negative => -1.0,
-    };
-    let raw = trace
-        .voltage()
-        .unwrap()
-        .into_iter()
-        .enumerate()
-        .map(|(i, v)| (i as Real * sample_time, sign * (v as Real - baseline)));
-
-    let smoothed = raw
-        .clone()
-        .window(Baseline::new(parameters.baseline_length.unwrap_or(0), 0.1))
-        .window(SmoothingWindow::new(
-            parameters.smoothing_window_size.unwrap_or(1),
-        ))
-        .map(|(i, stats)| (i, stats.mean));
-
-    let events = smoothed
-        .clone()
-        .window(FiniteDifferences::<2>::new())
-        .events(AdvancedMuonDetector::new(
-            parameters.muon_onset,
-            parameters.muon_fall,
-            parameters.muon_termination,
-            parameters.duration,
-        ));
-
-    let pulses = events
-        .clone()
-        .assemble(AdvancedMuonAssembler::default())
-        .filter(|pulse| {
-            Option::zip(parameters.min_amplitude, pulse.peak.value)
-                .map(|(min, val)| min <= val)
-                .unwrap_or(true)
-        })
-        .filter(|pulse| {
-            Option::zip(parameters.max_amplitude, pulse.peak.value)
-                .map(|(max, val)| max >= val)
-                .unwrap_or(true)
-        });
-
-    if let Some(save_path) = save_path {
-        raw.clone()
-            .save_to_file(&get_save_file_name(
-                save_path,
-                metadata.frame_number(),
-                trace.channel(),
-                "raw",
-            ))
-            .unwrap();
-
-        smoothed
-            .clone()
-            .save_to_file(&get_save_file_name(
-                save_path,
-                metadata.frame_number(),
-                trace.channel(),
-                "smoothed",
-            ))
-            .unwrap();
-
-        pulses
-            .clone()
-            .save_to_file(&get_save_file_name(
-                save_path,
-                metadata.frame_number(),
-                trace.channel(),
-                "pulses",
-            ))
-            .unwrap();
-    }
-
-    let mut time = Vec::<Time>::new();
-    let mut voltage = Vec::<Intensity>::new();
-    for pulse in pulses {
-        time.push(pulse.steepest_rise.time.unwrap_or_default() as Time);
-        voltage.push(pulse.peak.value.unwrap_or_default() as Intensity);
-    }
-    (time, voltage)
-}
-
-fn get_save_file_name(
+pub(crate) fn get_save_file_name(
     path: &Path,
     frame_number: FrameNumber,
     channel: Channel,
@@ -244,7 +51,7 @@ pub(crate) fn process<'a>(
 
     let sample_time_in_ns: Real = 1_000_000_000.0 / trace.sample_rate() as Real;
 
-    let vec: Vec<(Channel, _)> = trace
+    let vec: Vec<(Channel, (Vec<u32>, Vec<u16>))> = trace
         .channels()
         .unwrap()
         .iter()
@@ -305,12 +112,14 @@ pub(crate) fn process<'a>(
 
 #[cfg(test)]
 mod tests {
+    use crate::{parameters::{AdvancedMuonDetectorParameters, FixedThresholdDiscriminatorParameters}, Mode, Polarity};
+
     use super::*;
     use chrono::Utc;
+    use supermusr_common::Intensity;
     use supermusr_streaming_types::{
         dat2_digitizer_analog_trace_v2_generated::{
-            finish_digitizer_analog_trace_message_buffer, root_as_digitizer_analog_trace_message,
-            ChannelTraceArgs, DigitizerAnalogTraceMessage, DigitizerAnalogTraceMessageArgs,
+            finish_digitizer_analog_trace_message_buffer, root_as_digitizer_analog_trace_message, ChannelTrace, ChannelTraceArgs, DigitizerAnalogTraceMessage, DigitizerAnalogTraceMessageArgs
         },
         dev2_digitizer_event_v2_generated::{
             digitizer_event_list_message_buffer_has_identifier,

--- a/trace-to-events/src/processing.rs
+++ b/trace-to-events/src/processing.rs
@@ -34,7 +34,7 @@ pub(crate) fn get_save_file_name(
     }
 }
 
-#[tracing::instrument(skip_all)]
+#[tracing::instrument(skip_all, fields(num_pulses))]
 pub(crate) fn process<'a>(
     fbb: &mut FlatBufferBuilder<'a>,
     trace: &'a DigitizerAnalogTraceMessage,
@@ -106,6 +106,8 @@ pub(crate) fn process<'a>(
     };
     let message = DigitizerEventListMessage::create(fbb, &message);
     finish_digitizer_event_list_message_buffer(fbb, message);
+
+    tracing::Span::current().record("num_pulses", events.channel.len());
 }
 
 #[cfg(test)]

--- a/trace-to-events/src/processing.rs
+++ b/trace-to-events/src/processing.rs
@@ -34,7 +34,7 @@ pub(crate) fn get_save_file_name(
     }
 }
 
-#[tracing::instrument(skip_all, fields(num_pulses))]
+#[tracing::instrument(skip_all, fields(num_pulses = tracing::field::Empty))]
 pub(crate) fn process<'a>(
     fbb: &mut FlatBufferBuilder<'a>,
     trace: &'a DigitizerAnalogTraceMessage,

--- a/trace-to-events/src/processing.rs
+++ b/trace-to-events/src/processing.rs
@@ -1,11 +1,9 @@
-use crate::{
-    channels::find_channel_events, parameters::DetectorSettings, pulse_detection::Real
-};
+use crate::{channels::find_channel_events, parameters::DetectorSettings, pulse_detection::Real};
 use rayon::prelude::*;
 use std::path::{Path, PathBuf};
 use supermusr_common::{
     spanned::{SpanWrapper, Spanned},
-    Channel, EventData, FrameNumber
+    Channel, EventData, FrameNumber,
 };
 use supermusr_streaming_types::{
     dat2_digitizer_analog_trace_v2_generated::DigitizerAnalogTraceMessage,
@@ -112,14 +110,19 @@ pub(crate) fn process<'a>(
 
 #[cfg(test)]
 mod tests {
-    use crate::{parameters::{AdvancedMuonDetectorParameters, FixedThresholdDiscriminatorParameters}, Mode, Polarity};
+    use crate::{
+        parameters::{AdvancedMuonDetectorParameters, FixedThresholdDiscriminatorParameters},
+        Mode, Polarity,
+    };
 
     use super::*;
     use chrono::Utc;
     use supermusr_common::Intensity;
     use supermusr_streaming_types::{
         dat2_digitizer_analog_trace_v2_generated::{
-            finish_digitizer_analog_trace_message_buffer, root_as_digitizer_analog_trace_message, ChannelTrace, ChannelTraceArgs, DigitizerAnalogTraceMessage, DigitizerAnalogTraceMessageArgs
+            finish_digitizer_analog_trace_message_buffer, root_as_digitizer_analog_trace_message,
+            ChannelTrace, ChannelTraceArgs, DigitizerAnalogTraceMessage,
+            DigitizerAnalogTraceMessageArgs,
         },
         dev2_digitizer_event_v2_generated::{
             digitizer_event_list_message_buffer_has_identifier,

--- a/trace-to-events/src/processing.rs
+++ b/trace-to-events/src/processing.rs
@@ -14,7 +14,7 @@ use supermusr_streaming_types::{
     flatbuffers::FlatBufferBuilder,
     frame_metadata_v2_generated::{FrameMetadataV2, FrameMetadataV2Args},
 };
-use tracing::info;
+use tracing::debug;
 
 pub(crate) fn get_save_file_name(
     path: &Path,
@@ -41,7 +41,7 @@ pub(crate) fn process<'a>(
     detector_settings: &DetectorSettings,
     save_options: Option<&Path>,
 ) {
-    info!(
+    debug!(
         "Dig ID: {}, Metadata: {:?}",
         trace.digitizer_id(),
         trace.metadata()

--- a/trace-to-events/src/processing.rs
+++ b/trace-to-events/src/processing.rs
@@ -49,7 +49,7 @@ pub(crate) fn process<'a>(
 
     let sample_time_in_ns: Real = 1_000_000_000.0 / trace.sample_rate() as Real;
 
-    let vec: Vec<(Channel, (Vec<u32>, Vec<u16>))> = trace
+    let vec: Vec<(Channel, _)> = trace
         .channels()
         .unwrap()
         .iter()


### PR DESCRIPTION
## Summary of changes

Changes the way we set OpenTelemetry levels and tidies up some spans.

- Removed `otel_level` cli option from all components.
- Modified OpenTelemetry filter layer to use environment variable "OTEL_LOG" to determine which level to filter crates/modules on.
- Removed references to the `otel` target and `target = "otel"` syntax in spans/events (This accounts for most files changed). This target is not really useful, though OpenTelemetry-only targets may be introduced in the future.
- In `trace-to-events`, functions processing individual channels moved to their own file `channels.rs`. This allows the observability level for these to be set via including `trace_to_events::channels=????` in `OTEL_LOG`. At present use `info` to include channels, and `warn/error/off` to exclude.
- Level of `spanned_root_as` functions changed to `trace` from `info`.
- Added `digitiser_id` tag to `Digitiser Event List` span in digitiser aggregator.

## Instruction for review/testing

- General code review
- Has been tested on simulated data
