### PR TITLE
Route se logs and run logs correctly

### DIFF
--- a/nexus-writer/src/main.rs
+++ b/nexus-writer/src/main.rs
@@ -1,7 +1,9 @@
 mod nexus;
+mod message_handlers;
 
 use chrono::Duration;
 use clap::Parser;
+use message_handlers::{process_payload_on_alarm_topic, process_payload_on_control_topic, process_payload_on_frame_event_list_topic, process_payload_on_runlog_topic, process_payload_on_sample_env_topic};
 use metrics::counter;
 use metrics_exporter_prometheus::PrometheusBuilder;
 use nexus::{NexusConfiguration, NexusEngine, NexusSettings};
@@ -13,35 +15,17 @@ use std::{net::SocketAddr, path::PathBuf};
 use supermusr_common::{
     init_tracer,
     metrics::{
-        failures::{self, FailureKind},
         messages_received::{self, MessageKind},
         metric_names::{FAILURES, MESSAGES_PROCESSED, MESSAGES_RECEIVED},
     },
-    record_metadata_fields_to_span,
-    spanned::SpannedAggregator,
     tracer::{OptionalHeaderTracerExt, TracerEngine, TracerOptions},
     CommonKafkaOpts,
-};
-use supermusr_streaming_types::{
-    aev2_frame_assembled_event_v2_generated::{
-        frame_assembled_event_list_message_buffer_has_identifier,
-        root_as_frame_assembled_event_list_message,
-    },
-    ecs_6s4t_run_stop_generated::{root_as_run_stop, run_stop_buffer_has_identifier},
-    ecs_al00_alarm_generated::{alarm_buffer_has_identifier, root_as_alarm},
-    ecs_f144_logdata_generated::{f_144_log_data_buffer_has_identifier, root_as_f_144_log_data},
-    ecs_pl72_run_start_generated::{root_as_run_start, run_start_buffer_has_identifier},
-    ecs_se00_data_generated::{
-        root_as_se_00_sample_environment_data, se_00_sample_environment_data_buffer_has_identifier,
-    },
-    flatbuffers::InvalidFlatbuffer,
-    FrameMetadata,
 };
 use tokio::{
     signal::unix::{signal, SignalKind},
     time,
 };
-use tracing::{debug, error, info_span, instrument, warn, warn_span};
+use tracing::{debug, error, warn};
 
 #[derive(Debug, Parser)]
 #[clap(author, version, about)]
@@ -115,11 +99,11 @@ struct Cli {
 }
 
 struct Topics<'a> {
-    control : &'a str,
-    log : &'a str,
-    frame_event : &'a str,
-    sample_env : &'a str,
-    alarm : &'a str,
+    control: &'a str,
+    log: &'a str,
+    frame_event: &'a str,
+    sample_env: &'a str,
+    alarm: &'a str,
 }
 
 #[tokio::main]
@@ -247,7 +231,12 @@ async fn main() -> anyhow::Result<()> {
     num_cached_runs = nexus_engine.get_num_cached_runs(),
     kafka_message_timestamp_ms = msg.timestamp().to_millis()
 ))]
-fn process_kafka_message(topics: &Topics, nexus_engine: &mut NexusEngine, use_otel: bool, msg: &BorrowedMessage) {
+fn process_kafka_message(
+    topics: &Topics,
+    nexus_engine: &mut NexusEngine,
+    use_otel: bool,
+    msg: &BorrowedMessage,
+) {
     msg.headers().conditional_extract_to_current_span(use_otel);
 
     debug!(
@@ -264,288 +253,29 @@ fn process_kafka_message(topics: &Topics, nexus_engine: &mut NexusEngine, use_ot
     }
 }
 
-fn process_payload(topics: &Topics, nexus_engine: &mut NexusEngine, message_topic: &str, payload: &[u8]) {
+fn process_payload(
+    topics: &Topics,
+    nexus_engine: &mut NexusEngine,
+    message_topic: &str,
+    payload: &[u8],
+) {
     if message_topic == topics.frame_event {
-        if frame_assembled_event_list_message_buffer_has_identifier(payload) {
-            process_frame_assembled_event_list_message(nexus_engine, payload);
-        } else {
-            warn!("Incorrect message identifier on topic \"{message_topic}\"");
-        }
+        process_payload_on_frame_event_list_topic(nexus_engine, payload);
     } else if message_topic == topics.control {
-        if run_start_buffer_has_identifier(payload) {
-            process_run_start_message(nexus_engine, payload);
-        } else if run_stop_buffer_has_identifier(payload) {
-            process_run_stop_message(nexus_engine, payload);
-        } else {
-            warn!("Incorrect message identifier on topic \"{message_topic}\"");
-        }
+        process_payload_on_control_topic(nexus_engine, payload);
     } else if message_topic == topics.log {
-        if f_144_log_data_buffer_has_identifier(payload) {
-            process_logdata_message(nexus_engine, payload);
-        } else {
-            warn!("Incorrect message identifier on topic \"{message_topic}\"");
-        }
+        process_payload_on_runlog_topic(nexus_engine, payload);
     } else if message_topic == topics.sample_env {
-        if f_144_log_data_buffer_has_identifier(payload) {
-            process_logdata_message(nexus_engine, payload);
-        } else if se_00_sample_environment_data_buffer_has_identifier(payload) {
-            process_sample_environment_message(nexus_engine, payload);
-        } else {
-            warn!("Incorrect message identifier on topic \"{message_topic}\"");
-        }
+        process_payload_on_sample_env_topic(nexus_engine, payload);
     } else if message_topic == topics.alarm {
-        if alarm_buffer_has_identifier(payload) {
-            process_alarm_message(nexus_engine, payload);
-        } else {
-            warn!("Incorrect message identifier on topic \"{message_topic}\"");
-        }
+        process_payload_on_alarm_topic(nexus_engine, payload);
     } else {
-        warn!("Incorrect topic: \"{message_topic}\"");
+        warn!("Unknown topic: \"{message_topic}\"");
         debug!("Payload size: {}", payload.len());
         counter!(
             MESSAGES_RECEIVED,
             &[messages_received::get_label(MessageKind::Unexpected)]
         )
         .increment(1);
-    }
-}
-
-#[instrument(skip_all, level = "trace", err(level = "WARN"))]
-fn spanned_root_as<'a, R, F>(f: F, payload: &'a [u8]) -> Result<R, InvalidFlatbuffer>
-where
-    F: Fn(&'a [u8]) -> Result<R, InvalidFlatbuffer>,
-{
-    f(payload)
-}
-
-#[tracing::instrument(skip_all,
-    fields(
-        metadata_timestamp = tracing::field::Empty,
-        metadata_frame_number = tracing::field::Empty,
-        metadata_period_number = tracing::field::Empty,
-        metadata_veto_flags = tracing::field::Empty,
-        metadata_protons_per_pulse = tracing::field::Empty,
-        metadata_running = tracing::field::Empty,
-        frame_is_complete = tracing::field::Empty,
-    )
-)]
-fn process_frame_assembled_event_list_message(nexus_engine: &mut NexusEngine, payload: &[u8]) {
-    counter!(
-        MESSAGES_RECEIVED,
-        &[messages_received::get_label(MessageKind::Event)]
-    )
-    .increment(1);
-    match spanned_root_as(root_as_frame_assembled_event_list_message, payload) {
-        Ok(data) => {
-            data.metadata()
-                .try_into()
-                .map(|metadata: FrameMetadata| {
-                    record_metadata_fields_to_span!(metadata, tracing::Span::current());
-                    tracing::Span::current().record("frame_is_complete", data.complete());
-                })
-                .ok();
-            match nexus_engine.process_event_list(&data) {
-                Ok(run) => {
-                    if let Some(run) = run {
-                        if let Err(e) = run.link_current_span(|| {
-                            let span = info_span!(
-                                "Frame Event List",
-                                "metadata_timestamp" = tracing::field::Empty,
-                                "metadata_frame_number" = tracing::field::Empty,
-                                "metadata_period_number" = tracing::field::Empty,
-                                "metadata_veto_flags" = tracing::field::Empty,
-                                "metadata_protons_per_pulse" = tracing::field::Empty,
-                                "metadata_running" = tracing::field::Empty,
-                                "frame_is_complete" = data.complete(),
-                            );
-                            data.metadata()
-                                .try_into()
-                                .map(|metadata: FrameMetadata| {
-                                    record_metadata_fields_to_span!(metadata, span);
-                                })
-                                .ok();
-                            span
-                        }) {
-                            warn!("Run span linking failed {e}")
-                        }
-                    }
-                }
-                Err(e) => warn!("Failed to save frame assembled event list to file: {}", e),
-            }
-        }
-        Err(e) => {
-            warn!("Failed to parse message: {}", e);
-            counter!(
-                FAILURES,
-                &[failures::get_label(FailureKind::UnableToDecodeMessage)]
-            )
-            .increment(1);
-        }
-    }
-}
-
-#[tracing::instrument(skip_all)]
-fn process_run_start_message(nexus_engine: &mut NexusEngine, payload: &[u8]) {
-    counter!(
-        MESSAGES_RECEIVED,
-        &[messages_received::get_label(MessageKind::RunStart)]
-    )
-    .increment(1);
-    match spanned_root_as(root_as_run_start, payload) {
-        Ok(data) => match nexus_engine.start_command(data) {
-            Ok(run) => {
-                if let Err(e) = run.link_current_span(|| {
-                    info_span!(
-                        "Run Start Command",
-                        "Start" = run.parameters().collect_from.to_string()
-                    )
-                }) {
-                    warn!("Run span linking failed {e}")
-                }
-            }
-            Err(e) => warn!("Start command ({data:?}) failed {e}"),
-        },
-        Err(e) => {
-            warn!("Failed to parse message: {}", e);
-            counter!(
-                FAILURES,
-                &[failures::get_label(FailureKind::UnableToDecodeMessage)]
-            )
-            .increment(1);
-        }
-    }
-}
-
-#[tracing::instrument(skip_all)]
-fn process_run_stop_message(nexus_engine: &mut NexusEngine, payload: &[u8]) {
-    counter!(
-        MESSAGES_RECEIVED,
-        &[messages_received::get_label(MessageKind::RunStop)]
-    )
-    .increment(1);
-    match spanned_root_as(root_as_run_stop, payload) {
-        Ok(data) => match nexus_engine.stop_command(data) {
-            Ok(run) => {
-                if let Err(e) = run.link_current_span(|| {
-                    info_span!(
-                        "Run Stop Command",
-                        "Stop" = run
-                            .parameters()
-                            .run_stop_parameters
-                            .as_ref()
-                            .map(|s| s.collect_until.to_rfc3339())
-                            .unwrap_or_default()
-                    )
-                }) {
-                    warn!("Run span linking failed {e}")
-                }
-            }
-            Err(e) => {
-                let _guard = warn_span!(
-                    "RunStop Error",
-                    run_name = data.run_name(),
-                    stop_time = data.stop_time(),
-                )
-                .entered();
-                warn!("{e}");
-            }
-        },
-        Err(e) => {
-            warn!("Failed to parse message: {}", e);
-            counter!(
-                FAILURES,
-                &[failures::get_label(FailureKind::UnableToDecodeMessage)]
-            )
-            .increment(1);
-        }
-    }
-}
-
-#[tracing::instrument(skip_all)]
-fn process_sample_environment_message(nexus_engine: &mut NexusEngine, payload: &[u8]) {
-    counter!(
-        MESSAGES_RECEIVED,
-        &[messages_received::get_label(
-            MessageKind::SampleEnvironmentData
-        )]
-    )
-    .increment(1);
-    match spanned_root_as(root_as_se_00_sample_environment_data, payload) {
-        Ok(data) => match nexus_engine.sample_envionment(data) {
-            Ok(run) => {
-                if let Some(run) = run {
-                    if let Err(e) = run.link_current_span(|| info_span!("Sample Environment Log")) {
-                        warn!("Run span linking failed {e}")
-                    }
-                }
-            }
-            Err(e) => warn!("Sample environment ({data:?}) failed {e}"),
-        },
-        Err(e) => {
-            warn!("Failed to parse message: {}", e);
-            counter!(
-                FAILURES,
-                &[failures::get_label(FailureKind::UnableToDecodeMessage)]
-            )
-            .increment(1);
-        }
-    }
-}
-
-#[tracing::instrument(skip_all)]
-fn process_alarm_message(nexus_engine: &mut NexusEngine, payload: &[u8]) {
-    counter!(
-        MESSAGES_RECEIVED,
-        &[messages_received::get_label(MessageKind::Alarm)]
-    )
-    .increment(1);
-    match spanned_root_as(root_as_alarm, payload) {
-        Ok(data) => match nexus_engine.alarm(data) {
-            Ok(run) => {
-                if let Some(run) = run {
-                    if let Err(e) = run.link_current_span(|| info_span!("Alarm")) {
-                        warn!("Run span linking failed {e}")
-                    }
-                }
-            }
-            Err(e) => warn!("Alarm ({data:?}) failed {e}"),
-        },
-        Err(e) => {
-            warn!("Failed to parse message: {}", e);
-            counter!(
-                FAILURES,
-                &[failures::get_label(FailureKind::UnableToDecodeMessage)]
-            )
-            .increment(1);
-        }
-    }
-}
-
-#[tracing::instrument(skip_all)]
-fn process_logdata_message(nexus_engine: &mut NexusEngine, payload: &[u8]) {
-    counter!(
-        MESSAGES_RECEIVED,
-        &[messages_received::get_label(MessageKind::LogData)]
-    )
-    .increment(1);
-    match spanned_root_as(root_as_f_144_log_data, payload) {
-        Ok(data) => match nexus_engine.logdata(&data) {
-            Ok(run) => {
-                if let Some(run) = run {
-                    if let Err(e) = run.link_current_span(|| info_span!("Run Log Data")) {
-                        warn!("Run span linking failed {e}")
-                    }
-                }
-            }
-            Err(e) => warn!("Run Log Data ({data:?}) failed. Error: {e}"),
-        },
-        Err(e) => {
-            warn!("Failed to parse message: {}", e);
-            counter!(
-                FAILURES,
-                &[failures::get_label(FailureKind::UnableToDecodeMessage)]
-            )
-            .increment(1);
-        }
     }
 }

--- a/nexus-writer/src/main.rs
+++ b/nexus-writer/src/main.rs
@@ -1,9 +1,13 @@
-mod nexus;
 mod message_handlers;
+mod nexus;
 
 use chrono::Duration;
 use clap::Parser;
-use message_handlers::{process_payload_on_alarm_topic, process_payload_on_control_topic, process_payload_on_frame_event_list_topic, process_payload_on_runlog_topic, process_payload_on_sample_env_topic};
+use message_handlers::{
+    process_payload_on_alarm_topic, process_payload_on_control_topic,
+    process_payload_on_frame_event_list_topic, process_payload_on_runlog_topic,
+    process_payload_on_sample_env_topic,
+};
 use metrics::counter;
 use metrics_exporter_prometheus::PrometheusBuilder;
 use nexus::{NexusConfiguration, NexusEngine, NexusSettings};

--- a/nexus-writer/src/message_handlers.rs
+++ b/nexus-writer/src/message_handlers.rs
@@ -101,8 +101,11 @@ where
 }
 
 /// A wrapper function that handles repetative error handing.
-fn link_current_span_to_run<F>(run: &Run, f : F) where F: Fn() -> Span {
-    if let Err(e) = run.link_current_span(f){
+fn link_current_span_to_run<F>(run: &Run, f: F)
+where
+    F: Fn() -> Span,
+{
+    if let Err(e) = run.link_current_span(f) {
         warn!("Run span linking failed {e}")
     }
 }
@@ -135,7 +138,7 @@ fn process_run_start_message(nexus_engine: &mut NexusEngine, payload: &[u8]) {
             }),
             Err(e) => warn!("Start command ({data:?}) failed {e}"),
         },
-        Err(e) => report_parse_message_failure(e)
+        Err(e) => report_parse_message_failure(e),
     }
 }
 
@@ -170,7 +173,7 @@ fn process_run_stop_message(nexus_engine: &mut NexusEngine, payload: &[u8]) {
                 warn!("{e}");
             }
         },
-        Err(e) => report_parse_message_failure(e)
+        Err(e) => report_parse_message_failure(e),
     }
 }
 
@@ -225,7 +228,7 @@ fn process_frame_assembled_event_list_message(nexus_engine: &mut NexusEngine, pa
                 Err(e) => warn!("Failed to save frame assembled event list to file: {}", e),
             }
         }
-        Err(e) => report_parse_message_failure(e)
+        Err(e) => report_parse_message_failure(e),
     }
 }
 
@@ -257,8 +260,9 @@ fn process_sample_environment_message(
     )
     .increment(1);
     let wrapped_result = match se_type {
-        SampleEnvironmentLogType::LogData => spanned_root_as(root_as_f_144_log_data, payload)
-            .map(SampleEnvironmentLog::LogData),
+        SampleEnvironmentLogType::LogData => {
+            spanned_root_as(root_as_f_144_log_data, payload).map(SampleEnvironmentLog::LogData)
+        }
         SampleEnvironmentLogType::SampleEnvironmentData => {
             spanned_root_as(root_as_se_00_sample_environment_data, payload)
                 .map(SampleEnvironmentLog::SampleEnvironmentData)
@@ -270,12 +274,14 @@ fn process_sample_environment_message(
                 .sample_envionment(wrapped_se)
                 .inspect_err(|e| warn!("Sample environment error: {e}."));
             match result {
-                Ok(Some(run)) => link_current_span_to_run(run, || info_span!("Sample Environment Log")),
+                Ok(Some(run)) => {
+                    link_current_span_to_run(run, || info_span!("Sample Environment Log"))
+                }
                 Ok(_) => (),
                 Err(e) => warn!("Sample environment error: {e}"),
             }
         }
-        Err(e) => report_parse_message_failure(e)
+        Err(e) => report_parse_message_failure(e),
     }
 }
 
@@ -293,7 +299,7 @@ fn process_alarm_message(nexus_engine: &mut NexusEngine, payload: &[u8]) {
             Ok(_) => (),
             Err(e) => warn!("Alarm ({data:?}) failed {e}"),
         },
-        Err(e) => report_parse_message_failure(e)
+        Err(e) => report_parse_message_failure(e),
     }
 }
 
@@ -311,6 +317,6 @@ pub(crate) fn process_logdata_message(nexus_engine: &mut NexusEngine, payload: &
             Ok(_) => (),
             Err(e) => warn!("Run Log Data ({data:?}) failed. Error: {e}"),
         },
-        Err(e) => report_parse_message_failure(e)
+        Err(e) => report_parse_message_failure(e),
     }
 }

--- a/nexus-writer/src/message_handlers.rs
+++ b/nexus-writer/src/message_handlers.rs
@@ -60,6 +60,7 @@ pub(crate) fn process_payload_on_sample_env_topic(nexus_engine: &mut NexusEngine
     }
 }
 
+/// Processes the message payload for a message on the run_log topic
 pub(crate) fn process_payload_on_runlog_topic(nexus_engine: &mut NexusEngine, payload: &[u8]) {
     if f_144_log_data_buffer_has_identifier(payload) {
         process_logdata_message(nexus_engine, payload);
@@ -68,6 +69,7 @@ pub(crate) fn process_payload_on_runlog_topic(nexus_engine: &mut NexusEngine, pa
     }
 }
 
+/// Processes the message payload for a message on the alarm topic
 pub(crate) fn process_payload_on_alarm_topic(nexus_engine: &mut NexusEngine, payload: &[u8]) {
     if alarm_buffer_has_identifier(payload) {
         process_alarm_message(nexus_engine, payload);
@@ -76,6 +78,7 @@ pub(crate) fn process_payload_on_alarm_topic(nexus_engine: &mut NexusEngine, pay
     }
 }
 
+/// Processes the message payload for a message on the control topic
 pub(crate) fn process_payload_on_control_topic(nexus_engine: &mut NexusEngine, payload: &[u8]) {
     if run_start_buffer_has_identifier(payload) {
         process_run_start_message(nexus_engine, payload);
@@ -255,10 +258,10 @@ fn process_sample_environment_message(
     .increment(1);
     let wrapped_result = match se_type {
         SampleEnvironmentLogType::LogData => spanned_root_as(root_as_f_144_log_data, payload)
-            .map(|data| SampleEnvironmentLog::LogData(data)),
+            .map(SampleEnvironmentLog::LogData),
         SampleEnvironmentLogType::SampleEnvironmentData => {
             spanned_root_as(root_as_se_00_sample_environment_data, payload)
-                .map(|data| SampleEnvironmentLog::SampleEnvironmentData(data))
+                .map(SampleEnvironmentLog::SampleEnvironmentData)
         }
     };
     match wrapped_result {

--- a/nexus-writer/src/message_handlers.rs
+++ b/nexus-writer/src/message_handlers.rs
@@ -1,5 +1,5 @@
+use crate::nexus::{NexusEngine, Run};
 use metrics::counter;
-use crate::nexus::NexusEngine;
 use supermusr_common::{
     metrics::{
         failures::{self, FailureKind},
@@ -7,26 +7,33 @@ use supermusr_common::{
         metric_names::{FAILURES, MESSAGES_RECEIVED},
     },
     record_metadata_fields_to_span,
-    spanned::SpannedAggregator
+    spanned::SpannedAggregator,
 };
 use supermusr_streaming_types::{
-    aev2_frame_assembled_event_v2_generated::{frame_assembled_event_list_message_buffer_has_identifier, root_as_frame_assembled_event_list_message},
+    aev2_frame_assembled_event_v2_generated::{
+        frame_assembled_event_list_message_buffer_has_identifier,
+        root_as_frame_assembled_event_list_message,
+    },
     ecs_6s4t_run_stop_generated::{root_as_run_stop, run_stop_buffer_has_identifier},
     ecs_al00_alarm_generated::{alarm_buffer_has_identifier, root_as_alarm},
     ecs_f144_logdata_generated::{
-        f144_LogData, f_144_log_data_buffer_has_identifier, root_as_f_144_log_data
+        f144_LogData, f_144_log_data_buffer_has_identifier, root_as_f_144_log_data,
     },
     ecs_pl72_run_start_generated::{root_as_run_start, run_start_buffer_has_identifier},
     ecs_se00_data_generated::{
-        root_as_se_00_sample_environment_data, se00_SampleEnvironmentData, se_00_sample_environment_data_buffer_has_identifier
+        root_as_se_00_sample_environment_data, se00_SampleEnvironmentData,
+        se_00_sample_environment_data_buffer_has_identifier,
     },
     flatbuffers::InvalidFlatbuffer,
     FrameMetadata,
 };
-use tracing::{info_span, instrument, warn, warn_span};
+use tracing::{info_span, instrument, warn, warn_span, Span};
 
 /// Processes the message payload for a message on the frame_event_list topic
-pub(crate) fn process_payload_on_frame_event_list_topic(nexus_engine: &mut NexusEngine, payload: &[u8]) {
+pub(crate) fn process_payload_on_frame_event_list_topic(
+    nexus_engine: &mut NexusEngine,
+    payload: &[u8],
+) {
     if frame_assembled_event_list_message_buffer_has_identifier(payload) {
         process_frame_assembled_event_list_message(nexus_engine, payload);
     } else {
@@ -37,9 +44,17 @@ pub(crate) fn process_payload_on_frame_event_list_topic(nexus_engine: &mut Nexus
 /// Processes the message payload for a message on the sample_environment topic
 pub(crate) fn process_payload_on_sample_env_topic(nexus_engine: &mut NexusEngine, payload: &[u8]) {
     if f_144_log_data_buffer_has_identifier(payload) {
-        process_sample_environment_message(nexus_engine, SampleEnvironmentLogType::LogData, payload);
+        process_sample_environment_message(
+            nexus_engine,
+            SampleEnvironmentLogType::LogData,
+            payload,
+        );
     } else if se_00_sample_environment_data_buffer_has_identifier(payload) {
-        process_sample_environment_message(nexus_engine, SampleEnvironmentLogType::SampleEnvironmentData, payload);
+        process_sample_environment_message(
+            nexus_engine,
+            SampleEnvironmentLogType::SampleEnvironmentData,
+            payload,
+        );
     } else {
         warn!("Incorrect message identifier on sample environment topic");
     }
@@ -71,6 +86,9 @@ pub(crate) fn process_payload_on_control_topic(nexus_engine: &mut NexusEngine, p
     }
 }
 
+/// This wrapper function is used to allow tracing of the flatbuffer decoding function.
+/// This operation is generally so fast, that I'm not sure this is needed.
+/// Alternatively, it may be possible to trace this using functionality in the flatbuffer crate.
 #[instrument(skip_all, level = "trace", err(level = "WARN"))]
 fn spanned_root_as<'a, R, F>(f: F, payload: &'a [u8]) -> Result<R, InvalidFlatbuffer>
 where
@@ -79,6 +97,81 @@ where
     f(payload)
 }
 
+/// A wrapper function that handles repetative error handing.
+fn link_current_span_to_run<F>(run: &Run, f : F) where F: Fn() -> Span {
+    if let Err(e) = run.link_current_span(f){
+        warn!("Run span linking failed {e}")
+    }
+}
+
+/// Emit the warning on an invalid flatbuffer error and increase metric
+fn report_parse_message_failure(e: InvalidFlatbuffer) {
+    warn!("Failed to parse message: {}", e);
+    counter!(
+        FAILURES,
+        &[failures::get_label(FailureKind::UnableToDecodeMessage)]
+    )
+    .increment(1);
+}
+
+/// Decode, validate and process a flatbuffer RunStart message
+#[tracing::instrument(skip_all)]
+fn process_run_start_message(nexus_engine: &mut NexusEngine, payload: &[u8]) {
+    counter!(
+        MESSAGES_RECEIVED,
+        &[messages_received::get_label(MessageKind::RunStart)]
+    )
+    .increment(1);
+    match spanned_root_as(root_as_run_start, payload) {
+        Ok(data) => match nexus_engine.start_command(data) {
+            Ok(run) => link_current_span_to_run(run, || {
+                info_span!(
+                    "Run Start Command",
+                    "Start" = run.parameters().collect_from.to_string()
+                )
+            }),
+            Err(e) => warn!("Start command ({data:?}) failed {e}"),
+        },
+        Err(e) => report_parse_message_failure(e)
+    }
+}
+
+/// Decode, validate and process a flatbuffer RunStop message
+#[tracing::instrument(skip_all)]
+fn process_run_stop_message(nexus_engine: &mut NexusEngine, payload: &[u8]) {
+    counter!(
+        MESSAGES_RECEIVED,
+        &[messages_received::get_label(MessageKind::RunStop)]
+    )
+    .increment(1);
+    match spanned_root_as(root_as_run_stop, payload) {
+        Ok(data) => match nexus_engine.stop_command(data) {
+            Ok(run) => link_current_span_to_run(run, || {
+                info_span!(
+                    "Run Stop Command",
+                    "Stop" = run
+                        .parameters()
+                        .run_stop_parameters
+                        .as_ref()
+                        .map(|s| s.collect_until.to_rfc3339())
+                        .unwrap_or_default()
+                )
+            }),
+            Err(e) => {
+                let _guard = warn_span!(
+                    "RunStop Error",
+                    run_name = data.run_name(),
+                    stop_time = data.stop_time(),
+                )
+                .entered();
+                warn!("{e}");
+            }
+        },
+        Err(e) => report_parse_message_failure(e)
+    }
+}
+
+/// Decode, validate and process a flatbuffer FrameEventList message
 #[tracing::instrument(skip_all,
     fields(
         metadata_timestamp = tracing::field::Empty,
@@ -106,132 +199,47 @@ fn process_frame_assembled_event_list_message(nexus_engine: &mut NexusEngine, pa
                 })
                 .ok();
             match nexus_engine.process_event_list(&data) {
-                Ok(run) => {
-                    if let Some(run) = run {
-                        if let Err(e) = run.link_current_span(|| {
-                            let span = info_span!(
-                                "Frame Event List",
-                                "metadata_timestamp" = tracing::field::Empty,
-                                "metadata_frame_number" = tracing::field::Empty,
-                                "metadata_period_number" = tracing::field::Empty,
-                                "metadata_veto_flags" = tracing::field::Empty,
-                                "metadata_protons_per_pulse" = tracing::field::Empty,
-                                "metadata_running" = tracing::field::Empty,
-                                "frame_is_complete" = data.complete(),
-                            );
-                            data.metadata()
-                                .try_into()
-                                .map(|metadata: FrameMetadata| {
-                                    record_metadata_fields_to_span!(metadata, span);
-                                })
-                                .ok();
-                            span
-                        }) {
-                            warn!("Run span linking failed {e}")
-                        }
-                    }
-                }
+                Ok(Some(run)) => link_current_span_to_run(run, || {
+                    let span = info_span!(
+                        "Frame Event List",
+                        "metadata_timestamp" = tracing::field::Empty,
+                        "metadata_frame_number" = tracing::field::Empty,
+                        "metadata_period_number" = tracing::field::Empty,
+                        "metadata_veto_flags" = tracing::field::Empty,
+                        "metadata_protons_per_pulse" = tracing::field::Empty,
+                        "metadata_running" = tracing::field::Empty,
+                        "frame_is_complete" = data.complete(),
+                    );
+                    data.metadata()
+                        .try_into()
+                        .map(|metadata: FrameMetadata| {
+                            record_metadata_fields_to_span!(metadata, span);
+                        })
+                        .ok();
+                    span
+                }),
+                Ok(_) => (),
                 Err(e) => warn!("Failed to save frame assembled event list to file: {}", e),
             }
         }
-        Err(e) => {
-            warn!("Failed to parse message: {}", e);
-            counter!(
-                FAILURES,
-                &[failures::get_label(FailureKind::UnableToDecodeMessage)]
-            )
-            .increment(1);
-        }
+        Err(e) => report_parse_message_failure(e)
     }
 }
 
-#[tracing::instrument(skip_all)]
-fn process_run_start_message(nexus_engine: &mut NexusEngine, payload: &[u8]) {
-    counter!(
-        MESSAGES_RECEIVED,
-        &[messages_received::get_label(MessageKind::RunStart)]
-    )
-    .increment(1);
-    match spanned_root_as(root_as_run_start, payload) {
-        Ok(data) => match nexus_engine.start_command(data) {
-            Ok(run) => {
-                if let Err(e) = run.link_current_span(|| {
-                    info_span!(
-                        "Run Start Command",
-                        "Start" = run.parameters().collect_from.to_string()
-                    )
-                }) {
-                    warn!("Run span linking failed {e}")
-                }
-            }
-            Err(e) => warn!("Start command ({data:?}) failed {e}"),
-        },
-        Err(e) => {
-            warn!("Failed to parse message: {}", e);
-            counter!(
-                FAILURES,
-                &[failures::get_label(FailureKind::UnableToDecodeMessage)]
-            )
-            .increment(1);
-        }
-    }
-}
-
-#[tracing::instrument(skip_all)]
-fn process_run_stop_message(nexus_engine: &mut NexusEngine, payload: &[u8]) {
-    counter!(
-        MESSAGES_RECEIVED,
-        &[messages_received::get_label(MessageKind::RunStop)]
-    )
-    .increment(1);
-    match spanned_root_as(root_as_run_stop, payload) {
-        Ok(data) => match nexus_engine.stop_command(data) {
-            Ok(run) => {
-                if let Err(e) = run.link_current_span(|| {
-                    info_span!(
-                        "Run Stop Command",
-                        "Stop" = run
-                            .parameters()
-                            .run_stop_parameters
-                            .as_ref()
-                            .map(|s| s.collect_until.to_rfc3339())
-                            .unwrap_or_default()
-                    )
-                }) {
-                    warn!("Run span linking failed {e}")
-                }
-            }
-            Err(e) => {
-                let _guard = warn_span!(
-                    "RunStop Error",
-                    run_name = data.run_name(),
-                    stop_time = data.stop_time(),
-                )
-                .entered();
-                warn!("{e}");
-            }
-        },
-        Err(e) => {
-            warn!("Failed to parse message: {}", e);
-            counter!(
-                FAILURES,
-                &[failures::get_label(FailureKind::UnableToDecodeMessage)]
-            )
-            .increment(1);
-        }
-    }
-}
-
+/// As Sample Environment Logs can be delivered via both f144 or se00 type messages,
+/// a wrapper enum is required to handle them.
 enum SampleEnvironmentLogType {
     LogData,
     SampleEnvironmentData,
 }
 
+#[derive(Debug)]
 pub(crate) enum SampleEnvironmentLog<'a> {
     LogData(f144_LogData<'a>),
     SampleEnvironmentData(se00_SampleEnvironmentData<'a>),
 }
 
+/// Decode, validate and process flatbuffer SampleEnvironmentLog messages
 #[tracing::instrument(skip_all)]
 fn process_sample_environment_message(
     nexus_engine: &mut NexusEngine,
@@ -245,48 +253,30 @@ fn process_sample_environment_message(
         )]
     )
     .increment(1);
-    let result = match se_type {
-        SampleEnvironmentLogType::LogData => {
-            spanned_root_as(root_as_f_144_log_data, payload)
-                .map(|data|
-                    nexus_engine.sample_envionment(SampleEnvironmentLog::LogData(data))
-                        .inspect_err(|_|{
-                            warn!("Sample environment ({data:?}) failed.")
-                        })
-            )
-        }
+    let wrapped_result = match se_type {
+        SampleEnvironmentLogType::LogData => spanned_root_as(root_as_f_144_log_data, payload)
+            .map(|data| SampleEnvironmentLog::LogData(data)),
         SampleEnvironmentLogType::SampleEnvironmentData => {
             spanned_root_as(root_as_se_00_sample_environment_data, payload)
-                .map(|data|
-                    nexus_engine.sample_envionment(SampleEnvironmentLog::SampleEnvironmentData(data))
-                        .map_err(|e|{
-                            warn!("Sample environment ({data:?}) failed."); e
-                        })
-                )
+                .map(|data| SampleEnvironmentLog::SampleEnvironmentData(data))
         }
     };
-    match result {
-        Ok(result) => match result {
-            Ok(run) => {
-                if let Some(run) = run {
-                    if let Err(e) = run.link_current_span(|| info_span!("Sample Environment Log")) {
-                        warn!("Run span linking failed {e}")
-                    }
-                }
+    match wrapped_result {
+        Ok(wrapped_se) => {
+            let result = nexus_engine
+                .sample_envionment(wrapped_se)
+                .inspect_err(|e| warn!("Sample environment error: {e}."));
+            match result {
+                Ok(Some(run)) => link_current_span_to_run(run, || info_span!("Sample Environment Log")),
+                Ok(_) => (),
+                Err(e) => warn!("Sample environment error: {e}"),
             }
-            Err(e) => warn!("Sample environment error: {e}"),
-        },
-        Err(e) => {
-            warn!("Failed to parse message: {}", e);
-            counter!(
-                FAILURES,
-                &[failures::get_label(FailureKind::UnableToDecodeMessage)]
-            )
-            .increment(1);
         }
+        Err(e) => report_parse_message_failure(e)
     }
 }
 
+/// Decode, validate and process a flatbuffer Alarm message
 #[tracing::instrument(skip_all)]
 fn process_alarm_message(nexus_engine: &mut NexusEngine, payload: &[u8]) {
     counter!(
@@ -296,26 +286,15 @@ fn process_alarm_message(nexus_engine: &mut NexusEngine, payload: &[u8]) {
     .increment(1);
     match spanned_root_as(root_as_alarm, payload) {
         Ok(data) => match nexus_engine.alarm(data) {
-            Ok(run) => {
-                if let Some(run) = run {
-                    if let Err(e) = run.link_current_span(|| info_span!("Alarm")) {
-                        warn!("Run span linking failed {e}")
-                    }
-                }
-            }
+            Ok(Some(run)) => link_current_span_to_run(run, || info_span!("Alarm")),
+            Ok(_) => (),
             Err(e) => warn!("Alarm ({data:?}) failed {e}"),
         },
-        Err(e) => {
-            warn!("Failed to parse message: {}", e);
-            counter!(
-                FAILURES,
-                &[failures::get_label(FailureKind::UnableToDecodeMessage)]
-            )
-            .increment(1);
-        }
+        Err(e) => report_parse_message_failure(e)
     }
 }
 
+/// Decode, validate and process a flatbuffer RunLog message
 #[tracing::instrument(skip_all)]
 pub(crate) fn process_logdata_message(nexus_engine: &mut NexusEngine, payload: &[u8]) {
     counter!(
@@ -325,22 +304,10 @@ pub(crate) fn process_logdata_message(nexus_engine: &mut NexusEngine, payload: &
     .increment(1);
     match spanned_root_as(root_as_f_144_log_data, payload) {
         Ok(data) => match nexus_engine.logdata(&data) {
-            Ok(run) => {
-                if let Some(run) = run {
-                    if let Err(e) = run.link_current_span(|| info_span!("Run Log Data")) {
-                        warn!("Run span linking failed {e}")
-                    }
-                }
-            }
+            Ok(Some(run)) => link_current_span_to_run(run, || info_span!("Run Log Data")),
+            Ok(_) => (),
             Err(e) => warn!("Run Log Data ({data:?}) failed. Error: {e}"),
         },
-        Err(e) => {
-            warn!("Failed to parse message: {}", e);
-            counter!(
-                FAILURES,
-                &[failures::get_label(FailureKind::UnableToDecodeMessage)]
-            )
-            .increment(1);
-        }
+        Err(e) => report_parse_message_failure(e)
     }
 }

--- a/nexus-writer/src/message_handlers.rs
+++ b/nexus-writer/src/message_handlers.rs
@@ -1,0 +1,346 @@
+use metrics::counter;
+use crate::nexus::NexusEngine;
+use supermusr_common::{
+    metrics::{
+        failures::{self, FailureKind},
+        messages_received::{self, MessageKind},
+        metric_names::{FAILURES, MESSAGES_RECEIVED},
+    },
+    record_metadata_fields_to_span,
+    spanned::SpannedAggregator
+};
+use supermusr_streaming_types::{
+    aev2_frame_assembled_event_v2_generated::{frame_assembled_event_list_message_buffer_has_identifier, root_as_frame_assembled_event_list_message},
+    ecs_6s4t_run_stop_generated::{root_as_run_stop, run_stop_buffer_has_identifier},
+    ecs_al00_alarm_generated::{alarm_buffer_has_identifier, root_as_alarm},
+    ecs_f144_logdata_generated::{
+        f144_LogData, f_144_log_data_buffer_has_identifier, root_as_f_144_log_data
+    },
+    ecs_pl72_run_start_generated::{root_as_run_start, run_start_buffer_has_identifier},
+    ecs_se00_data_generated::{
+        root_as_se_00_sample_environment_data, se00_SampleEnvironmentData, se_00_sample_environment_data_buffer_has_identifier
+    },
+    flatbuffers::InvalidFlatbuffer,
+    FrameMetadata,
+};
+use tracing::{info_span, instrument, warn, warn_span};
+
+/// Processes the message payload for a message on the frame_event_list topic
+pub(crate) fn process_payload_on_frame_event_list_topic(nexus_engine: &mut NexusEngine, payload: &[u8]) {
+    if frame_assembled_event_list_message_buffer_has_identifier(payload) {
+        process_frame_assembled_event_list_message(nexus_engine, payload);
+    } else {
+        warn!("Incorrect message identifier on frame event list topic");
+    }
+}
+
+/// Processes the message payload for a message on the sample_environment topic
+pub(crate) fn process_payload_on_sample_env_topic(nexus_engine: &mut NexusEngine, payload: &[u8]) {
+    if f_144_log_data_buffer_has_identifier(payload) {
+        process_sample_environment_message(nexus_engine, SampleEnvironmentLogType::LogData, payload);
+    } else if se_00_sample_environment_data_buffer_has_identifier(payload) {
+        process_sample_environment_message(nexus_engine, SampleEnvironmentLogType::SampleEnvironmentData, payload);
+    } else {
+        warn!("Incorrect message identifier on sample environment topic");
+    }
+}
+
+pub(crate) fn process_payload_on_runlog_topic(nexus_engine: &mut NexusEngine, payload: &[u8]) {
+    if f_144_log_data_buffer_has_identifier(payload) {
+        process_logdata_message(nexus_engine, payload);
+    } else {
+        warn!("Incorrect message identifier on runlog topic");
+    }
+}
+
+pub(crate) fn process_payload_on_alarm_topic(nexus_engine: &mut NexusEngine, payload: &[u8]) {
+    if alarm_buffer_has_identifier(payload) {
+        process_alarm_message(nexus_engine, payload);
+    } else {
+        warn!("Incorrect message identifier on alarm topic");
+    }
+}
+
+pub(crate) fn process_payload_on_control_topic(nexus_engine: &mut NexusEngine, payload: &[u8]) {
+    if run_start_buffer_has_identifier(payload) {
+        process_run_start_message(nexus_engine, payload);
+    } else if run_stop_buffer_has_identifier(payload) {
+        process_run_stop_message(nexus_engine, payload);
+    } else {
+        warn!("Incorrect message identifier on control topic");
+    }
+}
+
+#[instrument(skip_all, level = "trace", err(level = "WARN"))]
+fn spanned_root_as<'a, R, F>(f: F, payload: &'a [u8]) -> Result<R, InvalidFlatbuffer>
+where
+    F: Fn(&'a [u8]) -> Result<R, InvalidFlatbuffer>,
+{
+    f(payload)
+}
+
+#[tracing::instrument(skip_all,
+    fields(
+        metadata_timestamp = tracing::field::Empty,
+        metadata_frame_number = tracing::field::Empty,
+        metadata_period_number = tracing::field::Empty,
+        metadata_veto_flags = tracing::field::Empty,
+        metadata_protons_per_pulse = tracing::field::Empty,
+        metadata_running = tracing::field::Empty,
+        frame_is_complete = tracing::field::Empty,
+    )
+)]
+fn process_frame_assembled_event_list_message(nexus_engine: &mut NexusEngine, payload: &[u8]) {
+    counter!(
+        MESSAGES_RECEIVED,
+        &[messages_received::get_label(MessageKind::Event)]
+    )
+    .increment(1);
+    match spanned_root_as(root_as_frame_assembled_event_list_message, payload) {
+        Ok(data) => {
+            data.metadata()
+                .try_into()
+                .map(|metadata: FrameMetadata| {
+                    record_metadata_fields_to_span!(metadata, tracing::Span::current());
+                    tracing::Span::current().record("frame_is_complete", data.complete());
+                })
+                .ok();
+            match nexus_engine.process_event_list(&data) {
+                Ok(run) => {
+                    if let Some(run) = run {
+                        if let Err(e) = run.link_current_span(|| {
+                            let span = info_span!(
+                                "Frame Event List",
+                                "metadata_timestamp" = tracing::field::Empty,
+                                "metadata_frame_number" = tracing::field::Empty,
+                                "metadata_period_number" = tracing::field::Empty,
+                                "metadata_veto_flags" = tracing::field::Empty,
+                                "metadata_protons_per_pulse" = tracing::field::Empty,
+                                "metadata_running" = tracing::field::Empty,
+                                "frame_is_complete" = data.complete(),
+                            );
+                            data.metadata()
+                                .try_into()
+                                .map(|metadata: FrameMetadata| {
+                                    record_metadata_fields_to_span!(metadata, span);
+                                })
+                                .ok();
+                            span
+                        }) {
+                            warn!("Run span linking failed {e}")
+                        }
+                    }
+                }
+                Err(e) => warn!("Failed to save frame assembled event list to file: {}", e),
+            }
+        }
+        Err(e) => {
+            warn!("Failed to parse message: {}", e);
+            counter!(
+                FAILURES,
+                &[failures::get_label(FailureKind::UnableToDecodeMessage)]
+            )
+            .increment(1);
+        }
+    }
+}
+
+#[tracing::instrument(skip_all)]
+fn process_run_start_message(nexus_engine: &mut NexusEngine, payload: &[u8]) {
+    counter!(
+        MESSAGES_RECEIVED,
+        &[messages_received::get_label(MessageKind::RunStart)]
+    )
+    .increment(1);
+    match spanned_root_as(root_as_run_start, payload) {
+        Ok(data) => match nexus_engine.start_command(data) {
+            Ok(run) => {
+                if let Err(e) = run.link_current_span(|| {
+                    info_span!(
+                        "Run Start Command",
+                        "Start" = run.parameters().collect_from.to_string()
+                    )
+                }) {
+                    warn!("Run span linking failed {e}")
+                }
+            }
+            Err(e) => warn!("Start command ({data:?}) failed {e}"),
+        },
+        Err(e) => {
+            warn!("Failed to parse message: {}", e);
+            counter!(
+                FAILURES,
+                &[failures::get_label(FailureKind::UnableToDecodeMessage)]
+            )
+            .increment(1);
+        }
+    }
+}
+
+#[tracing::instrument(skip_all)]
+fn process_run_stop_message(nexus_engine: &mut NexusEngine, payload: &[u8]) {
+    counter!(
+        MESSAGES_RECEIVED,
+        &[messages_received::get_label(MessageKind::RunStop)]
+    )
+    .increment(1);
+    match spanned_root_as(root_as_run_stop, payload) {
+        Ok(data) => match nexus_engine.stop_command(data) {
+            Ok(run) => {
+                if let Err(e) = run.link_current_span(|| {
+                    info_span!(
+                        "Run Stop Command",
+                        "Stop" = run
+                            .parameters()
+                            .run_stop_parameters
+                            .as_ref()
+                            .map(|s| s.collect_until.to_rfc3339())
+                            .unwrap_or_default()
+                    )
+                }) {
+                    warn!("Run span linking failed {e}")
+                }
+            }
+            Err(e) => {
+                let _guard = warn_span!(
+                    "RunStop Error",
+                    run_name = data.run_name(),
+                    stop_time = data.stop_time(),
+                )
+                .entered();
+                warn!("{e}");
+            }
+        },
+        Err(e) => {
+            warn!("Failed to parse message: {}", e);
+            counter!(
+                FAILURES,
+                &[failures::get_label(FailureKind::UnableToDecodeMessage)]
+            )
+            .increment(1);
+        }
+    }
+}
+
+enum SampleEnvironmentLogType {
+    LogData,
+    SampleEnvironmentData,
+}
+
+pub(crate) enum SampleEnvironmentLog<'a> {
+    LogData(f144_LogData<'a>),
+    SampleEnvironmentData(se00_SampleEnvironmentData<'a>),
+}
+
+#[tracing::instrument(skip_all)]
+fn process_sample_environment_message(
+    nexus_engine: &mut NexusEngine,
+    se_type: SampleEnvironmentLogType,
+    payload: &[u8],
+) {
+    counter!(
+        MESSAGES_RECEIVED,
+        &[messages_received::get_label(
+            MessageKind::SampleEnvironmentData
+        )]
+    )
+    .increment(1);
+    let result = match se_type {
+        SampleEnvironmentLogType::LogData => {
+            spanned_root_as(root_as_f_144_log_data, payload)
+                .map(|data|
+                    nexus_engine.sample_envionment(SampleEnvironmentLog::LogData(data))
+                        .inspect_err(|_|{
+                            warn!("Sample environment ({data:?}) failed.")
+                        })
+            )
+        }
+        SampleEnvironmentLogType::SampleEnvironmentData => {
+            spanned_root_as(root_as_se_00_sample_environment_data, payload)
+                .map(|data|
+                    nexus_engine.sample_envionment(SampleEnvironmentLog::SampleEnvironmentData(data))
+                        .map_err(|e|{
+                            warn!("Sample environment ({data:?}) failed."); e
+                        })
+                )
+        }
+    };
+    match result {
+        Ok(result) => match result {
+            Ok(run) => {
+                if let Some(run) = run {
+                    if let Err(e) = run.link_current_span(|| info_span!("Sample Environment Log")) {
+                        warn!("Run span linking failed {e}")
+                    }
+                }
+            }
+            Err(e) => warn!("Sample environment error: {e}"),
+        },
+        Err(e) => {
+            warn!("Failed to parse message: {}", e);
+            counter!(
+                FAILURES,
+                &[failures::get_label(FailureKind::UnableToDecodeMessage)]
+            )
+            .increment(1);
+        }
+    }
+}
+
+#[tracing::instrument(skip_all)]
+fn process_alarm_message(nexus_engine: &mut NexusEngine, payload: &[u8]) {
+    counter!(
+        MESSAGES_RECEIVED,
+        &[messages_received::get_label(MessageKind::Alarm)]
+    )
+    .increment(1);
+    match spanned_root_as(root_as_alarm, payload) {
+        Ok(data) => match nexus_engine.alarm(data) {
+            Ok(run) => {
+                if let Some(run) = run {
+                    if let Err(e) = run.link_current_span(|| info_span!("Alarm")) {
+                        warn!("Run span linking failed {e}")
+                    }
+                }
+            }
+            Err(e) => warn!("Alarm ({data:?}) failed {e}"),
+        },
+        Err(e) => {
+            warn!("Failed to parse message: {}", e);
+            counter!(
+                FAILURES,
+                &[failures::get_label(FailureKind::UnableToDecodeMessage)]
+            )
+            .increment(1);
+        }
+    }
+}
+
+#[tracing::instrument(skip_all)]
+pub(crate) fn process_logdata_message(nexus_engine: &mut NexusEngine, payload: &[u8]) {
+    counter!(
+        MESSAGES_RECEIVED,
+        &[messages_received::get_label(MessageKind::LogData)]
+    )
+    .increment(1);
+    match spanned_root_as(root_as_f_144_log_data, payload) {
+        Ok(data) => match nexus_engine.logdata(&data) {
+            Ok(run) => {
+                if let Some(run) = run {
+                    if let Err(e) = run.link_current_span(|| info_span!("Run Log Data")) {
+                        warn!("Run span linking failed {e}")
+                    }
+                }
+            }
+            Err(e) => warn!("Run Log Data ({data:?}) failed. Error: {e}"),
+        },
+        Err(e) => {
+            warn!("Failed to parse message: {}", e);
+            counter!(
+                FAILURES,
+                &[failures::get_label(FailureKind::UnableToDecodeMessage)]
+            )
+            .increment(1);
+        }
+    }
+}

--- a/nexus-writer/src/nexus/engine.rs
+++ b/nexus-writer/src/nexus/engine.rs
@@ -1,3 +1,5 @@
+use crate::message_handlers::SampleEnvironmentLog;
+
 use super::{
     error::{ErrorCodeLocation, FlatBufferMissingError, NexusWriterError, NexusWriterResult},
     NexusDateTime, Run, RunParameters,
@@ -15,8 +17,7 @@ use supermusr_common::spanned::SpannedAggregator;
 use supermusr_streaming_types::{
     aev2_frame_assembled_event_v2_generated::FrameAssembledEventListMessage,
     ecs_6s4t_run_stop_generated::RunStop, ecs_al00_alarm_generated::Alarm,
-    ecs_f144_logdata_generated::f144_LogData, ecs_pl72_run_start_generated::RunStart,
-    ecs_se00_data_generated::se00_SampleEnvironmentData,
+    ecs_f144_logdata_generated::f144_LogData, ecs_pl72_run_start_generated::RunStart
 };
 use tracing::{info_span, warn};
 
@@ -94,9 +95,14 @@ impl NexusEngine {
     #[tracing::instrument(skip_all)]
     pub(crate) fn sample_envionment(
         &mut self,
-        data: se00_SampleEnvironmentData<'_>,
+        data: SampleEnvironmentLog,
     ) -> NexusWriterResult<Option<&Run>> {
-        let timestamp = NexusDateTime::from_timestamp_nanos(data.packet_timestamp());
+        let timestamp = NexusDateTime::from_timestamp_nanos(match data {
+            SampleEnvironmentLog::LogData(f144_log_data) => f144_log_data.timestamp(),
+            SampleEnvironmentLog::SampleEnvironmentData(se00_sample_environment_data) => {
+                se00_sample_environment_data.packet_timestamp()
+            }
+        });
         if let Some(run) = self
             .run_cache
             .iter_mut()

--- a/nexus-writer/src/nexus/engine.rs
+++ b/nexus-writer/src/nexus/engine.rs
@@ -17,7 +17,7 @@ use supermusr_common::spanned::SpannedAggregator;
 use supermusr_streaming_types::{
     aev2_frame_assembled_event_v2_generated::FrameAssembledEventListMessage,
     ecs_6s4t_run_stop_generated::RunStop, ecs_al00_alarm_generated::Alarm,
-    ecs_f144_logdata_generated::f144_LogData, ecs_pl72_run_start_generated::RunStart
+    ecs_f144_logdata_generated::f144_LogData, ecs_pl72_run_start_generated::RunStart,
 };
 use tracing::{info_span, warn};
 

--- a/nexus-writer/src/nexus/hdf5_file/run_file.rs
+++ b/nexus-writer/src/nexus/hdf5_file/run_file.rs
@@ -3,11 +3,14 @@ use super::{
     hdf5_writer::{DatasetExt, GroupExt, HasAttributesExt},
     EventRun,
 };
-use crate::nexus::{
-    hdf5_file::run_file_components::{RunLog, SeLog},
-    nexus_class as NX,
-    run_parameters::RunStopParameters,
-    NexusConfiguration, NexusDateTime, NexusSettings, RunParameters, DATETIME_FORMAT,
+use crate::{
+    nexus::{
+        hdf5_file::run_file_components::{RunLog, SeLog},
+        nexus_class as NX,
+        run_parameters::RunStopParameters,
+        NexusConfiguration, NexusDateTime, NexusSettings, RunParameters, DATETIME_FORMAT,
+    },
+    message_handlers::SampleEnvironmentLog,
 };
 use chrono::Utc;
 use hdf5::{types::VarLenUnicode, Dataset, File};
@@ -15,7 +18,6 @@ use std::{fs::create_dir_all, path::Path};
 use supermusr_streaming_types::{
     aev2_frame_assembled_event_v2_generated::FrameAssembledEventListMessage,
     ecs_al00_alarm_generated::Alarm, ecs_f144_logdata_generated::f144_LogData,
-    ecs_se00_data_generated::se00_SampleEnvironmentData,
 };
 use tracing::debug;
 
@@ -306,13 +308,23 @@ impl RunFile {
     #[tracing::instrument(skip_all, level = "trace", err(level = "warn"))]
     pub(crate) fn push_selogdata(
         &mut self,
-        selogdata: se00_SampleEnvironmentData,
+        selogdata: SampleEnvironmentLog,
         origin_time: &NexusDateTime,
         nexus_settings: &NexusSettings,
     ) -> NexusHDF5Result<()> {
-        self.contents
-            .selogs
-            .push_selogdata_to_selog(&selogdata, origin_time, nexus_settings)
+        match selogdata {
+            SampleEnvironmentLog::LogData(f144_log_data) => self
+                .contents
+                .selogs
+                .push_logdata_to_selog(&f144_log_data, origin_time, nexus_settings),
+            SampleEnvironmentLog::SampleEnvironmentData(se00_sample_environment_data) => {
+                self.contents.selogs.push_selogdata_to_selog(
+                    &se00_sample_environment_data,
+                    origin_time,
+                    nexus_settings,
+                )
+            }
+        }
     }
 
     #[tracing::instrument(skip_all, level = "trace", err(level = "warn"))]

--- a/nexus-writer/src/nexus/hdf5_file/run_file.rs
+++ b/nexus-writer/src/nexus/hdf5_file/run_file.rs
@@ -4,13 +4,13 @@ use super::{
     EventRun,
 };
 use crate::{
+    message_handlers::SampleEnvironmentLog,
     nexus::{
         hdf5_file::run_file_components::{RunLog, SeLog},
         nexus_class as NX,
         run_parameters::RunStopParameters,
         NexusConfiguration, NexusDateTime, NexusSettings, RunParameters, DATETIME_FORMAT,
     },
-    message_handlers::SampleEnvironmentLog,
 };
 use chrono::Utc;
 use hdf5::{types::VarLenUnicode, Dataset, File};

--- a/nexus-writer/src/nexus/run.rs
+++ b/nexus-writer/src/nexus/run.rs
@@ -1,3 +1,5 @@
+use crate::message_handlers::SampleEnvironmentLog;
+
 use super::{
     error::NexusWriterResult, hdf5_file::RunFile, NexusConfiguration, NexusDateTime, NexusSettings,
     RunParameters,
@@ -8,7 +10,7 @@ use supermusr_common::spanned::{SpanOnce, SpanOnceError, Spanned, SpannedAggrega
 use supermusr_streaming_types::{
     aev2_frame_assembled_event_v2_generated::FrameAssembledEventListMessage,
     ecs_6s4t_run_stop_generated::RunStop, ecs_al00_alarm_generated::Alarm,
-    ecs_f144_logdata_generated::f144_LogData, ecs_se00_data_generated::se00_SampleEnvironmentData,
+    ecs_f144_logdata_generated::f144_LogData,
 };
 use tracing::{info, info_span, warn, Span};
 
@@ -121,7 +123,7 @@ impl Run {
     pub(crate) fn push_selogdata(
         &mut self,
         local_path: Option<&Path>,
-        logdata: se00_SampleEnvironmentData,
+        logdata: SampleEnvironmentLog,
         nexus_settings: &NexusSettings,
     ) -> NexusWriterResult<()> {
         if let Some(local_path) = local_path {


### PR DESCRIPTION
## Summary of changes

Sample environment logs can be delivered using both `f144_logdata` and `se00_data` schemas. The current nexus writer identifies SELogs by its schema, regardless of which topic it's delivered on. This causes SELogs to be written as RunLogs.

This PR causes the writer to identify each type of Kafka message by the topic it's delivered on, validate it's schema, and process it appropriately.

- Topics are stored in a new struct `Topics` which is passed by reference to functions.
- The `process_payload` function is refactored into functions which handle each topic separately.
- The functions  referred to in `process_payload` are moved into a separate file.
- A `SampleEnvironmentLog` enum is introduced to handle the different schemas that can be used.

## Instruction for review/testing

General code review
Tested with HiFi
(concise and correct instructions to aid the reviewer in verifying that the changes work as intended)
