### PR TITLE
Add Git revision to version output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ edition = "2024"
 anyhow = "1.0.98"
 assert_approx_eq = "1.1.0"
 chrono = { version = "0.4.41", features = ["serde"] }
-clap = { version = "4.5.37", features = ["derive", "env"] }
+clap = { version = "4.5.37", features = ["derive", "env", "cargo", "string"] }
 crossterm = { version = "0.28.1", default-features = false, features = ["events"] }
 flatbuffers = "25.2.10"
 glob = "0.3.2"

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod metrics;
 pub mod spanned;
 pub mod tracer;
+mod version;
 
 use clap::Args;
 use rdkafka::{

--- a/common/src/version.rs
+++ b/common/src/version.rs
@@ -1,0 +1,10 @@
+#[macro_export]
+macro_rules! version {
+    () => {
+        format!(
+            "v{} git={}",
+            clap::crate_version!(),
+            std::option_env!("GIT_REVISION").unwrap_or("<unknown>")
+        )
+    };
+}

--- a/diagnostics/src/main.rs
+++ b/diagnostics/src/main.rs
@@ -5,7 +5,7 @@ use clap::{Args, Parser, Subcommand};
 use supermusr_common::CommonKafkaOpts;
 
 #[derive(Debug, Parser)]
-#[clap(author, version, about)]
+#[clap(author, version = supermusr_common::version!(), about)]
 struct Cli {
     #[clap(subcommand)]
     command: Commands,

--- a/digitiser-aggregator/src/main.rs
+++ b/digitiser-aggregator/src/main.rs
@@ -45,7 +45,7 @@ type AggregatedFrameToBufferSender = Sender<AggregatedFrame<EventData>>;
 type SendAggregatedFrameError = SendError<AggregatedFrame<EventData>>;
 
 #[derive(Debug, Parser)]
-#[clap(author, version, about)]
+#[clap(author, version = supermusr_common::version!(), about)]
 struct Cli {
     #[clap(flatten)]
     common_kafka_options: CommonKafkaOpts,

--- a/nexus-writer/src/main.rs
+++ b/nexus-writer/src/main.rs
@@ -55,7 +55,7 @@ use tracing::{debug, error, warn};
 
 /// [clap] derived struct to handle command line parameters.
 #[derive(Debug, Parser)]
-#[clap(author, version, about)]
+#[clap(author, version = supermusr_common::version!(), about)]
 struct Cli {
     #[clap(flatten)]
     common_kafka_options: CommonKafkaOpts,

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -39,7 +39,7 @@ use tokio::time;
 use tracing::{debug, error, info, warn};
 
 #[derive(Clone, Parser)]
-#[clap(author, version, about)]
+#[clap(author, version = supermusr_common::version!(), about)]
 struct Cli {
     /// Kafka options common to all tools.
     #[clap(flatten)]

--- a/trace-archiver-hdf5/src/main.rs
+++ b/trace-archiver-hdf5/src/main.rs
@@ -23,7 +23,7 @@ use supermusr_streaming_types::dat2_digitizer_analog_trace_v2_generated::{
 use tracing::{debug, error, info, warn};
 
 #[derive(Debug, Parser)]
-#[clap(author, version, about)]
+#[clap(author, version = supermusr_common::version!(), about)]
 struct Cli {
     #[clap(flatten)]
     common_kafka_options: CommonKafkaOpts,

--- a/trace-archiver-tdengine/src/main.rs
+++ b/trace-archiver-tdengine/src/main.rs
@@ -16,7 +16,7 @@ use tdengine::{TimeSeriesEngine, wrapper::TDEngine};
 use tracing::{debug, info, warn};
 
 #[derive(Parser)]
-#[clap(author, version, about)]
+#[clap(author, version = supermusr_common::version!(), about)]
 pub(crate) struct Cli {
     #[clap(flatten)]
     common_kafka_options: CommonKafkaOpts,

--- a/trace-reader/src/main.rs
+++ b/trace-reader/src/main.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use supermusr_common::{CommonKafkaOpts, DigitizerId, FrameNumber};
 
 #[derive(Debug, Parser)]
-#[clap(author, version, about)]
+#[clap(author, version = supermusr_common::version!(), about)]
 struct Cli {
     #[clap(flatten)]
     common_kafka_options: CommonKafkaOpts,

--- a/trace-telemetry-exporter/src/main.rs
+++ b/trace-telemetry-exporter/src/main.rs
@@ -30,7 +30,7 @@ const METRIC_CHANNEL_COUNT: &str = "digitiser_channel_count";
 const METRIC_SAMPLE_COUNT: &str = "digitiser_sample_count";
 
 #[derive(Debug, Parser)]
-#[clap(author, version, about)]
+#[clap(author, version = supermusr_common::version!(), about)]
 struct Cli {
     #[clap(flatten)]
     common_kafka_options: CommonKafkaOpts,

--- a/trace-to-events/src/main.rs
+++ b/trace-to-events/src/main.rs
@@ -46,7 +46,7 @@ type TrySendDigitiserEventListError = TrySendError<DeliveryFuture>;
 const EVENTS_FOUND_METRIC: &str = "events_found";
 
 #[derive(Debug, Parser)]
-#[clap(author, version, about)]
+#[clap(author, version = supermusr_common::version!(), about)]
 struct Cli {
     #[clap(flatten)]
     common_kafka_options: CommonKafkaOpts,


### PR DESCRIPTION
## Summary of changes

Adds Git revision to the output of `--version` when built using Nix.

Note this only really works when components are built as a container image, but that is also really the only time it will be distributed.

## Instruction for review/testing

- Build the container image for a component
- Run it with `--version`
- See that Git revision is also output (and is also correct)
