### PR TITLE
Remove remaining uses of `anyhow`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1302,10 +1302,10 @@ dependencies = [
 name = "diagnostics"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "chrono",
  "clap",
  "crossterm 0.29.0",
+ "miette",
  "ratatui",
  "rdkafka",
  "supermusr-common",
@@ -2972,13 +2972,13 @@ checksum = "60993920e071b0c9b66f14e2b32740a4e27ffc82854dcd72035887f336a09a28"
 name = "nexus-writer"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "chrono",
  "clap",
  "glob",
  "hdf5-metno",
  "metrics",
  "metrics-exporter-prometheus",
+ "miette",
  "ndarray",
  "rdkafka",
  "strum 0.27.2",
@@ -4509,9 +4509,9 @@ checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 name = "simulator"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "chrono",
  "clap",
+ "miette",
  "rand 0.9.2",
  "rand_distr",
  "rayon",
@@ -5088,9 +5088,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 name = "trace-reader"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "chrono",
  "clap",
+ "miette",
  "rand 0.9.2",
  "rdkafka",
  "supermusr-common",
@@ -5104,13 +5104,13 @@ dependencies = [
 name = "trace-to-events"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "assert_approx_eq",
  "chrono",
  "clap",
  "const_format",
  "metrics",
  "metrics-exporter-prometheus",
+ "miette",
  "num",
  "rand 0.9.2",
  "rayon",
@@ -5156,10 +5156,10 @@ dependencies = [
 name = "trace-viewer-tui"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "chrono",
  "clap",
  "crossterm 0.29.0",
+ "miette",
  "plotters",
  "ratatui",
  "rdkafka",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ edition = "2024"
 [workspace.dependencies]
 actix-files = { version = "0.6" }
 actix-web = { version = "4", features = ["macros"] }
-anyhow = "1.0.98"
 assert_approx_eq = "1.1.0"
 cfg-if = { version = "1" }
 chrono = { version = "0.4.41", features = ["serde"] }

--- a/diagnostics/Cargo.toml
+++ b/diagnostics/Cargo.toml
@@ -5,10 +5,10 @@ license.workspace = true
 edition.workspace = true
 
 [dependencies]
-anyhow.workspace = true
 chrono.workspace = true
 clap.workspace = true
 crossterm.workspace = true
+miette = { workspace = true, features = ["fancy"] }
 ratatui.workspace = true
 rdkafka.workspace = true
 supermusr-common.workspace = true

--- a/diagnostics/src/kafka_tail.rs
+++ b/diagnostics/src/kafka_tail.rs
@@ -1,4 +1,5 @@
 use super::CommonOpts;
+use miette::IntoDiagnostic;
 use rdkafka::{
     Message,
     consumer::{CommitMode, Consumer, StreamConsumer},
@@ -6,7 +7,7 @@ use rdkafka::{
 use tracing::{debug, error, warn};
 
 // Message dumping tool
-pub(crate) async fn run(args: CommonOpts) -> anyhow::Result<()> {
+pub(crate) async fn run(args: CommonOpts) -> miette::Result<()> {
     tracing_subscriber::fmt::init();
 
     let kafka_opts = args.common_kafka_options;
@@ -20,9 +21,10 @@ pub(crate) async fn run(args: CommonOpts) -> anyhow::Result<()> {
     .set("enable.partition.eof", "false")
     .set("session.timeout.ms", "6000")
     .set("enable.auto.commit", "false")
-    .create()?;
+    .create()
+    .into_diagnostic()?;
 
-    consumer.subscribe(&[&args.topic])?;
+    consumer.subscribe(&[&args.topic]).into_diagnostic()?;
 
     loop {
         match consumer.recv().await {

--- a/diagnostics/src/main.rs
+++ b/diagnostics/src/main.rs
@@ -67,7 +67,7 @@ struct DaqTraceOpts {
 }
 
 #[tokio::main]
-async fn main() -> anyhow::Result<()> {
+async fn main() -> miette::Result<()> {
     let cli = Cli::parse();
     match cli.command {
         Commands::DaqTrace(args) => daq_trace::run(args).await,

--- a/nexus-writer/Cargo.toml
+++ b/nexus-writer/Cargo.toml
@@ -5,13 +5,13 @@ license.workspace = true
 edition.workspace = true
 
 [dependencies]
-anyhow.workspace = true
 chrono.workspace = true
 clap.workspace = true
 glob.workspace = true
 hdf5.workspace = true
 metrics.workspace = true
 metrics-exporter-prometheus.workspace = true
+miette = { workspace = true, features = ["fancy"] }
 ndarray.workspace = true
 rdkafka.workspace = true
 strum.workspace = true

--- a/simulator/Cargo.toml
+++ b/simulator/Cargo.toml
@@ -5,9 +5,9 @@ license.workspace = true
 edition.workspace = true
 
 [dependencies]
-anyhow.workspace = true
 chrono.workspace = true
 clap.workspace = true
+miette = { workspace = true, features = ["fancy"] }
 rand.workspace = true
 rand_distr.workspace = true
 rayon.workspace = true

--- a/trace-reader/Cargo.toml
+++ b/trace-reader/Cargo.toml
@@ -5,9 +5,9 @@ license.workspace = true
 edition.workspace = true
 
 [dependencies]
-anyhow.workspace = true
 chrono.workspace = true
 clap.workspace = true
+miette = { workspace = true, features = ["fancy"] }
 rand.workspace = true
 rdkafka.workspace = true
 supermusr-common.workspace = true

--- a/trace-to-events/Cargo.toml
+++ b/trace-to-events/Cargo.toml
@@ -5,12 +5,12 @@ license.workspace = true
 edition.workspace = true
 
 [dependencies]
-anyhow.workspace = true
 chrono.workspace = true
 clap.workspace = true
 const_format.workspace = true
 metrics.workspace = true
 metrics-exporter-prometheus.workspace = true
+miette = { workspace = true, features = ["fancy"] }
 num.workspace = true
 rayon.workspace = true
 rdkafka.workspace = true

--- a/trace-viewer-tui/Cargo.toml
+++ b/trace-viewer-tui/Cargo.toml
@@ -5,10 +5,10 @@ license.workspace = true
 edition.workspace = true
 
 [dependencies]
-anyhow.workspace = true
 chrono.workspace = true
 clap.workspace = true
 crossterm.workspace = true
+miette = { workspace = true, features = ["fancy"] }
 plotters.workspace = true
 ratatui.workspace = true
 rdkafka.workspace = true

--- a/trace-viewer-tui/src/graphics/mod.rs
+++ b/trace-viewer-tui/src/graphics/mod.rs
@@ -2,6 +2,7 @@ mod bounds;
 mod svg;
 
 use crate::messages::{DigitiserMetadata, DigitiserTrace};
+use miette::IntoDiagnostic;
 use std::{
     fs::create_dir_all,
     path::{Path, PathBuf},
@@ -24,16 +25,16 @@ impl FileFormat {
         path: &Path,
         metadata: &DigitiserMetadata,
         channel: Channel,
-    ) -> anyhow::Result<PathBuf> {
+    ) -> miette::Result<PathBuf> {
         let mut path_buf = path.to_owned();
         path_buf.push(metadata.timestamp.to_rfc3339());
-        create_dir_all(&path_buf)?;
+        create_dir_all(&path_buf).into_diagnostic()?;
         path_buf.push(channel.to_string());
 
         if path_buf.set_extension(self.to_string()) {
             Ok(path_buf)
         } else {
-            Err(anyhow::anyhow!(
+            Err(miette::miette!(
                 "Could not set file extension {} to {:?}",
                 self.to_string(),
                 path_buf
@@ -49,5 +50,5 @@ pub(crate) trait GraphSaver: Default {
         path: PathBuf,
         size: (u32, u32),
         bounds: Bounds,
-    ) -> Result<(), anyhow::Error>;
+    ) -> Result<(), miette::Error>;
 }

--- a/trace-viewer-tui/src/graphics/svg.rs
+++ b/trace-viewer-tui/src/graphics/svg.rs
@@ -3,6 +3,7 @@ use crate::{
     graphics::Bounds,
     messages::{DigitiserTrace, EventList, Trace},
 };
+use miette::IntoDiagnostic;
 use plotters::{
     chart::{ChartBuilder, ChartContext},
     coord::{Shift, types::RangedCoordf64},
@@ -19,13 +20,13 @@ type MyChartContext<'a> =
     ChartContext<'a, SVGBackend<'a>, Cartesian2d<RangedCoordf64, RangedCoordf64>>;
 
 trait MyBuilder<'a>: Sized {
-    fn build_trace_graph(root: &MyDrawingArea<'a>, bounds: Bounds) -> anyhow::Result<Self>;
+    fn build_trace_graph(root: &MyDrawingArea<'a>, bounds: Bounds) -> miette::Result<Self>;
     fn draw_eventlist_to_chart(
         &mut self,
         eventlist: &EventList,
         label: &str,
-    ) -> Result<(), anyhow::Error>;
-    fn draw_trace_to_chart(&mut self, trace: &Trace, label: &str) -> Result<(), anyhow::Error>;
+    ) -> Result<(), miette::Error>;
+    fn draw_trace_to_chart(&mut self, trace: &Trace, label: &str) -> Result<(), miette::Error>;
 }
 
 #[derive(Default)]
@@ -36,7 +37,7 @@ impl<'a> MyBuilder<'a> for MyChartContext<'a> {
     fn build_trace_graph(
         root: &MyDrawingArea<'a>,
         bounds: Bounds,
-    ) -> anyhow::Result<MyChartContext<'a>> {
+    ) -> miette::Result<MyChartContext<'a>> {
         let mut chart = ChartBuilder::on(root)
             .x_label_area_size(35)
             .y_label_area_size(40)
@@ -45,14 +46,16 @@ impl<'a> MyBuilder<'a> for MyChartContext<'a> {
             .build_cartesian_2d(
                 bounds.time.min..bounds.time.max,
                 bounds.intensity.min..bounds.intensity.max,
-            )?;
+            )
+            .into_diagnostic()?;
 
         chart
             .configure_mesh()
             .disable_x_mesh()
             .disable_y_mesh()
             .y_label_formatter(&|x| format!("{x:e}"))
-            .draw()?;
+            .draw()
+            .into_diagnostic()?;
 
         Ok(chart)
     }
@@ -62,27 +65,29 @@ impl<'a> MyBuilder<'a> for MyChartContext<'a> {
         &mut self,
         eventlist: &EventList,
         label: &str,
-    ) -> Result<(), anyhow::Error> {
+    ) -> Result<(), miette::Error> {
         let data = eventlist
             .iter()
             .map(|el| (el.time as f64, el.intensity as f64));
         let ps: PointSeries<_, _, Circle<_, _>, _> =
             PointSeries::new(data, 4, ShapeStyle::from(&BLACK));
-        self.draw_series(ps)?
+        self.draw_series(ps)
+            .into_diagnostic()?
             .label(label)
             .legend(|(x, y)| Circle::new((x, y), 4, BLACK));
         Ok(())
     }
 
     #[instrument(skip_all, level = "debug")]
-    fn draw_trace_to_chart(&mut self, trace: &Trace, label: &str) -> Result<(), anyhow::Error> {
+    fn draw_trace_to_chart(&mut self, trace: &Trace, label: &str) -> Result<(), miette::Error> {
         let data = trace
             .iter()
             .cloned()
             .enumerate()
             .map(|(x, y)| (x as f64, y as f64));
 
-        self.draw_series(LineSeries::new(data, &BLUE))?
+        self.draw_series(LineSeries::new(data, &BLUE))
+            .into_diagnostic()?
             .label(label)
             .legend(|(x, y)| PathElement::new(vec![(x - 10, y), (x + 10, y)], BLUE));
         Ok(())
@@ -96,10 +101,10 @@ impl GraphSaver for SvgSaver {
         path: PathBuf,
         (width, height): (u32, u32),
         bounds: Bounds,
-    ) -> Result<(), anyhow::Error> {
+    ) -> Result<(), miette::Error> {
         let root = SVGBackend::new(&path, (width, height)).into_drawing_area();
 
-        root.fill(&WHITE)?;
+        root.fill(&WHITE).into_diagnostic()?;
 
         let mut chart = MyChartContext::build_trace_graph(&root, bounds)?;
 
@@ -115,9 +120,10 @@ impl GraphSaver for SvgSaver {
         chart
             .configure_series_labels()
             .background_style(WHITE)
-            .draw()?;
+            .draw()
+            .into_diagnostic()?;
 
-        root.present()?;
+        root.present().into_diagnostic()?;
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary of changes

Replaces the last uses of `anyhow` with `miette`.

## Instruction for review/testing

Code review and CI passing should be sufficient. Make sure the `fancy` feature is on for binaries and off for anything else.
