### PR TITLE
Pause sample env topic between runs

### DIFF
--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -5,7 +5,8 @@ pub mod tracer;
 use clap::Args;
 use rdkafka::{
     config::ClientConfig,
-    consumer::{Consumer, StreamConsumer}, error::KafkaError,
+    consumer::{Consumer, StreamConsumer},
+    error::KafkaError,
 };
 
 pub type DigitizerId = u8;
@@ -85,8 +86,7 @@ pub fn create_default_consumer(
     // Subscribe to if topics are provided.
     if let Some(topics_to_subscribe) = topics_to_subscribe {
         // Note this fails if the topics list is empty
-        consumer
-            .subscribe(topics_to_subscribe)?;
+        consumer.subscribe(topics_to_subscribe)?;
     }
 
     Ok(consumer)

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -80,8 +80,7 @@ pub fn create_default_consumer(
         .set("enable.partition.eof", "false")
         .set("session.timeout.ms", "6000")
         .set("enable.auto.commit", "false")
-        .create()
-        .expect("kafka consumer should be created");
+        .create()?;
 
     // Subscribe to if topics are provided.
     if let Some(topics_to_subscribe) = topics_to_subscribe {

--- a/digitiser-aggregator/src/main.rs
+++ b/digitiser-aggregator/src/main.rs
@@ -113,7 +113,7 @@ async fn main() -> anyhow::Result<()> {
         &kafka_opts.username,
         &kafka_opts.password,
         &args.consumer_group,
-        Some(&[args.input_topic.as_str()])
+        Some(&[args.input_topic.as_str()]),
     )?;
 
     let producer: FutureProducer = supermusr_common::generate_kafka_client_config(

--- a/digitiser-aggregator/src/main.rs
+++ b/digitiser-aggregator/src/main.rs
@@ -114,7 +114,8 @@ async fn main() -> anyhow::Result<()> {
         &kafka_opts.password,
         &args.consumer_group,
         Some(&[args.input_topic.as_str()]),
-    ).expect("Topic list should be non-empty, this should never fail.");
+    )
+    .expect("Topic list should be non-empty, this should never fail.");
 
     let producer: FutureProducer = supermusr_common::generate_kafka_client_config(
         &kafka_opts.broker,

--- a/digitiser-aggregator/src/main.rs
+++ b/digitiser-aggregator/src/main.rs
@@ -113,9 +113,8 @@ async fn main() -> anyhow::Result<()> {
         &kafka_opts.username,
         &kafka_opts.password,
         &args.consumer_group,
-        Some(&[args.input_topic.as_str()]),
-    )
-    .expect("Topic list should be non-empty, this should never fail.");
+        Some(&[args.input_topic.as_str()])
+    )?;
 
     let producer: FutureProducer = supermusr_common::generate_kafka_client_config(
         &kafka_opts.broker,

--- a/digitiser-aggregator/src/main.rs
+++ b/digitiser-aggregator/src/main.rs
@@ -113,8 +113,8 @@ async fn main() -> anyhow::Result<()> {
         &kafka_opts.username,
         &kafka_opts.password,
         &args.consumer_group,
-        &[args.input_topic.as_str()],
-    );
+        Some(&[args.input_topic.as_str()]),
+    ).expect("Topic list should be non-empty, this should never fail.");
 
     let producer: FutureProducer = supermusr_common::generate_kafka_client_config(
         &kafka_opts.broker,

--- a/nexus-writer/src/error.rs
+++ b/nexus-writer/src/error.rs
@@ -1,5 +1,6 @@
 use crate::{hdf5_handlers::NexusHDF5Error, run_engine::NexusDateTime};
 use glob::{GlobError, PatternError};
+use rdkafka::error::KafkaError;
 use std::{num::TryFromIntError, path::PathBuf};
 use supermusr_streaming_types::time_conversions::GpsTimeConversionError;
 use thiserror::Error;
@@ -42,6 +43,8 @@ pub(crate) enum NexusWriterError {
     FlatBufferTimestampConversion(#[from] GpsTimeConversionError),
     #[error("{0} at {1}")]
     FlatBufferMissing(FlatBufferMissingError, ErrorCodeLocation),
+    #[error("Kafka Error: {0}")]
+    KafkaError(#[from] KafkaError),
     #[error("Cannot convert local path to string: {path} at {location}")]
     CannotConvertPath {
         path: PathBuf,

--- a/nexus-writer/src/kafka_topic_interface.rs
+++ b/nexus-writer/src/kafka_topic_interface.rs
@@ -1,0 +1,97 @@
+use rdkafka::{
+    consumer::{Consumer, StreamConsumer},
+    error::KafkaResult,
+};
+use tracing::debug;
+
+pub(crate) trait KafkaTopicInterface {
+    fn ensure_subscription_mode_is(&mut self, mode: TopicMode) -> KafkaResult<()>;
+}
+
+pub(super) struct Topics {
+    pub(super) control: String,
+    pub(super) log: String,
+    pub(super) frame_event: String,
+    pub(super) sample_env: String,
+    pub(super) alarm: String,
+}
+
+fn get_nonrepeating_list(list: Vec<&str>) -> Vec<&str> {
+    let mut topics_to_subscribe = list.into_iter().collect::<Vec<&str>>();
+    debug!("{topics_to_subscribe:?}");
+    topics_to_subscribe.sort();
+    topics_to_subscribe.dedup();
+    topics_to_subscribe
+}
+
+impl Topics {
+    fn get_full_nonrepeating_list(&self) -> Vec<&str> {
+        get_nonrepeating_list(vec![
+            &self.control,
+            &self.log,
+            &self.frame_event,
+            &self.sample_env,
+            &self.alarm,
+        ])
+    }
+
+    fn get_continuous_only_nonrepeating_list(&self) -> Vec<&str> {
+        get_nonrepeating_list(vec![&self.control, &self.log, &self.frame_event])
+    }
+}
+
+#[derive(PartialEq)]
+pub(crate) enum TopicMode {
+    Full,
+    ConitinousOnly,
+}
+
+pub(crate) struct TopicSubscriber<'a> {
+    mode: Option<TopicMode>,
+    consumer: &'a StreamConsumer,
+    full_list: Vec<&'a str>,
+    continous_only_list: Vec<&'a str>,
+}
+
+impl<'a> TopicSubscriber<'a> {
+    pub(crate) fn new(consumer: &'a StreamConsumer, topics: &'a Topics) -> Self {
+        let full_list = topics.get_full_nonrepeating_list();
+        let continous_only_list = topics.get_continuous_only_nonrepeating_list();
+        Self {
+            mode: None,
+            consumer,
+            full_list,
+            continous_only_list,
+        }
+    }
+}
+
+impl KafkaTopicInterface for TopicSubscriber<'_> {
+    fn ensure_subscription_mode_is(&mut self, mode: TopicMode) -> KafkaResult<()> {
+        if self
+            .mode
+            .as_ref()
+            .is_none_or(|this_mode| this_mode.eq(&mode))
+        {
+            if self.mode.is_some() {
+                self.consumer.unsubscribe();
+            }
+            match mode {
+                TopicMode::Full => self.consumer.subscribe(&self.full_list)?,
+                TopicMode::ConitinousOnly => self.consumer.subscribe(&self.continous_only_list)?,
+            };
+            self.mode = Some(mode);
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+pub(crate) struct NoKafka;
+
+#[cfg(test)]
+impl KafkaTopicInterface for NoKafka {
+    fn ensure_subscription_mode_is(&mut self, _mode: TopicMode) -> KafkaResult<()> {
+        Ok(())
+    }
+}

--- a/nexus-writer/src/kafka_topic_interface.rs
+++ b/nexus-writer/src/kafka_topic_interface.rs
@@ -2,7 +2,6 @@ use rdkafka::{
     consumer::{Consumer, StreamConsumer},
     error::KafkaResult,
 };
-use tracing::debug;
 
 #[derive(PartialEq)]
 pub(crate) enum TopicMode {
@@ -23,7 +22,7 @@ pub(super) struct Topics {
 }
 
 impl Topics {
-    fn unique_sorted_list_of_mode(&self, mode: TopicMode) -> Vec<&str> {
+    fn topics_for_mode(&self, mode: TopicMode) -> Vec<&str> {
         let mut list: Vec<&str> = match mode {
             TopicMode::Full => vec![
                 &self.control,
@@ -36,7 +35,6 @@ impl Topics {
                 vec![&self.control, &self.log, &self.frame_event]
             }
         };
-        debug!("{list:?}");
         list.sort();
         list.dedup();
         list
@@ -55,8 +53,8 @@ impl<'a> TopicSubscriber<'a> {
         Self {
             mode: None,
             consumer,
-            full_list: topics.unique_sorted_list_of_mode(TopicMode::Full),
-            continous_only_list: topics.unique_sorted_list_of_mode(TopicMode::ConitinousOnly),
+            full_list: topics.topics_for_mode(TopicMode::Full),
+            continous_only_list: topics.topics_for_mode(TopicMode::ConitinousOnly),
         }
     }
 }

--- a/nexus-writer/src/main.rs
+++ b/nexus-writer/src/main.rs
@@ -116,7 +116,7 @@ struct Cli {
 }
 
 struct EngineDependencies<'a> {
-    phantom: PhantomData<&'a ()>
+    phantom: PhantomData<&'a ()>,
 }
 
 impl<'a> NexusEngineDependencies for EngineDependencies<'a> {
@@ -152,7 +152,8 @@ async fn main() -> anyhow::Result<()> {
         &kafka_opts.password,
         &args.consumer_group,
         None,
-    ).expect("Error not possible, this should never fail.");
+    )
+    .expect("Error not possible, this should never fail.");
     let mut topics_subscriber = TopicSubscriber::new(&consumer, &topics);
     topics_subscriber.ensure_subscription_mode_is(TopicMode::Full)?;
 

--- a/nexus-writer/src/main.rs
+++ b/nexus-writer/src/main.rs
@@ -151,9 +151,8 @@ async fn main() -> anyhow::Result<()> {
         &kafka_opts.username,
         &kafka_opts.password,
         &args.consumer_group,
-        None,
-    )
-    .expect("Error not possible, this should never fail.");
+        None
+    )?;
     let mut topics_subscriber = TopicSubscriber::new(&consumer, &topics);
     topics_subscriber.ensure_subscription_mode_is(TopicMode::Full)?;
 

--- a/nexus-writer/src/main.rs
+++ b/nexus-writer/src/main.rs
@@ -151,7 +151,7 @@ async fn main() -> anyhow::Result<()> {
         &kafka_opts.username,
         &kafka_opts.password,
         &args.consumer_group,
-        None
+        None,
     )?;
     let mut topics_subscriber = TopicSubscriber::new(&consumer, &topics);
     topics_subscriber.ensure_subscription_mode_is(TopicMode::Full)?;

--- a/nexus-writer/src/message_handlers.rs
+++ b/nexus-writer/src/message_handlers.rs
@@ -1,5 +1,6 @@
 use crate::{
-    run_engine::{run_messages::SampleEnvironmentLog, NexusEngine}, EngineDependencies
+    run_engine::{run_messages::SampleEnvironmentLog, NexusEngine},
+    EngineDependencies,
 };
 use metrics::counter;
 use supermusr_common::{

--- a/nexus-writer/src/message_handlers.rs
+++ b/nexus-writer/src/message_handlers.rs
@@ -1,6 +1,5 @@
 use crate::{
-    run_engine::{run_messages::SampleEnvironmentLog, NexusEngine},
-    NexusFile,
+    run_engine::{run_messages::SampleEnvironmentLog, NexusEngine}, EngineDependencies
 };
 use metrics::counter;
 use supermusr_common::{
@@ -30,7 +29,7 @@ use tracing::{instrument, warn, warn_span};
 
 /// Processes the message payload for a message on the frame_event_list topic
 pub(crate) fn process_payload_on_frame_event_list_topic(
-    nexus_engine: &mut NexusEngine<NexusFile>,
+    nexus_engine: &mut NexusEngine<EngineDependencies>,
     message_kafka_timestamp_ms: i64,
     payload: &[u8],
 ) {
@@ -43,7 +42,7 @@ pub(crate) fn process_payload_on_frame_event_list_topic(
 
 /// Processes the message payload for a message on the sample_environment topic
 pub(crate) fn process_payload_on_sample_env_topic(
-    nexus_engine: &mut NexusEngine<NexusFile>,
+    nexus_engine: &mut NexusEngine<EngineDependencies>,
     message_kafka_timestamp_ms: i64,
     payload: &[u8],
 ) {
@@ -58,7 +57,7 @@ pub(crate) fn process_payload_on_sample_env_topic(
 
 /// Processes the message payload for a message on the run_log topic
 pub(crate) fn process_payload_on_runlog_topic(
-    nexus_engine: &mut NexusEngine<NexusFile>,
+    nexus_engine: &mut NexusEngine<EngineDependencies>,
     message_kafka_timestamp_ms: i64,
     payload: &[u8],
 ) {
@@ -71,7 +70,7 @@ pub(crate) fn process_payload_on_runlog_topic(
 
 /// Processes the message payload for a message on the alarm topic
 pub(crate) fn process_payload_on_alarm_topic(
-    nexus_engine: &mut NexusEngine<NexusFile>,
+    nexus_engine: &mut NexusEngine<EngineDependencies>,
     message_kafka_timestamp_ms: i64,
     payload: &[u8],
 ) {
@@ -84,7 +83,7 @@ pub(crate) fn process_payload_on_alarm_topic(
 
 /// Processes the message payload for a message on the control topic
 pub(crate) fn process_payload_on_control_topic(
-    nexus_engine: &mut NexusEngine<NexusFile>,
+    nexus_engine: &mut NexusEngine<EngineDependencies>,
     message_kafka_timestamp_ms: i64,
     payload: &[u8],
 ) {
@@ -125,7 +124,7 @@ fn increment_message_received_counter(kind: MessageKind) {
 /// Decode, validate and process a flatbuffer RunStart message
 #[tracing::instrument(skip_all, fields(kafka_message_timestamp_ms=kafka_message_timestamp_ms))]
 fn push_run_start(
-    nexus_engine: &mut NexusEngine<NexusFile>,
+    nexus_engine: &mut NexusEngine<EngineDependencies>,
     kafka_message_timestamp_ms: i64,
     payload: &[u8],
 ) {
@@ -157,7 +156,7 @@ fn push_run_start(
     )
 )]
 fn push_frame_event_list(
-    nexus_engine: &mut NexusEngine<NexusFile>,
+    nexus_engine: &mut NexusEngine<EngineDependencies>,
     kafka_message_timestamp_ms: i64,
     payload: &[u8],
 ) {
@@ -182,7 +181,7 @@ fn push_frame_event_list(
 /// Decode, validate and process a flatbuffer RunLog message
 #[tracing::instrument(skip_all, fields(kafka_message_timestamp_ms=kafka_message_timestamp_ms, has_run))]
 pub(crate) fn push_run_log(
-    nexus_engine: &mut NexusEngine<NexusFile>,
+    nexus_engine: &mut NexusEngine<EngineDependencies>,
     kafka_message_timestamp_ms: i64,
     payload: &[u8],
 ) {
@@ -201,7 +200,7 @@ pub(crate) fn push_run_log(
 /// Decode, validate and process flatbuffer SampleEnvironmentLog messages
 #[tracing::instrument(skip_all, fields(kafka_message_timestamp_ms=kafka_message_timestamp_ms, has_run))]
 fn push_f144_sample_environment_log(
-    nexus_engine: &mut NexusEngine<NexusFile>,
+    nexus_engine: &mut NexusEngine<EngineDependencies>,
     kafka_message_timestamp_ms: i64,
     payload: &[u8],
 ) {
@@ -221,7 +220,7 @@ fn push_f144_sample_environment_log(
 /// Decode, validate and process flatbuffer SampleEnvironmentLog messages
 #[tracing::instrument(skip_all, fields(kafka_message_timestamp_ms=kafka_message_timestamp_ms, has_run))]
 fn push_se00_sample_environment_log(
-    nexus_engine: &mut NexusEngine<NexusFile>,
+    nexus_engine: &mut NexusEngine<EngineDependencies>,
     kafka_message_timestamp_ms: i64,
     payload: &[u8],
 ) {
@@ -241,7 +240,7 @@ fn push_se00_sample_environment_log(
 /// Decode, validate and process a flatbuffer Alarm message
 #[tracing::instrument(skip_all, fields(kafka_message_timestamp_ms=kafka_message_timestamp_ms, has_run))]
 fn push_alarm(
-    nexus_engine: &mut NexusEngine<NexusFile>,
+    nexus_engine: &mut NexusEngine<EngineDependencies>,
     kafka_message_timestamp_ms: i64,
     payload: &[u8],
 ) {
@@ -259,7 +258,7 @@ fn push_alarm(
 /// Decode, validate and process a flatbuffer RunStop message
 #[tracing::instrument(skip_all, fields(kafka_message_timestamp_ms=kafka_message_timestamp_ms, has_run))]
 fn push_run_stop(
-    nexus_engine: &mut NexusEngine<NexusFile>,
+    nexus_engine: &mut NexusEngine<EngineDependencies>,
     kafka_message_timestamp_ms: i64,
     payload: &[u8],
 ) {

--- a/nexus-writer/src/run_engine/engine.rs
+++ b/nexus-writer/src/run_engine/engine.rs
@@ -65,7 +65,8 @@ impl<I: NexusFileInterface> FindValidRun<I> for VecDeque<Run<I>> {
     }
 }
 
-pub(crate) trait NexusEngineDependencies{
+/// This trait encapsulates all dependencies injected into NexusEngine
+pub(crate) trait NexusEngineDependencies {
     type FileInterface: NexusFileInterface;
     type TopicInterface: KafkaTopicInterface;
 }
@@ -222,7 +223,10 @@ impl<D: NexusEngineDependencies> NexusEngine<D> {
 
     /// This pushes a RunStop message to the final run in the cache
     #[tracing::instrument(skip_all, level = "debug")]
-    pub(crate) fn push_run_stop(&mut self, data: RunStop<'_>) -> NexusWriterResult<&Run<D::FileInterface>> {
+    pub(crate) fn push_run_stop(
+        &mut self,
+        data: RunStop<'_>,
+    ) -> NexusWriterResult<&Run<D::FileInterface>> {
         if let Some(last_run) = self.run_cache.back_mut() {
             last_run.set_stop_if_valid(&data)?;
 
@@ -293,7 +297,8 @@ impl<D: NexusEngineDependencies> NexusEngine<D> {
 mod test {
     use super::{NexusEngine, NexusEngineDependencies};
     use crate::{
-        kafka_topic_interface::NoKafka, nexus::NexusNoFile, run_engine::NexusConfiguration, NexusSettings,
+        kafka_topic_interface::NoKafka, nexus::NexusNoFile, run_engine::NexusConfiguration,
+        NexusSettings,
     };
     use chrono::{DateTime, Duration, Utc};
     use supermusr_streaming_types::{

--- a/nexus-writer/src/run_engine/mod.rs
+++ b/nexus-writer/src/run_engine/mod.rs
@@ -4,7 +4,7 @@ pub(crate) mod run_messages;
 mod settings;
 
 use chrono::{DateTime, Utc};
-pub(crate) use engine::NexusEngine;
+pub(crate) use engine::{NexusEngine, NexusEngineDependencies};
 pub(crate) use run::{NexusConfiguration, Run, RunParameters, RunStopParameters};
 pub(crate) use settings::{
     AlarmChunkSize, ChunkSizeSettings, EventChunkSize, FrameChunkSize, NexusSettings,

--- a/nexus-writer/src/run_engine/run/mod.rs
+++ b/nexus-writer/src/run_engine/run/mod.rs
@@ -267,8 +267,12 @@ impl<I: NexusFileInterface> Run<I> {
         Ok(())
     }
 
-    pub(crate) fn is_message_timestamp_valid(&self, timestamp: &NexusDateTime) -> bool {
-        self.parameters.is_message_timestamp_valid(timestamp)
+    pub(crate) fn is_message_timestamp_within_range(&self, timestamp: &NexusDateTime) -> bool {
+        self.parameters.is_message_timestamp_within_range(timestamp)
+    }
+
+    pub(crate) fn is_message_timestamp_before_end(&self, timestamp: &NexusDateTime) -> bool {
+        self.parameters.is_message_timestamp_not_after_end(timestamp)
     }
 
     pub(crate) fn has_completed(&self, delay: &Duration) -> bool {

--- a/nexus-writer/src/run_engine/run/mod.rs
+++ b/nexus-writer/src/run_engine/run/mod.rs
@@ -272,7 +272,8 @@ impl<I: NexusFileInterface> Run<I> {
     }
 
     pub(crate) fn is_message_timestamp_before_end(&self, timestamp: &NexusDateTime) -> bool {
-        self.parameters.is_message_timestamp_not_after_end(timestamp)
+        self.parameters
+            .is_message_timestamp_not_after_end(timestamp)
     }
 
     pub(crate) fn has_completed(&self, delay: &Duration) -> bool {

--- a/nexus-writer/src/run_engine/run/run_parameters.rs
+++ b/nexus-writer/src/run_engine/run/run_parameters.rs
@@ -113,15 +113,22 @@ impl RunParameters {
     /// if run_stop_parameters exist then, if timestamp is strictly
     /// before params.collect_until.
     #[tracing::instrument(skip_all, level = "trace")]
-    pub(crate) fn is_message_timestamp_valid(&self, timestamp: &NexusDateTime) -> bool {
+    pub(crate) fn is_message_timestamp_within_range(&self, timestamp: &NexusDateTime) -> bool {
         if self.collect_from < *timestamp {
-            self.run_stop_parameters
-                .as_ref()
-                .map(|params| *timestamp < params.collect_until)
-                .unwrap_or(true)
+            self.is_message_timestamp_not_after_end(timestamp)
         } else {
             false
         }
+    }
+
+    /// if run_stop_parameters exist then, return true if timestamp is
+    /// strictly before params.collect_until, otherwise returns true.
+    #[tracing::instrument(skip_all, level = "trace")]
+    pub(crate) fn is_message_timestamp_not_after_end(&self, timestamp: &NexusDateTime) -> bool {
+        self.run_stop_parameters
+            .as_ref()
+            .map(|params| *timestamp < params.collect_until)
+            .unwrap_or(true)
     }
 
     #[tracing::instrument(skip_all, level = "trace")]

--- a/trace-archiver-hdf5/src/main.rs
+++ b/trace-archiver-hdf5/src/main.rs
@@ -63,8 +63,8 @@ async fn main() -> anyhow::Result<()> {
         &kafka_opts.username,
         &kafka_opts.password,
         &args.consumer_group,
-        &[args.trace_topic.as_str()],
-    );
+        Some(&[args.trace_topic.as_str()])
+    ).expect("Topic list should be non-empty, this should never fail.");
 
     // Install exporter and register metrics
     let builder = PrometheusBuilder::new();

--- a/trace-archiver-hdf5/src/main.rs
+++ b/trace-archiver-hdf5/src/main.rs
@@ -64,8 +64,7 @@ async fn main() -> anyhow::Result<()> {
         &kafka_opts.password,
         &args.consumer_group,
         Some(&[args.trace_topic.as_str()]),
-    )
-    .expect("Topic list should be non-empty, this should never fail.");
+    )?;
 
     // Install exporter and register metrics
     let builder = PrometheusBuilder::new();

--- a/trace-archiver-hdf5/src/main.rs
+++ b/trace-archiver-hdf5/src/main.rs
@@ -63,8 +63,9 @@ async fn main() -> anyhow::Result<()> {
         &kafka_opts.username,
         &kafka_opts.password,
         &args.consumer_group,
-        Some(&[args.trace_topic.as_str()])
-    ).expect("Topic list should be non-empty, this should never fail.");
+        Some(&[args.trace_topic.as_str()]),
+    )
+    .expect("Topic list should be non-empty, this should never fail.");
 
     // Install exporter and register metrics
     let builder = PrometheusBuilder::new();

--- a/trace-archiver-tdengine/src/main.rs
+++ b/trace-archiver-tdengine/src/main.rs
@@ -85,8 +85,8 @@ async fn main() {
         &kafka_opts.username,
         &kafka_opts.password,
         &args.kafka_consumer_group,
-        &[args.trace_topic.as_str()],
-    );
+        Some(&[args.trace_topic.as_str()])
+    ).expect("Topic list should be non-empty, this should never fail.");
 
     debug!("Begin Listening For Messages");
     loop {

--- a/trace-archiver-tdengine/src/main.rs
+++ b/trace-archiver-tdengine/src/main.rs
@@ -85,8 +85,9 @@ async fn main() {
         &kafka_opts.username,
         &kafka_opts.password,
         &args.kafka_consumer_group,
-        Some(&[args.trace_topic.as_str()])
-    ).expect("Topic list should be non-empty, this should never fail.");
+        Some(&[args.trace_topic.as_str()]),
+    )
+    .expect("Topic list should be non-empty, this should never fail.");
 
     debug!("Begin Listening For Messages");
     loop {

--- a/trace-telemetry-exporter/src/main.rs
+++ b/trace-telemetry-exporter/src/main.rs
@@ -64,8 +64,8 @@ async fn main() -> anyhow::Result<()> {
         &kafka_opts.username,
         &kafka_opts.password,
         &args.consumer_group,
-        &[args.trace_topic.as_str()],
-    );
+        Some(&[args.trace_topic.as_str()])
+    ).expect("Topic list should be non-empty, this should never fail.");
 
     let builder = PrometheusBuilder::new();
     builder

--- a/trace-telemetry-exporter/src/main.rs
+++ b/trace-telemetry-exporter/src/main.rs
@@ -65,8 +65,7 @@ async fn main() -> anyhow::Result<()> {
         &kafka_opts.password,
         &args.consumer_group,
         Some(&[args.trace_topic.as_str()]),
-    )
-    .expect("Topic list should be non-empty, this should never fail.");
+    )?;
 
     let builder = PrometheusBuilder::new();
     builder

--- a/trace-telemetry-exporter/src/main.rs
+++ b/trace-telemetry-exporter/src/main.rs
@@ -64,8 +64,9 @@ async fn main() -> anyhow::Result<()> {
         &kafka_opts.username,
         &kafka_opts.password,
         &args.consumer_group,
-        Some(&[args.trace_topic.as_str()])
-    ).expect("Topic list should be non-empty, this should never fail.");
+        Some(&[args.trace_topic.as_str()]),
+    )
+    .expect("Topic list should be non-empty, this should never fail.");
 
     let builder = PrometheusBuilder::new();
     builder

--- a/trace-to-events/src/main.rs
+++ b/trace-to-events/src/main.rs
@@ -121,7 +121,7 @@ async fn main() -> anyhow::Result<()> {
         &kafka_opts.username,
         &kafka_opts.password,
         &args.consumer_group,
-        Some(&[args.trace_topic.as_str()])
+        Some(&[args.trace_topic.as_str()]),
     )?;
 
     // Install exporter and register metrics

--- a/trace-to-events/src/main.rs
+++ b/trace-to-events/src/main.rs
@@ -121,9 +121,8 @@ async fn main() -> anyhow::Result<()> {
         &kafka_opts.username,
         &kafka_opts.password,
         &args.consumer_group,
-        Some(&[args.trace_topic.as_str()]),
-    )
-    .expect("Topic list should be non-empty, this should never fail.");
+        Some(&[args.trace_topic.as_str()])
+    )?;
 
     // Install exporter and register metrics
     let builder = PrometheusBuilder::new();

--- a/trace-to-events/src/main.rs
+++ b/trace-to-events/src/main.rs
@@ -121,8 +121,8 @@ async fn main() -> anyhow::Result<()> {
         &kafka_opts.username,
         &kafka_opts.password,
         &args.consumer_group,
-        &[args.trace_topic.as_str()],
-    );
+        Some(&[args.trace_topic.as_str()]),
+    ).expect("Topic list should be non-empty, this should never fail.");
 
     // Install exporter and register metrics
     let builder = PrometheusBuilder::new();

--- a/trace-to-events/src/main.rs
+++ b/trace-to-events/src/main.rs
@@ -122,7 +122,8 @@ async fn main() -> anyhow::Result<()> {
         &kafka_opts.password,
         &args.consumer_group,
         Some(&[args.trace_topic.as_str()]),
-    ).expect("Topic list should be non-empty, this should never fail.");
+    )
+    .expect("Topic list should be non-empty, this should never fail.");
 
     // Install exporter and register metrics
     let builder = PrometheusBuilder::new();


### PR DESCRIPTION
## Summary of changes

- Modifies `create_default_consumer` in common crate to make `topics_to_subscribe` parameter optional. Also pushes error handling responsability to the caller.
- Updates all non nexus-writer components appropriately.
- Encapsulates all `NexusEngine` dependencies into a trait to aid future extension.
- Injects new dependency `KafkaTopicSubscriber` to `NexusEngine` which allows `NexusEngine` to switch between two topic subscriber modes: "Full" (which subscribes to all topics) and "Continuous" (which subscribes to all but SampleEnvironmentLogs and Alarms).

Pending further info from Peter, the RunLog topic could also be removed from the "Continuous" mode if required, at the moment it is not removed.

Closes [Record sample env logs since end of last run in current run](https://github.com/STFC-ICD-Research-and-Design/supermusr-data-pipeline/issues/335).

## Instruction for review/testing

General Code Review.
Tested on Simulated Data.
