### PR TITLE
Enable zstd compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,7 +188,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61b1d86e7705efe1be1b569bab41d4fa1e14e220b60a160f78de2db687add079"
 dependencies = [
- "bindgen",
+ "bindgen 0.69.5",
  "cc",
  "cmake",
  "dunce",
@@ -284,10 +284,28 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "shlex",
  "syn",
  "which",
+]
+
+[[package]]
+name = "bindgen"
+version = "0.71.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+dependencies = [
+ "bitflags 2.9.1",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 2.1.1",
+ "shlex",
+ "syn",
 ]
 
 [[package]]
@@ -2082,6 +2100,7 @@ dependencies = [
  "openssl-sys",
  "pkg-config",
  "sasl2-sys",
+ "zstd-sys",
 ]
 
 [[package]]
@@ -2162,6 +2181,12 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc_version"
@@ -3498,3 +3523,14 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.15+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
+dependencies = [
+ "bindgen 0.71.1",
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ rand = "0.9.1"
 rand_distr = "0.5.1"
 ratatui = "0.29.0"
 rayon = "1.10.0"
-rdkafka = { version = "0.37.0", features = ["cmake-build", "ssl", "gssapi", "sasl"] }
+rdkafka = { version = "0.37.0", features = ["cmake-build", "ssl", "gssapi", "sasl", "zstd"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1.0.140" }
 strum = { version = "0.27.1", features = ["derive"] }

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -55,6 +55,7 @@ pub fn generate_kafka_client_config(
 ) -> ClientConfig {
     let mut client_config = ClientConfig::new()
         .set("bootstrap.servers", broker_address)
+        .set("compression.type", "zstd")
         .clone();
 
     // Allow for authenticated Kafka connection if details are provided

--- a/diagnostics/default.nix
+++ b/diagnostics/default.nix
@@ -16,6 +16,8 @@
     nativeBuildInputs = nativeBuildInputs;
     buildInputs = buildInputs;
 
+    LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+
     overrideMain = p: {
       GIT_REVISION = gitRevision;
     };

--- a/digitiser-aggregator/default.nix
+++ b/digitiser-aggregator/default.nix
@@ -16,6 +16,8 @@
     nativeBuildInputs = nativeBuildInputs;
     buildInputs = buildInputs;
 
+    LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+
     overrideMain = p: {
       GIT_REVISION = gitRevision;
     };

--- a/flake.nix
+++ b/flake.nix
@@ -73,6 +73,8 @@
           ];
 
           RUSTFLAGS = lintingRustFlags;
+
+          LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
         };
 
         packages =

--- a/flake.nix
+++ b/flake.nix
@@ -44,6 +44,7 @@
           perl
           tcl
           pkg-config
+          clang
         ];
         buildInputs = with pkgs; [
           openssl

--- a/nexus-writer/default.nix
+++ b/nexus-writer/default.nix
@@ -16,6 +16,8 @@
     nativeBuildInputs = nativeBuildInputs;
     buildInputs = buildInputs;
 
+    LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+
     overrideMain = p: {
       GIT_REVISION = gitRevision;
     };

--- a/simulator/default.nix
+++ b/simulator/default.nix
@@ -16,6 +16,8 @@
     nativeBuildInputs = nativeBuildInputs;
     buildInputs = buildInputs;
 
+    LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+
     overrideMain = p: {
       GIT_REVISION = gitRevision;
     };

--- a/trace-reader/default.nix
+++ b/trace-reader/default.nix
@@ -16,6 +16,8 @@
     nativeBuildInputs = nativeBuildInputs;
     buildInputs = buildInputs;
 
+    LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+
     overrideMain = p: {
       GIT_REVISION = gitRevision;
     };

--- a/trace-telemetry-exporter/default.nix
+++ b/trace-telemetry-exporter/default.nix
@@ -16,6 +16,8 @@
     nativeBuildInputs = nativeBuildInputs;
     buildInputs = buildInputs;
 
+    LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+
     overrideMain = p: {
       GIT_REVISION = gitRevision;
     };

--- a/trace-to-events/default.nix
+++ b/trace-to-events/default.nix
@@ -16,6 +16,8 @@
     nativeBuildInputs = nativeBuildInputs;
     buildInputs = buildInputs;
 
+    LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+
     overrideMain = p: {
       GIT_REVISION = gitRevision;
     };


### PR DESCRIPTION
## Summary of changes

Provide the zstd library and enable zstd compression by default in all components that interact with Kafka.

This is partly experimental to see what the effects are on compute requirements and network throughput are for data "inside" the pipeline.

## Instruction for review/testing

- Run a demo pipeline, using the container images, with and without these changes and see that the same output is still obtained.
- Verify that the data produced is actually compressed (can be done via Redpanda Console).