### PR TITLE
Server path

### DIFF
--- a/trace-viewer/src/app/mod.rs
+++ b/trace-viewer/src/app/mod.rs
@@ -29,7 +29,16 @@ pub(crate) struct TopLevelContext {
     client_side_data: ClientSideData,
 }
 
-pub fn shell(leptos_options: LeptosOptions) -> impl IntoView + 'static {
+pub fn shell(mut leptos_options: LeptosOptions) -> impl IntoView + 'static {
+    let server_path = use_context::<ClientSideData>()
+        .expect("TopLevelContext should be provided, this should never fail.")
+        .server_path;
+
+    if let Some(server_path) = server_path {
+        leptos_options.site_pkg_dir =
+            format!("{server_path}/{}", leptos_options.site_pkg_dir).into();
+    }
+
     view! {
         <!DOCTYPE html>
         <html lang="en">

--- a/trace-viewer/src/app/topbar.rs
+++ b/trace-viewer/src/app/topbar.rs
@@ -20,6 +20,11 @@ pub(crate) fn TopBar() -> impl IntoView {
     let feature_url = format!(
         "https://github.com/STFC-ICD-Research-and-Design/supermusr-data-pipeline/issues/new?title=Trace Viewer ({git_revision}): &template=feature.md"
     );
+    let (home_url, help_url) = if let Some(server_path) = client_side_data.server_path {
+        (server_path.clone(), format!("{server_path}/help"))
+    } else {
+        ("/".to_string(), "/help".to_string())
+    };
 
     view! {
         <div class = "topbar">
@@ -28,11 +33,11 @@ pub(crate) fn TopBar() -> impl IntoView {
                 <div class = "subtitle">{broker_name}</div>
             </div>
             <div class = "menu">
-                <a href = "/"><span>Home</span></a>
+                <a href = {home_url}><span>Home</span></a>
                 {red_panda_link}
                 <a href = {issue_url}><span>"Report Issue"</span></a>
                 <a href = {feature_url}><span>"Request Feature"</span></a>
-                <a href = "/help"><span>Help</span></a>
+                <a href = {help_url}><span>Help</span></a>
             </div>
         </div>
     }

--- a/trace-viewer/src/main.rs
+++ b/trace-viewer/src/main.rs
@@ -44,6 +44,10 @@ cfg_if! {
             #[clap(long)]
             broker_name: String,
 
+            /// Optional path to use to API calls.
+            #[clap(long)]
+            server_path: Option<String>,
+
             /// Optional link to the redpanda console. If present, displayed in the topbar.
             #[clap(long)]
             link_to_redpanda_console: Option<String>,
@@ -110,6 +114,7 @@ cfg_if! {
                 link_to_redpanda_console: args.link_to_redpanda_console,
                 default_data : args.default,
                 refresh_session_interval_sec: args.refresh_session_interval_sec,
+                server_path: args.server_path,
             };
 
             let conf = get_configuration(None).unwrap();

--- a/trace-viewer/src/structs/mod.rs
+++ b/trace-viewer/src/structs/mod.rs
@@ -75,4 +75,5 @@ pub struct ClientSideData {
     pub broker_name: String,
     pub link_to_redpanda_console: Option<String>,
     pub refresh_session_interval_sec: u64,
+    pub server_path: Option<String>,
 }


### PR DESCRIPTION
## Summary of changes

- Adds optional `server-path` parameter for the command line.
- Modifies links and path to web resources.

## Instruction for review/testing

Test on MuSR with `--server-path trace-viewer` added to command line.

Closes [Trace viewer cannot be served from a path](https://github.com/STFC-ICD-Research-and-Design/supermusr-data-pipeline/issues/403).