### PR TITLE
Trace viewer fix ordering bug

### DIFF
--- a/trace-viewer/src/finder/task/binary_by_timestamp.rs
+++ b/trace-viewer/src/finder/task/binary_by_timestamp.rs
@@ -126,7 +126,7 @@ impl<'a> SearchTask<'a, BinarySearchByTimestamp> {
                 .await;
 
             for trace in trace_results.iter() {
-                cache.push_trace(&trace.try_unpacked_message().expect("Cannot Unpack Trace"));
+                cache.push_trace(&trace.try_unpacked_message().expect("Cannot Unpack Trace"))?;
             }
 
             if let Some((eventlist_results, _)) = eventlist_results {
@@ -135,7 +135,7 @@ impl<'a> SearchTask<'a, BinarySearchByTimestamp> {
                         &eventlist
                             .try_unpacked_message()
                             .expect("Cannot Unpack Eventlist"),
-                    );
+                    )?;
                 }
             }
         }

--- a/trace-viewer/src/finder/topic_searcher/searcher.rs
+++ b/trace-viewer/src/finder/topic_searcher/searcher.rs
@@ -9,8 +9,8 @@ use rdkafka::{
     consumer::{Consumer, StreamConsumer},
     error::KafkaError,
 };
-use supermusr_streaming_types::time_conversions::GpsTimeConversionError;
 use std::time::Duration;
+use supermusr_streaming_types::time_conversions::GpsTimeConversionError;
 use thiserror::Error;
 use tracing::{info, instrument};
 

--- a/trace-viewer/src/finder/topic_searcher/searcher.rs
+++ b/trace-viewer/src/finder/topic_searcher/searcher.rs
@@ -9,6 +9,7 @@ use rdkafka::{
     consumer::{Consumer, StreamConsumer},
     error::KafkaError,
 };
+use supermusr_streaming_types::time_conversions::GpsTimeConversionError;
 use std::time::Duration;
 use thiserror::Error;
 use tracing::{info, instrument};
@@ -21,7 +22,7 @@ pub(crate) enum SearcherError {
     EndOfTopicReached,
     #[error("No valid message found")]
     NoMessageFound(#[from] BorrowedMessageError),
-    #[error("Kafka Error {0}")]
+    #[error("Kafka Error: {0}")]
     Kafka(#[from] KafkaError),
 }
 

--- a/trace-viewer/src/finder/topic_searcher/searcher.rs
+++ b/trace-viewer/src/finder/topic_searcher/searcher.rs
@@ -22,6 +22,8 @@ pub(crate) enum SearcherError {
     EndOfTopicReached,
     #[error("No valid message found")]
     NoMessageFound(#[from] BorrowedMessageError),
+    #[error("Timestamp Conversion Error: {0}")]
+    TimestampConversion(#[from] GpsTimeConversionError),
     #[error("Kafka Error: {0}")]
     Kafka(#[from] KafkaError),
 }

--- a/trace-viewer/src/sessions/session.rs
+++ b/trace-viewer/src/sessions/session.rs
@@ -100,11 +100,6 @@ impl Session {
             .as_ref()
             .ok_or(SessionError::ResultsMissing)?
             .cache()?
-            .print();
-        self.results
-            .as_ref()
-            .ok_or(SessionError::ResultsMissing)?
-            .cache()?
             .iter()
             .nth(index)
             .ok_or(SessionError::TraceNotFound)

--- a/trace-viewer/src/sessions/session.rs
+++ b/trace-viewer/src/sessions/session.rs
@@ -65,19 +65,11 @@ impl Session {
 
     #[instrument(skip_all)]
     pub fn get_search_summaries(&self) -> Result<Vec<TraceSummary>, SessionError> {
-        let mut digitiser_messages = self
+        Ok(self
             .results
             .as_ref()
             .ok_or(SessionError::ResultsMissing)?
             .cache()?
-            .iter()
-            .collect::<Vec<_>>();
-
-        digitiser_messages.sort_by(|(metadata1, _), (metadata2, _)| {
-            metadata1.timestamp.cmp(&metadata2.timestamp)
-        });
-
-        Ok(digitiser_messages
             .iter()
             .enumerate()
             .map(|(index, (metadata, trace))| {
@@ -104,6 +96,11 @@ impl Session {
         &self,
         index: usize,
     ) -> Result<(&DigitiserMetadata, &DigitiserTrace), SessionError> {
+        self.results
+            .as_ref()
+            .ok_or(SessionError::ResultsMissing)?
+            .cache()?
+            .print();
         self.results
             .as_ref()
             .ok_or(SessionError::ResultsMissing)?

--- a/trace-viewer/src/structs/digitiser_messages.rs
+++ b/trace-viewer/src/structs/digitiser_messages.rs
@@ -1,5 +1,5 @@
 //! Converts borrowed trace and eventlist flatbuffer messages into convenient structures.
-use crate::{Channel, DigitizerId, Intensity, Time};
+use crate::{Channel, DigitizerId, Intensity, Time, Timestamp};
 use cfg_if::cfg_if;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
@@ -14,7 +14,7 @@ pub(crate) type Trace = Vec<Intensity>;
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Serialize, Deserialize)]
 pub(crate) struct DigitiserMetadata {
     /// Unique to each frame.
-    pub(crate) timestamp: DateTime<Utc>,
+    pub(crate) timestamp: Timestamp,
     /// Unique to each digitiser.
     pub(crate) id: DigitizerId,
 }

--- a/trace-viewer/src/structs/digitiser_messages.rs
+++ b/trace-viewer/src/structs/digitiser_messages.rs
@@ -1,7 +1,6 @@
 //! Converts borrowed trace and eventlist flatbuffer messages into convenient structures.
 use crate::{Channel, DigitizerId, Intensity, Time, Timestamp};
 use cfg_if::cfg_if;
-use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 

--- a/trace-viewer/src/structs/digitiser_messages.rs
+++ b/trace-viewer/src/structs/digitiser_messages.rs
@@ -11,12 +11,12 @@ use std::collections::HashMap;
 pub(crate) type Trace = Vec<Intensity>;
 
 /// Bundles all metadata which uniquely defines each digitiser message.
-#[derive(Clone, PartialEq, Eq, Hash, Debug, Serialize, Deserialize)]
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Debug, Serialize, Deserialize)]
 pub(crate) struct DigitiserMetadata {
-    /// Unique to each digitiser.
-    pub(crate) id: DigitizerId,
     /// Unique to each frame.
     pub(crate) timestamp: DateTime<Utc>,
+    /// Unique to each digitiser.
+    pub(crate) id: DigitizerId,
 }
 
 /// Encapsulates all traces of a digitiser trace message.

--- a/trace-viewer/src/structs/server_only/search_results.rs
+++ b/trace-viewer/src/structs/server_only/search_results.rs
@@ -103,20 +103,4 @@ impl Cache {
             }
         }
     }
-
-    pub(crate) fn print(&self) {
-        for trace in &self.traces {
-            println!("{}", trace.0.id);
-            println!(
-                "channels: {}",
-                trace
-                    .1
-                    .traces
-                    .iter()
-                    .map(|x| x.0.to_string())
-                    .collect::<Vec<_>>()
-                    .join(", ")
-            );
-        }
-    }
 }

--- a/trace-viewer/src/structs/server_only/search_results.rs
+++ b/trace-viewer/src/structs/server_only/search_results.rs
@@ -6,11 +6,12 @@ use crate::{
 };
 use std::collections::{
     BTreeMap,
-    btree_map::{self,Entry}
+    btree_map::{self, Entry},
 };
 use supermusr_streaming_types::{
     dat2_digitizer_analog_trace_v2_generated::DigitizerAnalogTraceMessage,
-    dev2_digitizer_event_v2_generated::DigitizerEventListMessage, time_conversions::GpsTimeConversionError,
+    dev2_digitizer_event_v2_generated::DigitizerEventListMessage,
+    time_conversions::GpsTimeConversionError,
 };
 use tracing::{error, info};
 
@@ -36,7 +37,10 @@ pub struct Cache {
 }
 
 impl Cache {
-    pub(crate) fn push_trace(&mut self, msg: &DigitizerAnalogTraceMessage<'_>) -> Result<(), GpsTimeConversionError> {
+    pub(crate) fn push_trace(
+        &mut self,
+        msg: &DigitizerAnalogTraceMessage<'_>,
+    ) -> Result<(), GpsTimeConversionError> {
         info!("New Trace");
         let metadata = DigitiserMetadata {
             id: msg.digitizer_id(),
@@ -62,7 +66,10 @@ impl Cache {
         self.traces.iter()
     }
 
-    pub(crate) fn push_events(&mut self, msg: &DigitizerEventListMessage<'_>) -> Result<(), GpsTimeConversionError> {
+    pub(crate) fn push_events(
+        &mut self,
+        msg: &DigitizerEventListMessage<'_>,
+    ) -> Result<(), GpsTimeConversionError> {
         let metadata = DigitiserMetadata {
             id: msg.digitizer_id(),
             timestamp: msg
@@ -96,12 +103,20 @@ impl Cache {
             }
         }
     }
-    
+
     pub(crate) fn print(&self) {
         for trace in &self.traces {
             println!("{}", trace.0.id);
-            println!("channels: {}", trace.1.traces.iter().map(|x|x.0.to_string()).collect::<Vec<_>>().join(", "));
-                
+            println!(
+                "channels: {}",
+                trace
+                    .1
+                    .traces
+                    .iter()
+                    .map(|x| x.0.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            );
         }
     }
 }


### PR DESCRIPTION
## Summary of changes

Fixes bug in which some channels and traces are not viewable when selected. This is due to inconsistent ordering of results.
This change replaces the `HashMap` with a `BTreeMap` which preserves order of the keys.

## Instruction for review/testing
- General Code review.
- Ensure the website shows results in order of time/digitiser id, and test traces can be displayed from a wide range of the results (no need to test them all).
```shell
RUST_LOG=debug cargo leptos --log wasm watch -- --broker="172.16.113.245:9092" --consumer-group viewer --trace-topic Traces --digitiser-event-topic Events --name Test --channels 14 --channels 50 --digitiser-ids 3 --timestamp 2025-08-12T11:28:19.1Z --number 20 --link-to-redpanda-console="http://130.246.55.29:8080/overview" --broker-name="Dan K Test Broker"
```

