### PR TITLE
Temporarily remove trace-viewer from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
           - simulator
           - trace-reader
           - trace-to-events
-          - trace-viewer
+          # - trace-viewer
           - trace-viewer-tui
 
     uses: ./.github/workflows/component.yml


### PR DESCRIPTION
## Summary of changes

Some more thought is needed how container images are built for this.

## Instruction for review/testing

See that trace-viewer does not appear in CI jobs.
