### PR TITLE
Server path

### DIFF
--- a/trace-viewer/src/app/mod.rs
+++ b/trace-viewer/src/app/mod.rs
@@ -8,10 +8,6 @@ use crate::structs::ClientSideData;
 use cfg_if::cfg_if;
 use leptos::prelude::*;
 use leptos_meta::*;
-use leptos_router::{
-    components::{Route, Router, Routes},
-    path,
-};
 use main_content::Main;
 use topbar::TopBar;
 
@@ -26,15 +22,13 @@ cfg_if! {
 /// and select the desired field.
 #[derive(Clone)]
 pub(crate) struct TopLevelContext {
-    client_side_data: ClientSideData,
+    pub(crate) client_side_data: ClientSideData
 }
 
-pub fn shell(mut leptos_options: LeptosOptions) -> impl IntoView + 'static {
-    let server_path = use_context::<ClientSideData>()
+pub fn shell(leptos_options: LeptosOptions) -> impl IntoView + 'static {
+    let server_origin = use_context::<ClientSideData>()
         .expect("ClientSideData should be provided, this should never fail.")
-        .server_path;
-
-    leptos_options.site_pkg_dir = format!("{server_path}{}", leptos_options.site_pkg_dir).into();
+        .server_url;
 
     view! {
         <!DOCTYPE html>
@@ -44,7 +38,8 @@ pub fn shell(mut leptos_options: LeptosOptions) -> impl IntoView + 'static {
                 <meta name="viewport" content="width=device-width, initial-scale=1"/>
                 <script src="https://cdn.plot.ly/plotly-2.14.0.min.js"></script>
                 <AutoReload options=leptos_options.clone() />
-                <HydrationScripts options=leptos_options.clone()/>
+                <HydrationScripts options=leptos_options.clone() root = server_origin.clone() />
+                <HashedStylesheet options=leptos_options root = server_origin />
                 <MetaTags/>
             </head>
             <body>
@@ -71,17 +66,11 @@ pub fn App() -> impl IntoView {
         // sets the document title
         <Title text="Trace Viewer" />
 
-        <Stylesheet href="/pkg/TraceViewer.css"/>
-
         // injects metadata in the <head> of the page
         <Meta charset="UTF-8" />
         <Meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
         <TopBar />
-        <Router>
-            <Routes fallback=|| ()>
-                <Route path=path!("/") view=Main/>
-            </Routes>
-        </Router>
+        <Main />
     }
 }

--- a/trace-viewer/src/app/mod.rs
+++ b/trace-viewer/src/app/mod.rs
@@ -22,7 +22,7 @@ cfg_if! {
 /// and select the desired field.
 #[derive(Clone)]
 pub(crate) struct TopLevelContext {
-    pub(crate) client_side_data: ClientSideData
+    pub(crate) client_side_data: ClientSideData,
 }
 
 pub fn shell(leptos_options: LeptosOptions) -> impl IntoView + 'static {

--- a/trace-viewer/src/app/mod.rs
+++ b/trace-viewer/src/app/mod.rs
@@ -31,13 +31,10 @@ pub(crate) struct TopLevelContext {
 
 pub fn shell(mut leptos_options: LeptosOptions) -> impl IntoView + 'static {
     let server_path = use_context::<ClientSideData>()
-        .expect("TopLevelContext should be provided, this should never fail.")
+        .expect("ClientSideData should be provided, this should never fail.")
         .server_path;
 
-    if let Some(server_path) = server_path {
-        leptos_options.site_pkg_dir =
-            format!("{server_path}/{}", leptos_options.site_pkg_dir).into();
-    }
+    leptos_options.site_pkg_dir = format!("{server_path}{}", leptos_options.site_pkg_dir).into();
 
     view! {
         <!DOCTYPE html>

--- a/trace-viewer/src/app/mod.rs
+++ b/trace-viewer/src/app/mod.rs
@@ -29,7 +29,16 @@ pub(crate) struct TopLevelContext {
     client_side_data: ClientSideData,
 }
 
-pub fn shell(leptos_options: LeptosOptions) -> impl IntoView + 'static {
+pub fn shell(mut leptos_options: LeptosOptions) -> impl IntoView + 'static {
+    let server_path = use_context::<ClientSideData>()
+        .expect("TopLevelContext should be provided, this should never fail.")
+        .server_path;
+
+    if let Some(server_path) = server_path {
+        leptos_options.site_pkg_dir =
+            format!("{server_path}/{}", leptos_options.site_pkg_dir).into();
+    }
+
     view! {
         <!DOCTYPE html>
         <html lang="en">

--- a/trace-viewer/src/app/topbar.rs
+++ b/trace-viewer/src/app/topbar.rs
@@ -21,7 +21,7 @@ pub(crate) fn TopBar() -> impl IntoView {
         "https://github.com/STFC-ICD-Research-and-Design/supermusr-data-pipeline/issues/new?title=Trace Viewer ({git_revision}): &template=feature.md"
     );
     let home_url = client_side_data.server_path.clone();
-    let help_url = format!("{}/help",client_side_data.server_path);
+    let help_url = format!("{}/help", client_side_data.server_path);
 
     view! {
         <div class = "topbar">

--- a/trace-viewer/src/app/topbar.rs
+++ b/trace-viewer/src/app/topbar.rs
@@ -20,11 +20,8 @@ pub(crate) fn TopBar() -> impl IntoView {
     let feature_url = format!(
         "https://github.com/STFC-ICD-Research-and-Design/supermusr-data-pipeline/issues/new?title=Trace Viewer ({git_revision}): &template=feature.md"
     );
-    let (home_url, help_url) = if let Some(server_path) = client_side_data.server_path {
-        (server_path.clone(), format!("{server_path}/help"))
-    } else {
-        ("/".to_string(), "/help".to_string())
-    };
+    let home_url = client_side_data.server_path.clone();
+    let help_url = format!("{}/help",client_side_data.server_path);
 
     view! {
         <div class = "topbar">

--- a/trace-viewer/src/app/topbar.rs
+++ b/trace-viewer/src/app/topbar.rs
@@ -20,8 +20,8 @@ pub(crate) fn TopBar() -> impl IntoView {
     let feature_url = format!(
         "https://github.com/STFC-ICD-Research-and-Design/supermusr-data-pipeline/issues/new?title=Trace Viewer ({git_revision}): &template=feature.md"
     );
-    let home_url = client_side_data.server_path.clone();
-    let help_url = format!("{}/help", client_side_data.server_path);
+    let home_url = client_side_data.server_url.clone();
+    let help_url = format!("{}/help", client_side_data.server_url.clone());
 
     view! {
         <div class = "topbar">

--- a/trace-viewer/src/app/topbar.rs
+++ b/trace-viewer/src/app/topbar.rs
@@ -20,6 +20,11 @@ pub(crate) fn TopBar() -> impl IntoView {
     let feature_url = format!(
         "https://github.com/STFC-ICD-Research-and-Design/supermusr-data-pipeline/issues/new?title=Trace Viewer ({git_revision}): &template=feature.md"
     );
+    let (home_url, help_url) = if let Some(server_path) = client_side_data.server_path {
+        (server_path.clone(), format!("{server_path}/help"))
+    } else {
+        ("/".to_string(), "/help".to_string())
+    };
 
     view! {
         <div class = "topbar">
@@ -28,11 +33,11 @@ pub(crate) fn TopBar() -> impl IntoView {
                 <div class = "subtitle">{broker_name}</div>
             </div>
             <div class = "menu">
-                <a href = "/"><span>Home</span></a>
+                <a href = {home_url}><span>Home</span></a>
                 {red_panda_link}
                 <a href = {issue_url}><span>"Report Issue"</span></a>
                 <a href = {feature_url}><span>"Request Feature"</span></a>
-                <a href = "/help"><span>Help</span></a>
+                <a href = {help_url}><span>Help</span></a>
             </div>
         </div>
     }

--- a/trace-viewer/src/lib.rs
+++ b/trace-viewer/src/lib.rs
@@ -33,8 +33,8 @@ cfg_if! {
 #[cfg(feature = "hydrate")]
 #[wasm_bindgen::prelude::wasm_bindgen]
 pub fn hydrate() {
-    use leptos::prelude::use_context;
     use crate::app::TopLevelContext;
+    use leptos::prelude::use_context;
 
     console_error_panic_hook::set_once();
 
@@ -43,7 +43,7 @@ pub fn hydrate() {
     let client_side_data = use_context::<TopLevelContext>()
         .expect("TopLevelContext should exists, this should never fail.")
         .client_side_data;
-    
+
     // The `leak` consumes the `String`, marks it's heap allocation as `'static`
     // and returns a static reference to it.
     // This only results in an actual memory leak if the returned reference is ever dropped.

--- a/trace-viewer/src/lib.rs
+++ b/trace-viewer/src/lib.rs
@@ -1,13 +1,12 @@
 #![allow(unused_crate_dependencies)]
 #![recursion_limit = "256"]
-
 pub mod app;
 pub mod structs;
 
-pub use app::{App, shell};
-
 use cfg_if::cfg_if;
 use chrono::{DateTime, Utc};
+
+pub use app::{App, shell};
 
 /// Used by instances of the website to refer to server-side sessions.
 pub type Uuid = Option<String>;
@@ -34,7 +33,23 @@ cfg_if! {
 #[cfg(feature = "hydrate")]
 #[wasm_bindgen::prelude::wasm_bindgen]
 pub fn hydrate() {
+    use leptos::prelude::use_context;
+    use crate::app::TopLevelContext;
+
     console_error_panic_hook::set_once();
 
     leptos::mount::hydrate_body(App);
+
+    let client_side_data = use_context::<TopLevelContext>()
+        .expect("TopLevelContext should exists, this should never fail.")
+        .client_side_data;
+    
+    // The `leak` consumes the `String`, marks it's heap allocation as `'static`
+    // and returns a static reference to it.
+    // This only results in an actual memory leak if the returned reference is ever dropped.
+    // By passing it to `set_server_url` we ensure this doesn't happen until the app is closed.
+    // Maybe, one day, leptos will allow `set_server_url` to be a String, allowing us to avoid
+    // having to use this scary sounding `leak` method... but this is not that day.
+    let server_url: &'static str = client_side_data.server_url.leak();
+    leptos::server_fn::client::set_server_url(server_url);
 }

--- a/trace-viewer/src/main.rs
+++ b/trace-viewer/src/main.rs
@@ -44,9 +44,9 @@ cfg_if! {
             #[clap(long)]
             broker_name: String,
 
-            /// Path to use to API calls, defaults to "".
-            #[clap(long, default_value = "")]
-            server_path: String,
+            /// URL at which the app is being hosted (without the trailing slash).
+            #[clap(long, default_value = "http://localhost:3000")]
+            server_url: String,
 
             /// Optional link to the redpanda console. If present, displayed in the topbar.
             #[clap(long)]
@@ -114,15 +114,15 @@ cfg_if! {
                 link_to_redpanda_console: args.link_to_redpanda_console,
                 default_data : args.default,
                 refresh_session_interval_sec: args.refresh_session_interval_sec,
-                server_path: args.server_path,
+                server_url: args.server_url,
             };
-
-            let conf = get_configuration(None).unwrap();
-            let addr = conf.leptos_options.site_addr;
 
             // Spawn the "purge expired sessions" task.
             let _purge_sessions = SessionEngine::spawn_purge_task(session_engine.clone(), args.purge_session_interval_sec);
 
+            let conf = get_configuration(None).unwrap();
+            let addr = conf.leptos_options.site_addr;
+            
             actix_web::HttpServer::new(move || {
                 // Generate the list of routes in your Leptos App
                 let routes = generate_route_list({

--- a/trace-viewer/src/main.rs
+++ b/trace-viewer/src/main.rs
@@ -44,6 +44,10 @@ cfg_if! {
             #[clap(long)]
             broker_name: String,
 
+            /// Optional path to use to API calls.
+            #[clap(long)]
+            server_path: Option<String>,
+
             /// Optional link to the redpanda console. If present, displayed in the topbar.
             #[clap(long)]
             link_to_redpanda_console: Option<String>,
@@ -110,6 +114,7 @@ cfg_if! {
                 link_to_redpanda_console: args.link_to_redpanda_console,
                 default_data : args.default,
                 refresh_session_interval_sec: args.refresh_session_interval_sec,
+                server_path: args.server_path,
             };
 
             let conf = get_configuration(None).unwrap();

--- a/trace-viewer/src/main.rs
+++ b/trace-viewer/src/main.rs
@@ -122,7 +122,7 @@ cfg_if! {
 
             let conf = get_configuration(None).unwrap();
             let addr = conf.leptos_options.site_addr;
-            
+
             actix_web::HttpServer::new(move || {
                 // Generate the list of routes in your Leptos App
                 let routes = generate_route_list({

--- a/trace-viewer/src/main.rs
+++ b/trace-viewer/src/main.rs
@@ -44,9 +44,9 @@ cfg_if! {
             #[clap(long)]
             broker_name: String,
 
-            /// Optional path to use to API calls.
-            #[clap(long)]
-            server_path: Option<String>,
+            /// Path to use to API calls, defaults to "".
+            #[clap(long, default_value = "")]
+            server_path: String,
 
             /// Optional link to the redpanda console. If present, displayed in the topbar.
             #[clap(long)]

--- a/trace-viewer/src/structs/mod.rs
+++ b/trace-viewer/src/structs/mod.rs
@@ -75,5 +75,5 @@ pub struct ClientSideData {
     pub broker_name: String,
     pub link_to_redpanda_console: Option<String>,
     pub refresh_session_interval_sec: u64,
-    pub server_path: Option<String>,
+    pub server_path: String,
 }

--- a/trace-viewer/src/structs/mod.rs
+++ b/trace-viewer/src/structs/mod.rs
@@ -75,4 +75,5 @@ pub struct ClientSideData {
     pub broker_name: String,
     pub link_to_redpanda_console: Option<String>,
     pub refresh_session_interval_sec: u64,
+    pub server_path: Option<String>,
 }

--- a/trace-viewer/src/structs/mod.rs
+++ b/trace-viewer/src/structs/mod.rs
@@ -75,5 +75,5 @@ pub struct ClientSideData {
     pub broker_name: String,
     pub link_to_redpanda_console: Option<String>,
     pub refresh_session_interval_sec: u64,
-    pub server_path: String,
+    pub server_url: String,
 }


### PR DESCRIPTION
## Summary of changes

Fixes the issue preventing us hosting on a subfolder via reverse proxy.

CLI parameter `server-path` changed to `server-url`, and now expects the absolute URL the app is hosted at.

I've had to dispense with the `<Router>` approach, which affects in-site navigation (we only expect to navigate to /help but help could be provided in a dialog box instead, so not a huge issue). I will try fix this as a future issue.

## Instruction for review/testing

- General code review.
- Test MuSR deployment with parameter `--server-path=trace-viewer` replaced with `--server-url=https://ndw2982.isis.cclrc.ac.uk/trace-viewer`