### PR TITLE
trace-to-events: record the cumulative number of events per channel

### DIFF
--- a/trace-to-events/src/main.rs
+++ b/trace-to-events/src/main.rs
@@ -44,6 +44,8 @@ use tracing::{debug, error, info, instrument, trace, warn};
 type DigitiserEventListToBufferSender = Sender<DeliveryFuture>;
 type TrySendDigitiserEventListError = TrySendError<DeliveryFuture>;
 
+const EVENTS_FOUND_METRIC: &str = "events_found";
+
 #[derive(Debug, Parser)]
 #[clap(author, version, about)]
 struct Cli {
@@ -142,6 +144,11 @@ async fn main() -> anyhow::Result<()> {
         FAILURES,
         metrics::Unit::Count,
         "Number of failures encountered"
+    );
+    metrics::describe_counter!(
+        EVENTS_FOUND_METRIC,
+        metrics::Unit::Count,
+        "Number of events found per channel"
     );
 
     let (sender, producer_task_handle) = create_producer_task(args.send_eventlist_buffer_size)?;


### PR DESCRIPTION
## Summary of changes

Allows querying an average event rate via Prometheus (InfluxDB probably has a similar feature).

## Instruction for review/testing

- Run simulated pipeline
- `curl` the metrics endpoint of `trace-to-events`
- See that the event count increases as expected for each digitiser and channel

Closes #305 
