### PR TITLE
When frame receives repeated digitiser messages

### DIFF
--- a/digitiser-aggregator/src/frame/mod.rs
+++ b/digitiser-aggregator/src/frame/mod.rs
@@ -4,3 +4,17 @@ mod partial;
 
 pub(crate) use aggregated::AggregatedFrame;
 pub(crate) use cache::FrameCache;
+
+pub(crate) enum RejectMessageError {
+    IdAlreadyPresent,
+    TimestampTooEarly,
+}
+
+impl Into<&'static str> for RejectMessageError {
+    fn into(self) -> &'static str {
+        match self {
+            RejectMessageError::IdAlreadyPresent => "id_already_present",
+            RejectMessageError::TimestampTooEarly => "timestamp_too_early",
+        }
+    }
+}

--- a/digitiser-aggregator/src/frame/mod.rs
+++ b/digitiser-aggregator/src/frame/mod.rs
@@ -10,9 +10,9 @@ pub(crate) enum RejectMessageError {
     TimestampTooEarly,
 }
 
-impl Into<&'static str> for RejectMessageError {
-    fn into(self) -> &'static str {
-        match self {
+impl From<RejectMessageError> for &'static str {
+    fn from(value: RejectMessageError) -> Self {
+        match value {
             RejectMessageError::IdAlreadyPresent => "id_already_present",
             RejectMessageError::TimestampTooEarly => "timestamp_too_early",
         }

--- a/digitiser-aggregator/src/frame/partial.rs
+++ b/digitiser-aggregator/src/frame/partial.rs
@@ -43,6 +43,10 @@ impl<D> PartialFrame<D> {
         }
     }
 
+    pub(super) fn has_digitiser_id(&self, did: DigitizerId) -> bool {
+        self.digitiser_data.iter().any(|(id, _)| did == *id)
+    }
+
     pub(super) fn push(&mut self, digitiser_id: DigitizerId, data: D) {
         self.digitiser_data.push((digitiser_id, data));
     }

--- a/digitiser-aggregator/src/main.rs
+++ b/digitiser-aggregator/src/main.rs
@@ -267,7 +267,7 @@ async fn process_digitiser_event_list_message(
 
             // Push the current digitiser message to the frame cache, possibly creating a new partial frame
             if let Err(err) = cache.push(msg.digitizer_id(), &metadata, msg.into()) {
-                tracing::Span::current().record(err.into(),true);
+                tracing::Span::current().record(err.into(), true);
             }
 
             record_metadata_fields_to_span!(&metadata, tracing::Span::current());

--- a/digitiser-aggregator/src/main.rs
+++ b/digitiser-aggregator/src/main.rs
@@ -246,14 +246,15 @@ async fn process_kafka_message(
 
 #[tracing::instrument(skip_all, fields(
     digitiser_id = msg.digitizer_id(),
-    metadata_timestamp = tracing::field::Empty,
-    metadata_frame_number = tracing::field::Empty,
-    metadata_period_number = tracing::field::Empty,
-    metadata_veto_flags = tracing::field::Empty,
-    metadata_protons_per_pulse = tracing::field::Empty,
-    metadata_running = tracing::field::Empty,
+    metadata_timestamp,
+    metadata_frame_number,
+    metadata_period_number,
+    metadata_veto_flags,
+    metadata_protons_per_pulse,
+    metadata_running,
     num_cached_frames = cache.get_num_partial_frames(),
-    is_discarded,
+    timestamp_too_early = false,
+    id_already_present = false,
 ))]
 async fn process_digitiser_event_list_message(
     channel_send: &AggregatedFrameToBufferSender,
@@ -265,12 +266,11 @@ async fn process_digitiser_event_list_message(
             debug!("Event packet: metadata: {:?}", msg.metadata());
 
             // Push the current digitiser message to the frame cache, possibly creating a new partial frame
-            let is_discarded = cache
-                .push(msg.digitizer_id(), &metadata, msg.into())
-                .is_err();
+            if let Err(err) = cache.push(msg.digitizer_id(), &metadata, msg.into()) {
+                tracing::Span::current().record(err.into(),true);
+            }
 
             record_metadata_fields_to_span!(&metadata, tracing::Span::current());
-            tracing::Span::current().record("is_discarded", is_discarded);
 
             cache_poll(channel_send, cache).await?;
         }


### PR DESCRIPTION
## Summary of changes

- The `digitiser-aggregator` checks whether the list of digitiser ids, and reject a digitiser message if its id is already present, and emits a warning.
- Replaces the tracing span field "is_discarded" with the pair "timestamp_too_early" and "id_already_present".
- Defines `RejectMessageError` struct which reports the reason for the digitiser message being rejected.

Closes [When a frame receives multiple messages from the same digitiser](https://github.com/STFC-ICD-Research-and-Design/supermusr-data-pipeline/issues/297).

## Instruction for review/testing

General code review.
Has been tested on simulated data.
