### PR TITLE
Fine grained separation of files in nexus writer

### DIFF
--- a/nexus-writer/src/flush_to_archive.rs
+++ b/nexus-writer/src/flush_to_archive.rs
@@ -1,0 +1,70 @@
+use crate::{NexusSettings, NexusWriterResult};
+use std::path::{Path, PathBuf};
+use tokio::{
+    signal::unix::{signal, SignalKind}, task::JoinHandle, time
+};
+use tracing::{debug, info, info_span, warn};
+
+
+#[tracing::instrument(skip_all, level = "debug")]
+fn move_file_to_archive(from_path: &Path, archive_path: &Path) -> NexusWriterResult<()> {
+    let mut to_path = archive_path.to_path_buf();
+    if let Some(file_name) = from_path.file_name() {
+        to_path.push(file_name);
+    }
+    
+    info_span!("Move to Remote Archive",
+        from_path = from_path.to_string_lossy().to_string(),
+        to_path = to_path.to_string_lossy().to_string()
+    ).in_scope(|| {
+        match std::fs::copy(from_path, to_path) {
+            Ok(bytes) => info!("File Move Succesful. {bytes} byte(s) moved."),
+            Err(e) => {
+                warn!("File Move Error {e}");
+                return Err(e);
+            },
+        };
+        if let Err(e) = std::fs::remove_file(from_path) {
+            warn!("Error removing temporary file: {e}");
+            Err(e)
+        } else {
+            Ok(())
+        }
+    })?;
+    Ok(())
+}
+
+/// If an additional archive location is set by the user,
+/// then completed runs placed in the vector `self.run_move_cache`
+/// have their nexus files asynchonously moved to that location.
+/// Afterwhich the runs are dropped.
+#[tracing::instrument(level = "debug", fields(glob_pattern))]
+pub(crate) async fn flush_to_archive(glob_pattern: &str, archive_path: &Path) -> NexusWriterResult<()> {
+    for file_path in glob::glob(glob_pattern)? {
+        move_file_to_archive(file_path?.as_path(), archive_path)?;
+    }
+    Ok(())
+}
+
+#[tracing::instrument(level = "info")]
+async fn archive_flush_task(glob_pattern: String, archive_path: PathBuf, archive_flush_interval_sec: u64) -> NexusWriterResult<()> {
+    let mut interval = tokio::time::interval(time::Duration::from_millis(archive_flush_interval_sec));
+    // Is used to await any sigint signals
+    let mut sigint = signal(SignalKind::interrupt())?;
+    
+    debug!("Finding files matched to {glob_pattern}");
+    loop {
+        tokio::select! {
+            _ = interval.tick() => flush_to_archive(&glob_pattern, &archive_path).await?,
+            _ = sigint.recv() => return Ok(())
+        }
+    }
+}
+
+#[tracing::instrument(skip_all, level = "info")]
+pub(crate) fn create_archive_flush_task(nexus_settings: &NexusSettings, archive_flush_interval_sec: u64) -> NexusWriterResult<Option<JoinHandle<NexusWriterResult<()>>>> {
+    let local_completed_glob_pattern = nexus_settings.get_local_completed_glob_pattern()?;
+    Ok(nexus_settings.get_archive_path().map(|archive_path|
+        tokio::spawn(archive_flush_task(local_completed_glob_pattern, archive_path.to_path_buf(), archive_flush_interval_sec))
+    ))
+}

--- a/nexus-writer/src/flush_to_archive.rs
+++ b/nexus-writer/src/flush_to_archive.rs
@@ -1,47 +1,46 @@
-use crate::{NexusSettings, NexusWriterResult};
+use crate::{
+    nexus::{ErrorCodeLocation, NexusWriterError},
+    NexusSettings, NexusWriterResult,
+};
 use std::path::{Path, PathBuf};
 use tokio::{
     signal::unix::{signal, SignalKind},
     task::JoinHandle,
     time::Interval,
 };
-use tracing::{debug, info, info_span, warn};
+use tracing::{debug, info, warn};
 
-#[tracing::instrument(skip_all, level = "debug")]
+/// Moves a single file to the archive
+#[tracing::instrument(skip_all, level = "info", fields(
+    from_path = from_path.to_string_lossy().to_string(),
+    to_path
+))]
 fn move_file_to_archive(from_path: &Path, archive_path: &Path) -> NexusWriterResult<()> {
     let mut to_path = archive_path.to_path_buf();
     if let Some(file_name) = from_path.file_name() {
         to_path.push(file_name);
+        tracing::Span::current().record("to_path", to_path.to_string_lossy().to_string());
     }
 
-    info_span!(
-        "Move to Remote Archive",
-        from_path = from_path.to_string_lossy().to_string(),
-        to_path = to_path.to_string_lossy().to_string()
-    )
-    .in_scope(|| {
-        match std::fs::copy(from_path, to_path) {
-            Ok(bytes) => info!("File Move Succesful. {bytes} byte(s) moved."),
-            Err(e) => {
-                warn!("File Move Error {e}");
-                return Err(e);
-            }
-        };
-        if let Err(e) = std::fs::remove_file(from_path) {
-            warn!("Error removing temporary file: {e}");
-            Err(e)
-        } else {
-            Ok(())
+    match std::fs::copy(from_path, to_path) {
+        Ok(bytes) => info!("File Move Succesful. {bytes} byte(s) moved."),
+        Err(e) => {
+            warn!("File Move Error {e}");
+            return Err(e.into());
         }
-    })?;
+    };
+    if let Err(e) = std::fs::remove_file(from_path) {
+        warn!("Error removing temporary file: {e}");
+        return Err(e.into());
+    }
     Ok(())
 }
 
-/// If an additional archive location is set by the user,
-/// then completed runs placed in the vector `self.run_move_cache`
-/// have their nexus files asynchonously moved to that location.
-/// Afterwhich the runs are dropped.
-#[tracing::instrument(level = "debug", fields(glob_pattern=glob_pattern,archive_path=archive_path.to_string_lossy().to_string()))]
+/// Flushes all files in the local completed directory to the archive
+#[tracing::instrument(level = "debug", fields(
+    glob_pattern = glob_pattern,
+    archive_path = archive_path.to_string_lossy().to_string()
+))]
 pub(crate) async fn flush_to_archive(
     glob_pattern: &str,
     archive_path: &Path,
@@ -52,7 +51,11 @@ pub(crate) async fn flush_to_archive(
     Ok(())
 }
 
-#[tracing::instrument(skip_all, level = "info", fields(glob_pattern=glob_pattern,archive_path=archive_path.to_string_lossy().to_string()))]
+/// This task periodically moves any files in the completed directory to the archive
+#[tracing::instrument(skip_all, level = "info", fields(
+    glob_pattern = glob_pattern,
+    archive_path = archive_path.to_string_lossy().to_string()
+))]
 async fn archive_flush_task(
     glob_pattern: String,
     archive_path: PathBuf,
@@ -70,11 +73,20 @@ async fn archive_flush_task(
     }
 }
 
+/// If the user specified an archive path,
+/// creates the archive flush task and returns the JoinHandle
+/// Otherwise returns None
 #[tracing::instrument(skip_all, level = "info")]
 pub(crate) fn create_archive_flush_task(
     nexus_settings: &NexusSettings,
 ) -> NexusWriterResult<Option<JoinHandle<NexusWriterResult<()>>>> {
-    let local_completed_glob_pattern = nexus_settings.get_local_completed_glob_pattern()?;
+    let local_completed_glob_pattern =
+        nexus_settings
+            .get_local_completed_glob_pattern()
+            .map_err(|path| NexusWriterError::CannotConvertPath {
+                path: path.to_path_buf(),
+                location: ErrorCodeLocation::FlushToArchive,
+            })?;
     Ok(nexus_settings.get_archive_path().map(|archive_path| {
         tokio::spawn(archive_flush_task(
             local_completed_glob_pattern,

--- a/nexus-writer/src/flush_to_archive.rs
+++ b/nexus-writer/src/flush_to_archive.rs
@@ -1,10 +1,11 @@
 use crate::{NexusSettings, NexusWriterResult};
 use std::path::{Path, PathBuf};
 use tokio::{
-    signal::unix::{signal, SignalKind}, task::JoinHandle, time::Interval
+    signal::unix::{signal, SignalKind},
+    task::JoinHandle,
+    time::Interval,
 };
 use tracing::{debug, info, info_span, warn};
-
 
 #[tracing::instrument(skip_all, level = "debug")]
 fn move_file_to_archive(from_path: &Path, archive_path: &Path) -> NexusWriterResult<()> {
@@ -12,17 +13,19 @@ fn move_file_to_archive(from_path: &Path, archive_path: &Path) -> NexusWriterRes
     if let Some(file_name) = from_path.file_name() {
         to_path.push(file_name);
     }
-    
-    info_span!("Move to Remote Archive",
+
+    info_span!(
+        "Move to Remote Archive",
         from_path = from_path.to_string_lossy().to_string(),
         to_path = to_path.to_string_lossy().to_string()
-    ).in_scope(|| {
+    )
+    .in_scope(|| {
         match std::fs::copy(from_path, to_path) {
             Ok(bytes) => info!("File Move Succesful. {bytes} byte(s) moved."),
             Err(e) => {
                 warn!("File Move Error {e}");
                 return Err(e);
-            },
+            }
         };
         if let Err(e) = std::fs::remove_file(from_path) {
             warn!("Error removing temporary file: {e}");
@@ -39,7 +42,10 @@ fn move_file_to_archive(from_path: &Path, archive_path: &Path) -> NexusWriterRes
 /// have their nexus files asynchonously moved to that location.
 /// Afterwhich the runs are dropped.
 #[tracing::instrument(level = "debug", fields(glob_pattern=glob_pattern,archive_path=archive_path.to_string_lossy().to_string()))]
-pub(crate) async fn flush_to_archive(glob_pattern: &str, archive_path: &Path) -> NexusWriterResult<()> {
+pub(crate) async fn flush_to_archive(
+    glob_pattern: &str,
+    archive_path: &Path,
+) -> NexusWriterResult<()> {
     for file_path in glob::glob(glob_pattern)? {
         move_file_to_archive(file_path?.as_path(), archive_path)?;
     }
@@ -47,11 +53,14 @@ pub(crate) async fn flush_to_archive(glob_pattern: &str, archive_path: &Path) ->
 }
 
 #[tracing::instrument(skip_all, level = "info", fields(glob_pattern=glob_pattern,archive_path=archive_path.to_string_lossy().to_string()))]
-async fn archive_flush_task(glob_pattern: String, archive_path: PathBuf, mut interval: Interval) -> NexusWriterResult<()> {
-    //let mut interval = tokio::time::interval(time::Duration::from_secs(archive_flush_interval_sec));
+async fn archive_flush_task(
+    glob_pattern: String,
+    archive_path: PathBuf,
+    mut interval: Interval,
+) -> NexusWriterResult<()> {
     // Is used to await any sigint signals
     let mut sigint = signal(SignalKind::interrupt())?;
-    
+
     debug!("Finding files matched to {glob_pattern}");
     loop {
         tokio::select! {
@@ -62,9 +71,15 @@ async fn archive_flush_task(glob_pattern: String, archive_path: PathBuf, mut int
 }
 
 #[tracing::instrument(skip_all, level = "info")]
-pub(crate) fn create_archive_flush_task(nexus_settings: &NexusSettings) -> NexusWriterResult<Option<JoinHandle<NexusWriterResult<()>>>> {
+pub(crate) fn create_archive_flush_task(
+    nexus_settings: &NexusSettings,
+) -> NexusWriterResult<Option<JoinHandle<NexusWriterResult<()>>>> {
     let local_completed_glob_pattern = nexus_settings.get_local_completed_glob_pattern()?;
-    Ok(nexus_settings.get_archive_path().map(|archive_path|
-        tokio::spawn(archive_flush_task(local_completed_glob_pattern, archive_path.to_path_buf(), nexus_settings.get_archive_flush_interval()))
-    ))
+    Ok(nexus_settings.get_archive_path().map(|archive_path| {
+        tokio::spawn(archive_flush_task(
+            local_completed_glob_pattern,
+            archive_path.to_path_buf(),
+            nexus_settings.get_archive_flush_interval(),
+        ))
+    }))
 }

--- a/nexus-writer/src/main.rs
+++ b/nexus-writer/src/main.rs
@@ -205,7 +205,7 @@ async fn main() -> anyhow::Result<()> {
         metrics::Unit::Count,
         "Number of failures encountered"
     );
-    
+
     let run_ttl =
         Duration::try_milliseconds(args.cache_run_ttl_ms).expect("Conversion is possible");
 

--- a/nexus-writer/src/main.rs
+++ b/nexus-writer/src/main.rs
@@ -79,15 +79,15 @@ struct Cli {
     #[clap(long)]
     configuration_options: Option<String>,
 
-    /// Local path in which the NeXus file is held whilst being written
+    /// Whilst the nexus file is being written, it is stored in "local_path/temp", and moved to "local_path/completed" once it is finished. The "temp" and "completed" folders are created automatically.
     #[clap(long)]
     local_path: PathBuf,
 
-    /// Remote path the NeXus file will be moved to once completed. If not present, no move takes place.
+    /// Remote path the NeXus file will eventually be moved to after it is finished. If not set, no move takes place.
     #[clap(long)]
     archive_path: Option<PathBuf>,
 
-    /// How often in seconds completed run files are flushed to the remote archive
+    /// How often in seconds completed run files are flushed to the remote archive (this does nothing if "archive_path" is not set)
     #[clap(long, default_value = "60")]
     archive_flush_interval_sec: u64,
 

--- a/nexus-writer/src/main.rs
+++ b/nexus-writer/src/main.rs
@@ -163,13 +163,15 @@ async fn main() -> anyhow::Result<()> {
         args.frame_list_chunk_size,
         args.event_list_chunk_size,
         args.archive_path.as_deref(),
+        args.archive_flush_interval_sec,
     );
 
     let mut cache_poll_interval =
         tokio::time::interval(time::Duration::from_millis(args.cache_poll_interval_ms));
 
-    let archive_flush_task = create_archive_flush_task(&nexus_settings, args.archive_flush_interval_sec)?;
+    let archive_flush_task = create_archive_flush_task(&nexus_settings)?;
 
+    //  Setup the directory structure, if it doesn't already exist.
     create_dir_all(nexus_settings.get_local_temp_path())?;
     create_dir_all(nexus_settings.get_local_completed_path())?;
     if let Some(archive_path) = nexus_settings.get_archive_path() {

--- a/nexus-writer/src/main.rs
+++ b/nexus-writer/src/main.rs
@@ -205,6 +205,7 @@ async fn main() -> anyhow::Result<()> {
         metrics::Unit::Count,
         "Number of failures encountered"
     );
+    
     let run_ttl =
         Duration::try_milliseconds(args.cache_run_ttl_ms).expect("Conversion is possible");
 

--- a/nexus-writer/src/main.rs
+++ b/nexus-writer/src/main.rs
@@ -75,7 +75,7 @@ struct Cli {
     #[clap(long)]
     frame_event_topic: String,
 
-    /// Optional configuration options to include in the nexus file
+    /// Optional data pipeline configuration options to include in the nexus file. If present written to attribute `/raw_data_1/program_name/configuration`.
     #[clap(long)]
     configuration_options: Option<String>,
 

--- a/nexus-writer/src/main.rs
+++ b/nexus-writer/src/main.rs
@@ -79,7 +79,7 @@ struct Cli {
     #[clap(long)]
     configuration_options: Option<String>,
 
-    /// Whilst the nexus file is being written, it is stored in "local_path/temp", and moved to "local_path/completed" once it is finished. The "temp" and "completed" folders are created automatically.
+    /// Whilst the nexus file is being written, it is stored in "local-path/", and moved to "local-path/completed/" once it is finished. The "local-path/" and "local-path/completed/" folders are created automatically.
     #[clap(long)]
     local_path: PathBuf,
 
@@ -172,7 +172,7 @@ async fn main() -> anyhow::Result<()> {
     let archive_flush_task = create_archive_flush_task(&nexus_settings)?;
 
     //  Setup the directory structure, if it doesn't already exist.
-    create_dir_all(nexus_settings.get_local_temp_path())?;
+    create_dir_all(nexus_settings.get_local_path())?;
     create_dir_all(nexus_settings.get_local_completed_path())?;
     if let Some(archive_path) = nexus_settings.get_archive_path() {
         create_dir_all(archive_path)?;

--- a/nexus-writer/src/main.rs
+++ b/nexus-writer/src/main.rs
@@ -1,5 +1,5 @@
-mod nexus;
 mod flush_to_archive;
+mod nexus;
 
 use chrono::Duration;
 use clap::Parser;
@@ -180,10 +180,7 @@ async fn main() -> anyhow::Result<()> {
 
     let nexus_configuration = NexusConfiguration::new(args.configuration_options);
 
-    let mut nexus_engine = NexusEngine::new(
-        Some(nexus_settings),
-        nexus_configuration,
-    );
+    let mut nexus_engine = NexusEngine::new(Some(nexus_settings), nexus_configuration);
     nexus_engine.resume_partial_runs()?;
 
     // Install exporter and register metrics

--- a/nexus-writer/src/main.rs
+++ b/nexus-writer/src/main.rs
@@ -81,10 +81,6 @@ struct Cli {
     #[clap(long)]
     local_path: PathBuf,
 
-    /// Local path where the NeXus file should be moved to after completion
-    #[clap(long)]
-    local_holding_path: PathBuf,
-
     /// Remote path the NeXus file will be moved to once completed. If not present, no move takes place.
     #[clap(long)]
     archive_path: Option<PathBuf>,
@@ -161,17 +157,16 @@ async fn main() -> anyhow::Result<()> {
     );
 
     let nexus_settings = NexusSettings::new(
+        args.local_path.as_path(),
         args.frame_list_chunk_size,
         args.event_list_chunk_size,
-        &args.local_holding_path,
         args.archive_path.as_deref(),
     );
 
     let nexus_configuration = NexusConfiguration::new(args.configuration_options);
 
     let mut nexus_engine = NexusEngine::new(
-        Some(&args.local_path.as_path()),
-        nexus_settings,
+        Some(nexus_settings),
         nexus_configuration,
     );
     nexus_engine.resume_partial_runs()?;

--- a/nexus-writer/src/nexus/engine.rs
+++ b/nexus-writer/src/nexus/engine.rs
@@ -458,7 +458,7 @@ mod test {
 
         assert!(run.unwrap().is_message_timestamp_valid(&timestamp));
 
-        nexus.flush(&Duration::zero());
+        let _ = nexus.flush(&Duration::zero());
         assert_eq!(nexus.cache_iter().len(), 0);
     }
 
@@ -492,7 +492,7 @@ mod test {
 
         assert_eq!(nexus.cache_iter().len(), 2);
 
-        nexus.flush(&Duration::zero());
+        let _ = nexus.flush(&Duration::zero());
         assert_eq!(nexus.cache_iter().len(), 0);
     }
 }

--- a/nexus-writer/src/nexus/engine.rs
+++ b/nexus-writer/src/nexus/engine.rs
@@ -171,7 +171,7 @@ impl NexusEngine {
             last_run.set_stop_if_valid(
                 self.nexus_settings
                     .as_ref()
-                    .map(NexusSettings::get_local_temp_path),
+                    .map(NexusSettings::get_local_path),
                 data,
             )?;
 
@@ -234,7 +234,7 @@ impl NexusEngine {
                 }
                 if let Some(nexus_settings) = self.nexus_settings.as_ref() {
                     run.move_to_completed(
-                        nexus_settings.get_local_temp_path(),
+                        nexus_settings.get_local_path(),
                         nexus_settings.get_local_completed_path(),
                     )?;
                 }

--- a/nexus-writer/src/nexus/engine.rs
+++ b/nexus-writer/src/nexus/engine.rs
@@ -521,6 +521,7 @@ pub(crate) struct NexusSettings {
     pub(crate) runloglist_chunk_size: usize,
     pub(crate) seloglist_chunk_size: usize,
     pub(crate) alarmlist_chunk_size: usize,
+    holding_path: PathBuf,
     archive_path: Option<PathBuf>,
 }
 
@@ -528,6 +529,7 @@ impl NexusSettings {
     pub(crate) fn new(
         framelist_chunk_size: usize,
         eventlist_chunk_size: usize,
+        holding_path: &Path,
         archive_path: Option<&Path>,
     ) -> Self {
         Self {
@@ -537,6 +539,7 @@ impl NexusSettings {
             runloglist_chunk_size: 64,
             seloglist_chunk_size: 1024,
             alarmlist_chunk_size: 32,
+            holding_path: holding_path.to_path_buf(),
             archive_path: archive_path.map(Path::to_owned),
         }
     }

--- a/nexus-writer/src/nexus/engine.rs
+++ b/nexus-writer/src/nexus/engine.rs
@@ -244,30 +244,6 @@ impl NexusEngine {
         }
         Ok(())
     }
-    /*
-       /// If an additional archive location is set by the user,
-       /// then completed runs placed in the vector `self.run_move_cache`
-       /// have their nexus files asynchonously moved to that location.
-       /// Afterwhich the runs are dropped.
-       #[tracing::instrument(skip_all, level = "debug")]
-       pub(crate) async fn flush_move_cache_blah(&mut self) {
-           if let Some(nexus_settings) = self.nexus_settings.as_ref() {
-               if let Some(archive_path) = nexus_settings.get_archive_path() {
-                   for run in self.run_move_cache.iter() {
-                       match run.move_to_archive(nexus_settings.get_local_temp_path(), archive_path) {
-                           Ok(move_to_archive) => move_to_archive.await,
-                           Err(e) => warn!("Error Moving to Archive {e}"),
-                       }
-                   }
-               }
-           }
-           self.run_move_cache.clear();
-       }
-       #[tracing::instrument(skip_all, level = "info", name = "Closing", fields(num_runs_to_archive = self.run_move_cache.len()))]
-       pub(crate) async fn close(mut self) {
-           //self.flush_move_cache().await;
-       }
-    */
 }
 
 #[cfg(test)]

--- a/nexus-writer/src/nexus/error.rs
+++ b/nexus-writer/src/nexus/error.rs
@@ -43,6 +43,8 @@ pub(crate) enum NexusWriterError {
     GlobPattern(#[from] PatternError),
     #[error("Glob Error: {0}")]
     Glob(#[from] GlobError),
+    #[error("IO Error: {0}")]
+    IO(#[from] std::io::Error),
     #[error("Integer Conversion Error")]
     TryFromInt(#[from] TryFromIntError),
     #[error("Start Time {int} Out of Range for DateTime at {location}")]

--- a/nexus-writer/src/nexus/error.rs
+++ b/nexus-writer/src/nexus/error.rs
@@ -8,20 +8,22 @@ pub(crate) type NexusWriterResult<T> = Result<T, NexusWriterError>;
 
 #[derive(Debug, Error)]
 pub(crate) enum ErrorCodeLocation {
-    #[error("set_stop_if_valid")]
-    SetStopIfValid,
-    #[error("set_aborted_run")]
-    SetAbortedRun,
+    #[error("flush_to_archive")]
+    FlushToArchive,
     #[error("RunParameters::new")]
     NewRunParamemters,
-    #[error("stop_command")]
-    StopCommand,
     #[error("process_event_list")]
     ProcessEventList,
-    #[error("resume_partial_runs local directory path")]
-    ResumePartialRunsLocalDirectoryPath,
     #[error("resume_partial_runs file path")]
     ResumePartialRunsFilePath,
+    #[error("resume_partial_runs local directory path")]
+    ResumePartialRunsLocalDirectoryPath,
+    #[error("set_aborted_run")]
+    SetAbortedRun,
+    #[error("set_stop_if_valid")]
+    SetStopIfValid,
+    #[error("stop_command")]
+    StopCommand,
 }
 
 #[derive(Debug, Error)]

--- a/nexus-writer/src/nexus/mod.rs
+++ b/nexus-writer/src/nexus/mod.rs
@@ -8,9 +8,9 @@ mod settings;
 use chrono::{DateTime, Utc};
 pub(crate) use engine::NexusEngine;
 pub(crate) use error::NexusWriterResult;
-pub(crate) use settings::NexusSettings;
 pub(crate) use run::Run;
 pub(crate) use run_parameters::{NexusConfiguration, RunParameters};
+pub(crate) use settings::NexusSettings;
 
 pub(crate) const DATETIME_FORMAT: &str = "%Y-%m-%dT%H:%M:%S%z";
 pub(crate) type NexusDateTime = DateTime<Utc>;

--- a/nexus-writer/src/nexus/mod.rs
+++ b/nexus-writer/src/nexus/mod.rs
@@ -7,6 +7,7 @@ mod settings;
 
 use chrono::{DateTime, Utc};
 pub(crate) use engine::NexusEngine;
+pub(crate) use error::NexusWriterResult;
 pub(crate) use settings::NexusSettings;
 pub(crate) use run::Run;
 pub(crate) use run_parameters::{NexusConfiguration, RunParameters};

--- a/nexus-writer/src/nexus/mod.rs
+++ b/nexus-writer/src/nexus/mod.rs
@@ -7,7 +7,7 @@ mod settings;
 
 use chrono::{DateTime, Utc};
 pub(crate) use engine::NexusEngine;
-pub(crate) use error::NexusWriterResult;
+pub(crate) use error::{ErrorCodeLocation, NexusWriterError, NexusWriterResult};
 pub(crate) use run::Run;
 pub(crate) use run_parameters::{NexusConfiguration, RunParameters};
 pub(crate) use settings::NexusSettings;

--- a/nexus-writer/src/nexus/mod.rs
+++ b/nexus-writer/src/nexus/mod.rs
@@ -3,11 +3,13 @@ mod error;
 mod hdf5_file;
 mod run;
 mod run_parameters;
+mod settings;
 
 use chrono::{DateTime, Utc};
-pub(crate) use engine::{NexusConfiguration, NexusEngine, NexusSettings};
+pub(crate) use engine::NexusEngine;
+pub(crate) use settings::NexusSettings;
 pub(crate) use run::Run;
-pub(crate) use run_parameters::RunParameters;
+pub(crate) use run_parameters::{NexusConfiguration, RunParameters};
 
 pub(crate) const DATETIME_FORMAT: &str = "%Y-%m-%dT%H:%M:%S%z";
 pub(crate) type NexusDateTime = DateTime<Utc>;

--- a/nexus-writer/src/nexus/run.rs
+++ b/nexus-writer/src/nexus/run.rs
@@ -127,7 +127,7 @@ impl Run {
     pub(crate) fn push_selogdata(
         &mut self,
         nexus_settings: Option<&NexusSettings>,
-        logdata: se00_SampleEnvironmentData,
+        logdata: SampleEnvironmentLog,
     ) -> NexusWriterResult<()> {
         if let Some(nexus_settings) = nexus_settings {
             let mut hdf5 =

--- a/nexus-writer/src/nexus/run.rs
+++ b/nexus-writer/src/nexus/run.rs
@@ -54,6 +54,9 @@ impl Run {
         &self.parameters
     }
 
+    /// This method renames the path of LOCAL_PATH/temp/FILENAME.nxs to LOCAL_PATH/completed/FILENAME.nxs
+    /// As these paths are on the same mount, no actual file move occurs,
+    /// So this does not need to be async [citation needed].
     pub(crate) fn move_to_completed(
         &self,
         temp_path: &Path,

--- a/nexus-writer/src/nexus/run.rs
+++ b/nexus-writer/src/nexus/run.rs
@@ -28,7 +28,7 @@ impl Run {
             let mut hdf5 = RunFile::new_runfile(
                 nexus_settings.get_local_temp_path(),
                 &parameters.run_name,
-                &nexus_settings,
+                nexus_settings,
             )?;
             hdf5.init(&parameters, nexus_configuration)?;
             hdf5.close()?;
@@ -61,7 +61,7 @@ impl Run {
 
     /// This method renames the path of LOCAL_PATH/temp/FILENAME.nxs to LOCAL_PATH/completed/FILENAME.nxs
     /// As these paths are on the same mount, no actual file move occurs,
-    /// So this does not need to be async [citation needed].
+    /// So this does not need to be async.
     pub(crate) fn move_to_completed(
         &self,
         temp_path: &Path,
@@ -141,7 +141,7 @@ impl Run {
                 nexus_settings.get_local_temp_path(),
                 &self.parameters.run_name,
             )?;
-            hdf5.push_alarm_to_runfile(alarm, &self.parameters.collect_from, &nexus_settings)?;
+            hdf5.push_alarm_to_runfile(alarm, &self.parameters.collect_from, nexus_settings)?;
             hdf5.close()?;
         }
 
@@ -182,7 +182,7 @@ impl Run {
             hdf5.push_frame_eventlist_message_to_runfile(message)?;
 
             if !message.complete() {
-                hdf5.push_incomplete_frame_warning(message, &nexus_settings)?;
+                hdf5.push_incomplete_frame_warning(message, nexus_settings)?;
             }
 
             hdf5.close()?;

--- a/nexus-writer/src/nexus/run.rs
+++ b/nexus-writer/src/nexus/run.rs
@@ -2,14 +2,14 @@ use super::{
     error::NexusWriterResult, hdf5_file::RunFile, NexusConfiguration, NexusDateTime, NexusSettings, RunParameters
 };
 use chrono::{Duration, Utc};
-use std::{fs::create_dir_all, future::Future, io, path::Path};
+use std::{future::Future, io, path::Path};
 use supermusr_common::spanned::{SpanOnce, SpanOnceError, Spanned, SpannedAggregator, SpannedMut};
 use supermusr_streaming_types::{
     aev2_frame_assembled_event_v2_generated::FrameAssembledEventListMessage,
     ecs_6s4t_run_stop_generated::RunStop, ecs_al00_alarm_generated::Alarm,
     ecs_f144_logdata_generated::f144_LogData, ecs_se00_data_generated::se00_SampleEnvironmentData,
 };
-use tracing::{info, info_span, warn, Span};
+use tracing::{error, info, info_span, warn, Span};
 
 pub(crate) struct Run {
     span: SpanOnce,
@@ -24,7 +24,7 @@ impl Run {
         nexus_configuration: &NexusConfiguration,
     ) -> NexusWriterResult<Self> {
         if let Some(nexus_settings) = nexus_settings {
-            let mut hdf5 = RunFile::new_runfile(nexus_settings.get_local_current_path(), &parameters.run_name, &nexus_settings)?;
+            let mut hdf5 = RunFile::new_runfile(nexus_settings.get_local_temp_path(), &parameters.run_name, &nexus_settings)?;
             hdf5.init(&parameters, nexus_configuration)?;
             hdf5.close()?;
         }
@@ -39,7 +39,7 @@ impl Run {
         nexus_settings: &NexusSettings,
         filename: &str,
     ) -> NexusWriterResult<Self> {
-        let mut run = RunFile::open_runfile(nexus_settings.get_local_current_path(), filename)?;
+        let mut run = RunFile::open_runfile(nexus_settings.get_local_temp_path(), filename)?;
         let parameters = run.extract_run_parameters()?;
         run.push_run_resumed_warning(&Utc::now(), &parameters.collect_from, nexus_settings)?;
         run.close()?;
@@ -54,14 +54,37 @@ impl Run {
         &self.parameters
     }
 
+    pub(crate) fn move_to_completed(
+        &self,
+        temp_path: &Path,
+        completed_path: &Path
+    ) -> io::Result<()> {
+        let from_path = RunParameters::get_hdf5_filename(temp_path, &self.parameters.run_name);
+        let to_path = RunParameters::get_hdf5_filename(completed_path, &self.parameters.run_name);
+        
+        info_span!("Move To Completed",
+            from_path = from_path.to_string_lossy().to_string(),
+            to_path = to_path.to_string_lossy().to_string()
+        ).in_scope(|| {
+            match std::fs::rename(from_path, to_path) {
+                Ok(()) => {
+                    info!("File Move Succesful.");
+                    Ok(())
+                }
+                Err(e) => {
+                    error!("File Move Error {e}");
+                    Err(e)
+                }
+            }
+        })
+    }
+
     #[tracing::instrument(skip_all, level = "info")]
     pub(crate) fn move_to_archive(
         &self,
         local_name: &Path,
         archive_name: &Path,
     ) -> io::Result<impl Future<Output = ()>> {
-        create_dir_all(archive_name)?;
-
         let from_path = RunParameters::get_hdf5_filename(local_name, &self.parameters.run_name);
         let to_path = RunParameters::get_hdf5_filename(archive_name, &self.parameters.run_name);
 
@@ -87,7 +110,7 @@ impl Run {
         logdata: &f144_LogData,
     ) -> NexusWriterResult<()> {
         if let Some(nexus_settings) = nexus_settings {
-            let mut hdf5 = RunFile::open_runfile(nexus_settings.get_local_current_path(), &self.parameters.run_name)?;
+            let mut hdf5 = RunFile::open_runfile(nexus_settings.get_local_temp_path(), &self.parameters.run_name)?;
             hdf5.push_logdata_to_runfile(logdata, &self.parameters.collect_from, nexus_settings)?;
             hdf5.close()?;
         }
@@ -103,7 +126,7 @@ impl Run {
         alarm: Alarm,
     ) -> NexusWriterResult<()> {
         if let Some(nexus_settings) = nexus_settings {
-            let mut hdf5 = RunFile::open_runfile(nexus_settings.get_local_current_path(), &self.parameters.run_name)?;
+            let mut hdf5 = RunFile::open_runfile(nexus_settings.get_local_temp_path(), &self.parameters.run_name)?;
             hdf5.push_alarm_to_runfile(alarm, &self.parameters.collect_from, &nexus_settings)?;
             hdf5.close()?;
         }
@@ -119,7 +142,7 @@ impl Run {
         logdata: se00_SampleEnvironmentData,
     ) -> NexusWriterResult<()> {
         if let Some(nexus_settings) = nexus_settings {
-            let mut hdf5 = RunFile::open_runfile(nexus_settings.get_local_current_path(), &self.parameters.run_name)?;
+            let mut hdf5 = RunFile::open_runfile(nexus_settings.get_local_temp_path(), &self.parameters.run_name)?;
             hdf5.push_selogdata(logdata, &self.parameters.collect_from, nexus_settings)?;
             hdf5.close()?;
         }
@@ -135,7 +158,7 @@ impl Run {
         message: &FrameAssembledEventListMessage
     ) -> NexusWriterResult<()> {
         if let Some(nexus_settings) = nexus_settings {
-            let mut hdf5 = RunFile::open_runfile(nexus_settings.get_local_current_path(), &self.parameters.run_name)?;
+            let mut hdf5 = RunFile::open_runfile(nexus_settings.get_local_temp_path(), &self.parameters.run_name)?;
             hdf5.push_frame_eventlist_message_to_runfile(message)?;
 
             if !message.complete() {
@@ -189,7 +212,7 @@ impl Run {
         self.parameters.set_aborted_run(absolute_stop_time_ms)?;
 
         if let Some(nexus_settings) = nexus_settings {
-            let mut hdf5 = RunFile::open_runfile(nexus_settings.get_local_current_path(), &self.parameters.run_name)?;
+            let mut hdf5 = RunFile::open_runfile(nexus_settings.get_local_temp_path(), &self.parameters.run_name)?;
 
             let collect_until = self
                 .parameters

--- a/nexus-writer/src/nexus/run.rs
+++ b/nexus-writer/src/nexus/run.rs
@@ -26,7 +26,7 @@ impl Run {
     ) -> NexusWriterResult<Self> {
         if let Some(nexus_settings) = nexus_settings {
             let mut hdf5 = RunFile::new_runfile(
-                nexus_settings.get_local_temp_path(),
+                nexus_settings.get_local_path(),
                 &parameters.run_name,
                 nexus_settings,
             )?;
@@ -44,7 +44,7 @@ impl Run {
         nexus_settings: &NexusSettings,
         filename: &str,
     ) -> NexusWriterResult<Self> {
-        let mut run = RunFile::open_runfile(nexus_settings.get_local_temp_path(), filename)?;
+        let mut run = RunFile::open_runfile(nexus_settings.get_local_path(), filename)?;
         let parameters = run.extract_run_parameters()?;
         run.push_run_resumed_warning(&Utc::now(), &parameters.collect_from, nexus_settings)?;
         run.close()?;
@@ -94,10 +94,8 @@ impl Run {
         logdata: &f144_LogData,
     ) -> NexusWriterResult<()> {
         if let Some(nexus_settings) = nexus_settings {
-            let mut hdf5 = RunFile::open_runfile(
-                nexus_settings.get_local_temp_path(),
-                &self.parameters.run_name,
-            )?;
+            let mut hdf5 =
+                RunFile::open_runfile(nexus_settings.get_local_path(), &self.parameters.run_name)?;
             hdf5.push_logdata_to_runfile(logdata, &self.parameters.collect_from, nexus_settings)?;
             hdf5.close()?;
         }
@@ -113,10 +111,8 @@ impl Run {
         alarm: Alarm,
     ) -> NexusWriterResult<()> {
         if let Some(nexus_settings) = nexus_settings {
-            let mut hdf5 = RunFile::open_runfile(
-                nexus_settings.get_local_temp_path(),
-                &self.parameters.run_name,
-            )?;
+            let mut hdf5 =
+                RunFile::open_runfile(nexus_settings.get_local_path(), &self.parameters.run_name)?;
             hdf5.push_alarm_to_runfile(alarm, &self.parameters.collect_from, nexus_settings)?;
             hdf5.close()?;
         }
@@ -132,10 +128,8 @@ impl Run {
         logdata: se00_SampleEnvironmentData,
     ) -> NexusWriterResult<()> {
         if let Some(nexus_settings) = nexus_settings {
-            let mut hdf5 = RunFile::open_runfile(
-                nexus_settings.get_local_temp_path(),
-                &self.parameters.run_name,
-            )?;
+            let mut hdf5 =
+                RunFile::open_runfile(nexus_settings.get_local_path(), &self.parameters.run_name)?;
             hdf5.push_selogdata(logdata, &self.parameters.collect_from, nexus_settings)?;
             hdf5.close()?;
         }
@@ -151,10 +145,8 @@ impl Run {
         message: &FrameAssembledEventListMessage,
     ) -> NexusWriterResult<()> {
         if let Some(nexus_settings) = nexus_settings {
-            let mut hdf5 = RunFile::open_runfile(
-                nexus_settings.get_local_temp_path(),
-                &self.parameters.run_name,
-            )?;
+            let mut hdf5 =
+                RunFile::open_runfile(nexus_settings.get_local_path(), &self.parameters.run_name)?;
             hdf5.push_frame_eventlist_message_to_runfile(message)?;
 
             if !message.complete() {
@@ -208,10 +200,8 @@ impl Run {
         self.parameters.set_aborted_run(absolute_stop_time_ms)?;
 
         if let Some(nexus_settings) = nexus_settings {
-            let mut hdf5 = RunFile::open_runfile(
-                nexus_settings.get_local_temp_path(),
-                &self.parameters.run_name,
-            )?;
+            let mut hdf5 =
+                RunFile::open_runfile(nexus_settings.get_local_path(), &self.parameters.run_name)?;
 
             let collect_until = self
                 .parameters

--- a/nexus-writer/src/nexus/run.rs
+++ b/nexus-writer/src/nexus/run.rs
@@ -1,5 +1,6 @@
 use super::{
-    error::NexusWriterResult, hdf5_file::RunFile, NexusConfiguration, NexusDateTime, NexusSettings, RunParameters
+    error::NexusWriterResult, hdf5_file::RunFile, NexusConfiguration, NexusDateTime, NexusSettings,
+    RunParameters,
 };
 use chrono::{Duration, Utc};
 use std::{future::Future, io, path::Path};
@@ -24,7 +25,11 @@ impl Run {
         nexus_configuration: &NexusConfiguration,
     ) -> NexusWriterResult<Self> {
         if let Some(nexus_settings) = nexus_settings {
-            let mut hdf5 = RunFile::new_runfile(nexus_settings.get_local_temp_path(), &parameters.run_name, &nexus_settings)?;
+            let mut hdf5 = RunFile::new_runfile(
+                nexus_settings.get_local_temp_path(),
+                &parameters.run_name,
+                &nexus_settings,
+            )?;
             hdf5.init(&parameters, nexus_configuration)?;
             hdf5.close()?;
         }
@@ -60,24 +65,24 @@ impl Run {
     pub(crate) fn move_to_completed(
         &self,
         temp_path: &Path,
-        completed_path: &Path
+        completed_path: &Path,
     ) -> io::Result<()> {
         let from_path = RunParameters::get_hdf5_filename(temp_path, &self.parameters.run_name);
         let to_path = RunParameters::get_hdf5_filename(completed_path, &self.parameters.run_name);
-        
-        info_span!("Move To Completed",
+
+        info_span!(
+            "Move To Completed",
             from_path = from_path.to_string_lossy().to_string(),
             to_path = to_path.to_string_lossy().to_string()
-        ).in_scope(|| {
-            match std::fs::rename(from_path, to_path) {
-                Ok(()) => {
-                    info!("File Move Succesful.");
-                    Ok(())
-                }
-                Err(e) => {
-                    error!("File Move Error {e}");
-                    Err(e)
-                }
+        )
+        .in_scope(|| match std::fs::rename(from_path, to_path) {
+            Ok(()) => {
+                info!("File Move Succesful.");
+                Ok(())
+            }
+            Err(e) => {
+                error!("File Move Error {e}");
+                Err(e)
             }
         })
     }
@@ -113,7 +118,10 @@ impl Run {
         logdata: &f144_LogData,
     ) -> NexusWriterResult<()> {
         if let Some(nexus_settings) = nexus_settings {
-            let mut hdf5 = RunFile::open_runfile(nexus_settings.get_local_temp_path(), &self.parameters.run_name)?;
+            let mut hdf5 = RunFile::open_runfile(
+                nexus_settings.get_local_temp_path(),
+                &self.parameters.run_name,
+            )?;
             hdf5.push_logdata_to_runfile(logdata, &self.parameters.collect_from, nexus_settings)?;
             hdf5.close()?;
         }
@@ -129,7 +137,10 @@ impl Run {
         alarm: Alarm,
     ) -> NexusWriterResult<()> {
         if let Some(nexus_settings) = nexus_settings {
-            let mut hdf5 = RunFile::open_runfile(nexus_settings.get_local_temp_path(), &self.parameters.run_name)?;
+            let mut hdf5 = RunFile::open_runfile(
+                nexus_settings.get_local_temp_path(),
+                &self.parameters.run_name,
+            )?;
             hdf5.push_alarm_to_runfile(alarm, &self.parameters.collect_from, &nexus_settings)?;
             hdf5.close()?;
         }
@@ -145,7 +156,10 @@ impl Run {
         logdata: se00_SampleEnvironmentData,
     ) -> NexusWriterResult<()> {
         if let Some(nexus_settings) = nexus_settings {
-            let mut hdf5 = RunFile::open_runfile(nexus_settings.get_local_temp_path(), &self.parameters.run_name)?;
+            let mut hdf5 = RunFile::open_runfile(
+                nexus_settings.get_local_temp_path(),
+                &self.parameters.run_name,
+            )?;
             hdf5.push_selogdata(logdata, &self.parameters.collect_from, nexus_settings)?;
             hdf5.close()?;
         }
@@ -158,10 +172,13 @@ impl Run {
     pub(crate) fn push_frame_eventlist_message(
         &mut self,
         nexus_settings: Option<&NexusSettings>,
-        message: &FrameAssembledEventListMessage
+        message: &FrameAssembledEventListMessage,
     ) -> NexusWriterResult<()> {
         if let Some(nexus_settings) = nexus_settings {
-            let mut hdf5 = RunFile::open_runfile(nexus_settings.get_local_temp_path(), &self.parameters.run_name)?;
+            let mut hdf5 = RunFile::open_runfile(
+                nexus_settings.get_local_temp_path(),
+                &self.parameters.run_name,
+            )?;
             hdf5.push_frame_eventlist_message_to_runfile(message)?;
 
             if !message.complete() {
@@ -215,7 +232,10 @@ impl Run {
         self.parameters.set_aborted_run(absolute_stop_time_ms)?;
 
         if let Some(nexus_settings) = nexus_settings {
-            let mut hdf5 = RunFile::open_runfile(nexus_settings.get_local_temp_path(), &self.parameters.run_name)?;
+            let mut hdf5 = RunFile::open_runfile(
+                nexus_settings.get_local_temp_path(),
+                &self.parameters.run_name,
+            )?;
 
             let collect_until = self
                 .parameters

--- a/nexus-writer/src/nexus/run_parameters.rs
+++ b/nexus-writer/src/nexus/run_parameters.rs
@@ -10,6 +10,8 @@ use supermusr_streaming_types::{
 
 #[derive(Clone, Default, Debug)]
 pub(crate) struct NexusConfiguration {
+    /// Data pipeline configuration to be written to the `/raw_data_1/program_name/configuration`
+    /// attribute of the NeXus file.
     pub(crate) configuration: String,
 }
 

--- a/nexus-writer/src/nexus/run_parameters.rs
+++ b/nexus-writer/src/nexus/run_parameters.rs
@@ -8,7 +8,6 @@ use supermusr_streaming_types::{
     ecs_6s4t_run_stop_generated::RunStop, ecs_pl72_run_start_generated::RunStart,
 };
 
-
 #[derive(Clone, Default, Debug)]
 pub(crate) struct NexusConfiguration {
     pub(crate) configuration: String,

--- a/nexus-writer/src/nexus/run_parameters.rs
+++ b/nexus-writer/src/nexus/run_parameters.rs
@@ -8,6 +8,20 @@ use supermusr_streaming_types::{
     ecs_6s4t_run_stop_generated::RunStop, ecs_pl72_run_start_generated::RunStart,
 };
 
+
+#[derive(Clone, Default, Debug)]
+pub(crate) struct NexusConfiguration {
+    pub(crate) configuration: String,
+}
+
+impl NexusConfiguration {
+    pub(crate) fn new(configuration: Option<String>) -> Self {
+        Self {
+            configuration: configuration.unwrap_or_default(),
+        }
+    }
+}
+
 #[derive(Default, Debug, Clone)]
 pub(crate) struct RunStopParameters {
     pub(crate) collect_until: NexusDateTime,

--- a/nexus-writer/src/nexus/settings.rs
+++ b/nexus-writer/src/nexus/settings.rs
@@ -1,18 +1,12 @@
 use std::path::{Path, PathBuf};
-
 use tokio::time::Interval;
 
-use super::error::{ErrorCodeLocation, NexusWriterError, NexusWriterResult};
-
-fn get_path_glob_pattern(path: &Path) -> NexusWriterResult<String> {
-    let local_current_path_str =
-        path.as_os_str()
-            .to_str()
-            .ok_or_else(|| NexusWriterError::CannotConvertPath {
-                path: path.to_path_buf(),
-                location: ErrorCodeLocation::ResumePartialRunsLocalDirectoryPath,
-            })?;
-    Ok(format!("{local_current_path_str}/*.nxs"))
+/// Creates the patterns for
+fn get_path_glob_pattern(path: &Path) -> Result<String, &Path> {
+    path.as_os_str()
+        .to_str()
+        .map(|path| format!("{path}/*.nxs"))
+        .ok_or(path)
 }
 
 #[derive(Default, Debug)]
@@ -67,11 +61,11 @@ impl NexusSettings {
         self.archive_path.as_deref()
     }
 
-    pub(crate) fn get_local_temp_glob_pattern(&self) -> NexusWriterResult<String> {
+    pub(crate) fn get_local_temp_glob_pattern(&self) -> Result<String, &Path> {
         get_path_glob_pattern(&self.local_path_temp)
     }
 
-    pub(crate) fn get_local_completed_glob_pattern(&self) -> NexusWriterResult<String> {
+    pub(crate) fn get_local_completed_glob_pattern(&self) -> Result<String, &Path> {
         get_path_glob_pattern(&self.local_path_completed)
     }
 

--- a/nexus-writer/src/nexus/settings.rs
+++ b/nexus-writer/src/nexus/settings.rs
@@ -1,0 +1,71 @@
+use std::path::{Path, PathBuf};
+
+use super::error::{ErrorCodeLocation, NexusWriterError, NexusWriterResult};
+
+fn get_path_glob_pattern(path: &Path) -> NexusWriterResult<String> {
+    let local_current_path_str = path.as_os_str().to_str().ok_or_else(|| {
+        NexusWriterError::CannotConvertPath {
+            path: path.to_path_buf(),
+            location: ErrorCodeLocation::ResumePartialRunsLocalDirectoryPath,
+        }
+    })?;
+    Ok(format!("{local_current_path_str}/*.nxs"))
+}
+
+#[derive(Default, Debug)]
+pub(crate) struct NexusSettings {
+    local_path_current: PathBuf,
+    local_path_completed: PathBuf,
+    pub(crate) framelist_chunk_size: usize,
+    pub(crate) eventlist_chunk_size: usize,
+    pub(crate) periodlist_chunk_size: usize,
+    pub(crate) runloglist_chunk_size: usize,
+    pub(crate) seloglist_chunk_size: usize,
+    pub(crate) alarmlist_chunk_size: usize,
+    archive_path: Option<PathBuf>,
+}
+
+impl NexusSettings {
+    pub(crate) fn new(
+        local_path: &Path,
+        framelist_chunk_size: usize,
+        eventlist_chunk_size: usize,
+        archive_path: Option<&Path>,
+    ) -> Self {
+        let mut local_path_current = local_path.to_path_buf();
+        local_path_current.push("current");
+        let mut local_path_completed = local_path.to_path_buf();
+        local_path_completed.push("completed");
+        Self {
+            local_path_current,
+            local_path_completed,
+            framelist_chunk_size,
+            eventlist_chunk_size,
+            periodlist_chunk_size: 8,
+            runloglist_chunk_size: 64,
+            seloglist_chunk_size: 1024,
+            alarmlist_chunk_size: 32,
+            archive_path: archive_path.map(Path::to_owned),
+        }
+    }
+
+    pub(crate) fn get_local_current_path(&self) -> &Path {
+        &self.local_path_current
+    }
+
+    pub(crate) fn get_local_completed_path(&self) -> &Path {
+        &self.local_path_completed
+    }
+
+    pub(crate) fn get_archive_path(&self) -> Option<&Path> {
+        self.archive_path.as_deref()
+    }
+
+    pub(crate) fn get_local_current_glob_pattern(&self) -> NexusWriterResult<String> {
+        get_path_glob_pattern(&self.local_path_current)
+    }
+
+    pub(crate) fn get_local_completed_glob_pattern(&self) -> NexusWriterResult<String> {
+        get_path_glob_pattern(&self.local_path_completed)
+    }
+}

--- a/nexus-writer/src/nexus/settings.rs
+++ b/nexus-writer/src/nexus/settings.rs
@@ -14,7 +14,7 @@ fn get_path_glob_pattern(path: &Path) -> NexusWriterResult<String> {
 
 #[derive(Default, Debug)]
 pub(crate) struct NexusSettings {
-    local_path_current: PathBuf,
+    local_path_temp: PathBuf,
     local_path_completed: PathBuf,
     pub(crate) framelist_chunk_size: usize,
     pub(crate) eventlist_chunk_size: usize,
@@ -32,12 +32,12 @@ impl NexusSettings {
         eventlist_chunk_size: usize,
         archive_path: Option<&Path>,
     ) -> Self {
-        let mut local_path_current = local_path.to_path_buf();
-        local_path_current.push("current");
+        let mut local_path_temp = local_path.to_path_buf();
+        local_path_temp.push("current");
         let mut local_path_completed = local_path.to_path_buf();
         local_path_completed.push("completed");
         Self {
-            local_path_current,
+            local_path_temp,
             local_path_completed,
             framelist_chunk_size,
             eventlist_chunk_size,
@@ -49,8 +49,8 @@ impl NexusSettings {
         }
     }
 
-    pub(crate) fn get_local_current_path(&self) -> &Path {
-        &self.local_path_current
+    pub(crate) fn get_local_temp_path(&self) -> &Path {
+        &self.local_path_temp
     }
 
     pub(crate) fn get_local_completed_path(&self) -> &Path {
@@ -61,8 +61,8 @@ impl NexusSettings {
         self.archive_path.as_deref()
     }
 
-    pub(crate) fn get_local_current_glob_pattern(&self) -> NexusWriterResult<String> {
-        get_path_glob_pattern(&self.local_path_current)
+    pub(crate) fn get_local_temp_glob_pattern(&self) -> NexusWriterResult<String> {
+        get_path_glob_pattern(&self.local_path_temp)
     }
 
     pub(crate) fn get_local_completed_glob_pattern(&self) -> NexusWriterResult<String> {

--- a/nexus-writer/src/nexus/settings.rs
+++ b/nexus-writer/src/nexus/settings.rs
@@ -11,7 +11,7 @@ fn get_path_glob_pattern(path: &Path) -> Result<String, &Path> {
 
 #[derive(Default, Debug)]
 pub(crate) struct NexusSettings {
-    local_path_temp: PathBuf,
+    local_path: PathBuf,
     local_path_completed: PathBuf,
     pub(crate) framelist_chunk_size: usize,
     pub(crate) eventlist_chunk_size: usize,
@@ -31,12 +31,11 @@ impl NexusSettings {
         archive_path: Option<&Path>,
         archive_flush_interval_sec: u64,
     ) -> Self {
-        let mut local_path_temp = local_path.to_path_buf();
-        local_path_temp.push("temp");
+        let local_path = local_path.to_path_buf();
         let mut local_path_completed = local_path.to_path_buf();
         local_path_completed.push("completed");
         Self {
-            local_path_temp,
+            local_path,
             local_path_completed,
             framelist_chunk_size,
             eventlist_chunk_size,
@@ -49,8 +48,8 @@ impl NexusSettings {
         }
     }
 
-    pub(crate) fn get_local_temp_path(&self) -> &Path {
-        &self.local_path_temp
+    pub(crate) fn get_local_path(&self) -> &Path {
+        &self.local_path
     }
 
     pub(crate) fn get_local_completed_path(&self) -> &Path {
@@ -62,7 +61,7 @@ impl NexusSettings {
     }
 
     pub(crate) fn get_local_temp_glob_pattern(&self) -> Result<String, &Path> {
-        get_path_glob_pattern(&self.local_path_temp)
+        get_path_glob_pattern(&self.local_path)
     }
 
     pub(crate) fn get_local_completed_glob_pattern(&self) -> Result<String, &Path> {

--- a/nexus-writer/src/nexus/settings.rs
+++ b/nexus-writer/src/nexus/settings.rs
@@ -5,12 +5,13 @@ use tokio::time::Interval;
 use super::error::{ErrorCodeLocation, NexusWriterError, NexusWriterResult};
 
 fn get_path_glob_pattern(path: &Path) -> NexusWriterResult<String> {
-    let local_current_path_str = path.as_os_str().to_str().ok_or_else(|| {
-        NexusWriterError::CannotConvertPath {
-            path: path.to_path_buf(),
-            location: ErrorCodeLocation::ResumePartialRunsLocalDirectoryPath,
-        }
-    })?;
+    let local_current_path_str =
+        path.as_os_str()
+            .to_str()
+            .ok_or_else(|| NexusWriterError::CannotConvertPath {
+                path: path.to_path_buf(),
+                location: ErrorCodeLocation::ResumePartialRunsLocalDirectoryPath,
+            })?;
     Ok(format!("{local_current_path_str}/*.nxs"))
 }
 
@@ -25,7 +26,7 @@ pub(crate) struct NexusSettings {
     pub(crate) seloglist_chunk_size: usize,
     pub(crate) alarmlist_chunk_size: usize,
     archive_path: Option<PathBuf>,
-    archive_flush_interval_sec: u64
+    archive_flush_interval_sec: u64,
 }
 
 impl NexusSettings {
@@ -34,7 +35,7 @@ impl NexusSettings {
         framelist_chunk_size: usize,
         eventlist_chunk_size: usize,
         archive_path: Option<&Path>,
-        archive_flush_interval_sec: u64
+        archive_flush_interval_sec: u64,
     ) -> Self {
         let mut local_path_temp = local_path.to_path_buf();
         local_path_temp.push("temp");
@@ -75,6 +76,8 @@ impl NexusSettings {
     }
 
     pub(crate) fn get_archive_flush_interval(&self) -> Interval {
-        tokio::time::interval(tokio::time::Duration::from_secs(self.archive_flush_interval_sec))
+        tokio::time::interval(tokio::time::Duration::from_secs(
+            self.archive_flush_interval_sec,
+        ))
     }
 }


### PR DESCRIPTION
## Summary of changes

- Renames CLI options `file_name` and `archive_name` to `local_path` and `archive_path` respectively.
- Run files are stored in ~`local_path/temp`~ `local_path/` whilst being built up, and moved to `local_path/completed/` when finished. Failure of this file move results in component termination, and logging.
- Introduces CLI option `archive_flush_interval_sec` which tunes how often nexus-writer moves all files in `local_path/completed` to `archive_path`. `archive_flush_interval_sec` defaults to 60 (seconds) if not specified. Failure of these operations **does not** result in component termination, but warnings are emitted.
- Removed archive code from the `run.rs` and `engine.rs` to `flush_to_archive.rs` file.
- Code related to creating directory structure moved from `engine.rs` to `main.rs`
- Moved `NexusConfiguration` to `run_parameters.rs`
- The local path string is moved into `NexusSettings`, and functions which required `Some(local_path)` now requires `Some(nexus_settings)`. The use of `Option` allows unit testing.

Closes https://github.com/STFC-ICD-Research-and-Design/supermusr-data-pipeline/issues/321.

## Instruction for review/testing

General code review.
Has been tested with simulated data.

### Breaking Changes
When running this 
- The CLI option `file_name` should be changed to `local_path`.
- The CLI option `archive_name` should be changed to `archive_path`.

### Non-Breaking Changes
- If desired, CLI option `archive_flush_interval_sec` should be set.