### PR TITLE
Prefix metric names with `muon_data_pipeline_`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4649,6 +4649,7 @@ name = "supermusr-common"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "const_format",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
@@ -5123,6 +5124,7 @@ dependencies = [
  "assert_approx_eq",
  "chrono",
  "clap",
+ "const_format",
  "metrics",
  "metrics-exporter-prometheus",
  "num",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ cfg-if = { version = "1" }
 chrono = { version = "0.4.41", features = ["serde"] }
 clap = { version = "4.5.42", features = ["derive", "env", "cargo", "string"] }
 console_error_panic_hook = { version = "0.1" }
+const_format = "0.2.34"
 crossterm = { version = "0.29.0", default-features = false, features = ["events"] }
 flatbuffers = "25.2.10"
 glob = "0.3.2"

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 
 [dependencies]
 clap.workspace = true
+const_format.workspace = true
 opentelemetry.workspace = true
 opentelemetry-otlp.workspace = true
 opentelemetry_sdk.workspace = true

--- a/common/src/metrics.rs
+++ b/common/src/metrics.rs
@@ -1,8 +1,12 @@
-pub mod metric_names {
-    pub const FAILURES: &str = "failures";
-    pub const FRAMES_SENT: &str = "frames sent";
-    pub const MESSAGES_PROCESSED: &str = "messages_processed";
-    pub const MESSAGES_RECEIVED: &str = "messages_received";
+pub mod names {
+    use const_format::concatcp;
+
+    pub const METRIC_NAME_PREFIX: &str = "muon_data_pipeline_";
+
+    pub const FAILURES: &str = concatcp!(METRIC_NAME_PREFIX, "failures");
+    pub const FRAMES_SENT: &str = concatcp!(METRIC_NAME_PREFIX, "frames_sent");
+    pub const MESSAGES_PROCESSED: &str = concatcp!(METRIC_NAME_PREFIX, "messages_processed");
+    pub const MESSAGES_RECEIVED: &str = concatcp!(METRIC_NAME_PREFIX, "messages_received");
 }
 
 pub mod messages_received {

--- a/digitiser-aggregator/src/main.rs
+++ b/digitiser-aggregator/src/main.rs
@@ -54,7 +54,7 @@ use supermusr_common::{
     metrics::{
         failures::{self, FailureKind},
         messages_received::{self, MessageKind},
-        metric_names::{FAILURES, FRAMES_SENT, MESSAGES_PROCESSED, MESSAGES_RECEIVED},
+        names::{FAILURES, FRAMES_SENT, MESSAGES_PROCESSED, MESSAGES_RECEIVED},
     },
     record_metadata_fields_to_span,
     spanned::Spanned,

--- a/nexus-writer/src/main.rs
+++ b/nexus-writer/src/main.rs
@@ -43,7 +43,7 @@ use supermusr_common::{
     CommonKafkaOpts, init_tracer,
     metrics::{
         messages_received::{self, MessageKind},
-        metric_names::{FAILURES, MESSAGES_PROCESSED, MESSAGES_RECEIVED},
+        names::{FAILURES, MESSAGES_PROCESSED, MESSAGES_RECEIVED},
     },
     tracer::{OptionalHeaderTracerExt, TracerEngine, TracerOptions},
 };

--- a/nexus-writer/src/message_handlers.rs
+++ b/nexus-writer/src/message_handlers.rs
@@ -9,7 +9,7 @@ use supermusr_common::{
     metrics::{
         failures::{self, FailureKind},
         messages_received::{self, MessageKind},
-        metric_names::{FAILURES, MESSAGES_RECEIVED},
+        names::{FAILURES, MESSAGES_RECEIVED},
     },
     record_metadata_fields_to_span,
 };

--- a/trace-to-events/Cargo.toml
+++ b/trace-to-events/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
+const_format.workspace = true
 metrics.workspace = true
 metrics-exporter-prometheus.workspace = true
 num.workspace = true

--- a/trace-to-events/src/main.rs
+++ b/trace-to-events/src/main.rs
@@ -4,6 +4,7 @@ mod processing;
 mod pulse_detection;
 
 use clap::Parser;
+use const_format::concatcp;
 use metrics::counter;
 use metrics_exporter_prometheus::PrometheusBuilder;
 use parameters::{DetectorSettings, Mode, Polarity};
@@ -19,7 +20,7 @@ use supermusr_common::{
     metrics::{
         failures::{self, FailureKind},
         messages_received::{self, MessageKind},
-        metric_names::{FAILURES, MESSAGES_PROCESSED, MESSAGES_RECEIVED},
+        names::{FAILURES, MESSAGES_PROCESSED, MESSAGES_RECEIVED, METRIC_NAME_PREFIX},
     },
     record_metadata_fields_to_span,
     tracer::{FutureRecordTracerExt, OptionalHeaderTracerExt, TracerEngine, TracerOptions},
@@ -43,7 +44,7 @@ use tracing::{debug, error, info, instrument, trace, warn};
 type DigitiserEventListToBufferSender = Sender<DeliveryFuture>;
 type TrySendDigitiserEventListError = TrySendError<DeliveryFuture>;
 
-const EVENTS_FOUND_METRIC: &str = "events_found";
+const EVENTS_FOUND_METRIC: &str = concatcp!(METRIC_NAME_PREFIX, "events_found");
 
 #[derive(Debug, Parser)]
 #[clap(author, version = supermusr_common::version!(), about)]


### PR DESCRIPTION
## Summary of changes

Adds "muon_data_pipeline_" prefix to all common metric names.
Aids in finding metrics in the collection of other things collected by Prometheus.

## Instruction for review/testing

- Run any component that exposes metrics
- `curl` the metrics endpoint
- See that metrics names have the expected prefix

(or code review is realistically enough)
