### PR TITLE
use selog and runlog rather than selogs and runlogs to be consistent with an ICP-written file

### DIFF
--- a/nexus-writer/src/nexus_structure/entry/mod.rs
+++ b/nexus-writer/src/nexus_structure/entry/mod.rs
@@ -45,9 +45,9 @@ mod labels {
     pub(super) const NAME: &str = "name";
     pub(super) const TITLE: &str = "title";
     pub(super) const INSTRUMENT: &str = "instrument";
-    pub(super) const RUNLOGS: &str = "runlogs";
+    pub(super) const RUNLOGS: &str = "runlog";
     pub(super) const PERIODS: &str = "periods";
-    pub(super) const SELOGS: &str = "selogs";
+    pub(super) const SELOGS: &str = "selog";
     pub(super) const SAMPLE: &str = "sample";
     pub(super) const DETECTOR_1: &str = "detector_1";
 }


### PR DESCRIPTION

## Summary of changes

I believe these are `runlog` and `selog` in an ICP written file rather than the plural. 

## Instruction for review/testing

manual test - a file gets written with the new labels? 
