### PR TITLE
Add wasm-opt tool and increase recursion limit

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -92,6 +92,7 @@
             # Additional toolchain components for trace-viewer
             pkgs-unstable.cargo-leptos
             dart-sass
+            binaryen
           ];
 
           RUSTFLAGS = lintingRustFlags;

--- a/trace-viewer/src/lib.rs
+++ b/trace-viewer/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(unused_crate_dependencies)]
+#![recursion_limit = "256"]
 
 pub mod app;
 pub mod structs;


### PR DESCRIPTION
## Summary of changes

Adds `binaryen` package needed for optimise WASM.
Increases recursion limit during compilation.

## Instruction for review/testing

Ensure release build compiles with out error (don't worry about functionality).

```shell
cargo leptos watch --release -p trace-viewer -- --broker="localhost:9092" --consumer-group viewer --trace-topic Traces --digitiser-event-topic Events --name MuSR --channels 14 --channels 50 --digitiser-ids 3 --timestamp 2025-08-12T11:28:19.1Z --number 2 --link-to-redpanda-console="http://130.246.55.29:8080/overview" --broker-name="Local Broker"
```