### PR TITLE
Fix trace viewer Nix build

### DIFF
--- a/trace-viewer/default.nix
+++ b/trace-viewer/default.nix
@@ -16,6 +16,8 @@
     nativeBuildInputs = nativeBuildInputs;
     buildInputs = buildInputs;
 
+    LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+
     overrideMain = p: {
       GIT_REVISION = gitRevision;
     };


### PR DESCRIPTION
## Summary of changes

`trace-viewer` was missing the libclang path added in a previous PR.

## Instruction for review/testing

- See that `trace-viewer` now builds as expected
