### PR TITLE
Extra tracing, and non-chronological message detector in trace viewer

### DIFF
--- a/trace-viewer/src/finder/topic_searcher/iterators/binary.rs
+++ b/trace-viewer/src/finder/topic_searcher/iterators/binary.rs
@@ -41,7 +41,7 @@ where
         tracing::Span::current()
             .record("start", self.bound.start)
             .record("end", self.bound.end)
-            .record("size", self.bound.end-self.bound.start);
+            .record("size", self.bound.end - self.bound.start);
 
         debug!("New Binary Search Iterator");
     }

--- a/trace-viewer/src/finder/topic_searcher/iterators/binary.rs
+++ b/trace-viewer/src/finder/topic_searcher/iterators/binary.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 use rdkafka::consumer::StreamConsumer;
 use std::ops::Range;
-use tracing::{info, warn};
+use tracing::{debug, warn};
 
 /// Searches on a topic forwards, one message at a time.
 ///
@@ -30,6 +30,7 @@ impl<'a, M> BinarySearchIter<'a, M, StreamConsumer>
 where
     M: FBMessage<'a>,
 {
+    #[tracing::instrument(skip_all, level = "debug", fields(start, end, size))]
     pub(crate) async fn init(&mut self) {
         // TODO: Should implement some sort of buffer to avoid the left bound being pushed out of range.
         let bounds = self.inner.get_current_bounds();
@@ -37,10 +38,12 @@ where
         self.max_bound = bounds.0..bounds.1;
         self.bound = self.max_bound.clone();
 
-        info!(
-            "Binary Search Iterator. Bounds = ({},{})",
-            bounds.0, bounds.1
-        );
+        tracing::Span::current()
+            .record("start", self.bound.start)
+            .record("end", self.bound.end)
+            .record("size", self.bound.end-self.bound.start);
+
+        debug!("New Binary Search Iterator");
     }
 
     pub(crate) fn empty(&self) -> bool {
@@ -56,11 +59,8 @@ where
     /// # Return
     /// - Ok(true) if `self.bound` has length at most `1``.
     /// - Ok(false) otherwise
+    #[tracing::instrument(skip_all, level = "debug", fields(start = self.bound.start, end = self.bound.end, size = self.bound.end-self.bound.start))]
     pub(crate) async fn bisect(&mut self) -> Result<bool, SearcherError> {
-        info!(
-            "Binary Search Iterator. Bounds = ({},{})",
-            self.bound.start, self.bound.end
-        );
         if self.bound.end - self.bound.start > 1 {
             let mid = (self.bound.end + self.bound.start) / 2;
 
@@ -68,12 +68,15 @@ where
                 Ok(msg) => {
                     if msg.timestamp() <= self.target {
                         self.bound.start = mid;
+                        debug!("Bisecting upwards.");
                     } else if msg.timestamp() > self.target {
                         self.bound.end = mid;
+                        debug!("Bisecting downwards.");
                     }
                 }
                 Err(e) => {
                     warn!("{e}");
+                    // Should we do something else here?
                     self.bound.start += 2;
                 }
             }
@@ -86,7 +89,7 @@ where
                 Ok(false)
             }
         } else {
-            info!("Found match {}, {}", self.bound.start, self.bound.end);
+            debug!("Bisecting complete.");
             Ok(true)
         }
     }

--- a/trace-viewer/src/finder/topic_searcher/iterators/forward.rs
+++ b/trace-viewer/src/finder/topic_searcher/iterators/forward.rs
@@ -1,4 +1,8 @@
-use crate::{finder::topic_searcher::{iterators::NonChronologicalMessageDetector, Searcher}, structs::FBMessage, Timestamp};
+use crate::{
+    Timestamp,
+    finder::topic_searcher::{Searcher, iterators::NonChronologicalMessageDetector},
+    structs::FBMessage,
+};
 use rdkafka::consumer::StreamConsumer;
 use tracing::{debug, instrument, warn};
 
@@ -35,9 +39,10 @@ where
             if let Some(msg) = M::try_from(msg)
                 .inspect_err(|e| warn!("{e}"))
                 .ok()
-                .inspect(|m|last_timestamp.next(m.timestamp()))
-                .filter(|m| f(FBMessage::timestamp(m))) {
-                    self.message = Some(msg);
+                .inspect(|m| last_timestamp.next(m.timestamp()))
+                .filter(|m| f(FBMessage::timestamp(m)))
+            {
+                self.message = Some(msg);
                 break;
             }
         }
@@ -62,11 +67,7 @@ where
                 .inner
                 .recv()
                 .await
-                .and_then(|m| 
-                    M::try_from(m)
-                        .inspect_err(|e| warn!("{e}"))
-                        .ok()
-                );
+                .and_then(|m| M::try_from(m).inspect_err(|e| warn!("{e}")).ok());
 
             for _ in 0..number {
                 debug!("Matching {timestamp}.");
@@ -76,11 +77,7 @@ where
                         .inner
                         .recv()
                         .await
-                        .and_then(|m| 
-                            M::try_from(m)
-                                .inspect_err(|e| warn!("{e}"))
-                                .ok()
-                        );
+                        .and_then(|m| M::try_from(m).inspect_err(|e| warn!("{e}")).ok());
                     debug!("Advance to Next Broker Message.");
 
                     let new_timestamp = msg.timestamp();

--- a/trace-viewer/src/finder/topic_searcher/iterators/mod.rs
+++ b/trace-viewer/src/finder/topic_searcher/iterators/mod.rs
@@ -12,29 +12,33 @@ pub(crate) use back_step::BackstepIter;
 pub(crate) use binary::BinarySearchIter;
 pub(crate) use forward::ForwardSearchIter;
 
-use tracing::warn;
 use crate::Timestamp;
+use tracing::warn;
 
 /// Detects Chronologically Out of Order Timestamps in Adjacent Messages
 #[derive(Default)]
 struct NonChronologicalMessageDetector {
     /// The current timestamp.
-    last_timestamp: Option<Timestamp>
+    last_timestamp: Option<Timestamp>,
 }
 
 impl NonChronologicalMessageDetector {
     /// Creates a new instance with a given timestamp, use `default()`
     /// if there should be no initial timestamp.
     fn new(last_timestamp: Timestamp) -> Self {
-        Self { last_timestamp: Some(last_timestamp) }
+        Self {
+            last_timestamp: Some(last_timestamp),
+        }
     }
 
     /// Emits a warning if the given timestamp is less-than the current timestamp.
     /// Updates the current timestamp, to the given one.
     fn next(&mut self, next_timestamp: Timestamp) {
         self.last_timestamp
-            .filter(|&last_timestamp|last_timestamp > next_timestamp)
-            .inspect(|&last_timestamp|warn!("Timestamps Out of Order: {last_timestamp} > {next_timestamp}"));
+            .filter(|&last_timestamp| last_timestamp > next_timestamp)
+            .inspect(|&last_timestamp| {
+                warn!("Timestamps Out of Order: {last_timestamp} > {next_timestamp}")
+            });
         self.last_timestamp.replace(next_timestamp);
     }
 }

--- a/trace-viewer/src/finder/topic_searcher/iterators/mod.rs
+++ b/trace-viewer/src/finder/topic_searcher/iterators/mod.rs
@@ -11,3 +11,24 @@ mod forward;
 pub(crate) use back_step::BackstepIter;
 pub(crate) use binary::BinarySearchIter;
 pub(crate) use forward::ForwardSearchIter;
+
+use tracing::warn;
+use crate::Timestamp;
+
+#[derive(Default)]
+struct NonChronologicalMessageDetector {
+    last_timestamp: Option<Timestamp>
+}
+
+impl NonChronologicalMessageDetector {
+    fn new(last_timestamp: Timestamp) -> Self {
+        Self { last_timestamp: Some(last_timestamp) }
+    }
+
+    fn next(&mut self, next_timestamp: Timestamp) {
+        self.last_timestamp
+            .filter(|&last_timestamp|last_timestamp > next_timestamp)
+            .inspect(|&last_timestamp|warn!("Timestamps Out of Order: {last_timestamp} > {next_timestamp}"));
+        self.last_timestamp.replace(next_timestamp);
+    }
+}

--- a/trace-viewer/src/finder/topic_searcher/iterators/mod.rs
+++ b/trace-viewer/src/finder/topic_searcher/iterators/mod.rs
@@ -15,16 +15,22 @@ pub(crate) use forward::ForwardSearchIter;
 use tracing::warn;
 use crate::Timestamp;
 
+/// Detects Chronologically Out of Order Timestamps in Adjacent Messages
 #[derive(Default)]
 struct NonChronologicalMessageDetector {
+    /// The current timestamp.
     last_timestamp: Option<Timestamp>
 }
 
 impl NonChronologicalMessageDetector {
+    /// Creates a new instance with a given timestamp, use `default()`
+    /// if there should be no initial timestamp.
     fn new(last_timestamp: Timestamp) -> Self {
         Self { last_timestamp: Some(last_timestamp) }
     }
 
+    /// Emits a warning if the given timestamp is less-than the current timestamp.
+    /// Updates the current timestamp, to the given one.
     fn next(&mut self, next_timestamp: Timestamp) {
         self.last_timestamp
             .filter(|&last_timestamp|last_timestamp > next_timestamp)

--- a/trace-viewer/src/main.rs
+++ b/trace-viewer/src/main.rs
@@ -82,7 +82,8 @@ cfg_if! {
 
             let stdout_tracer = tracing_subscriber::fmt::layer()
                 .with_writer(std::io::stdout)
-                .with_ansi(false);
+                .with_ansi(false)
+                .with_target(false);
 
             // This filter is applied to the stdout tracer
             let log_filter = EnvFilter::from_default_env();

--- a/trace-viewer/src/structs/server_only/search_results.rs
+++ b/trace-viewer/src/structs/server_only/search_results.rs
@@ -37,11 +37,11 @@ pub struct Cache {
 }
 
 impl Cache {
+    #[tracing::instrument(skip_all)]
     pub(crate) fn push_trace(
         &mut self,
         msg: &DigitizerAnalogTraceMessage<'_>,
     ) -> Result<(), GpsTimeConversionError> {
-        info!("New Trace");
         let metadata = DigitiserMetadata {
             id: msg.digitizer_id(),
             timestamp: msg
@@ -56,11 +56,13 @@ impl Cache {
             running: msg.metadata().running(),
             veto_flags: msg.metadata().veto_flags(),
         };
+
         match self.traces.entry(metadata) {
             Entry::Occupied(occupied_entry) => {
                 error!("Trace already found: {0:?}", occupied_entry.key());
             }
             Entry::Vacant(vacant_entry) => {
+                info!("Trace Entered: {:?}", vacant_entry.key());
                 vacant_entry.insert(DigitiserTrace::from_message(msg));
             }
         }
@@ -71,6 +73,7 @@ impl Cache {
         self.traces.iter()
     }
 
+    #[tracing::instrument(skip_all)]
     pub(crate) fn push_events(
         &mut self,
         msg: &DigitizerEventListMessage<'_>,


### PR DESCRIPTION
## Summary of changes

- Adds some tracing to the trace-viewer, useful for diagnostics
- Adds a tool to detect out of chronological order messages in the `ForwardSearchIter` iterator.

## Instruction for review/testing

General code review
