### PR TITLE
Add extra search option in trace viewer

### DIFF
--- a/trace-viewer/src/app/sections/results/search_results/mod.rs
+++ b/trace-viewer/src/app/sections/results/search_results/mod.rs
@@ -84,9 +84,9 @@ pub(crate) fn SearchSummary() -> impl IntoView {
                     SearchTargetMode::Timestamp { timestamp } => view! {
                         <li> {format!("At or after: {} {}", timestamp.date_naive(), timestamp.time())} </li>
                     },
-                    SearchTargetMode::Dragnet {timestamp, back_step, forward_distance } => view! {
+                    SearchTargetMode::Dragnet {timestamp, backstep, forward_distance } => view! {
                         <li> {format!(
-                            "Around: {} {}, message range: [{back_step}, {forward_distance}]",
+                            "Around: {} {}, message range: [{backstep}, {forward_distance}]",
                             timestamp.date_naive(), timestamp.time())
                         } </li>
                     }

--- a/trace-viewer/src/app/sections/results/search_results/mod.rs
+++ b/trace-viewer/src/app/sections/results/search_results/mod.rs
@@ -81,8 +81,14 @@ pub(crate) fn SearchSummary() -> impl IntoView {
             "Found " {num_results} " results matching search criteria:"
             <ul>
                 {match target.mode {
-                    SearchTargetMode::Timestamp { timestamp } => view!{
+                    SearchTargetMode::Timestamp { timestamp } => view! {
                         <li> {format!("At or after: {} {}", timestamp.date_naive(), timestamp.time())} </li>
+                    },
+                    SearchTargetMode::Dragnet {timestamp, back_step, forward_distance } => view! {
+                        <li> {format!(
+                            "Around: {} {}, message range: [{back_step}, {forward_distance}]",
+                            timestamp.date_naive(), timestamp.time())
+                        } </li>
                     }
                 }}
                 {match target.by {

--- a/trace-viewer/src/app/sections/search/context.rs
+++ b/trace-viewer/src/app/sections/search/context.rs
@@ -1,5 +1,5 @@
 use crate::{
-    Channel, DigitizerId,
+    Channel, DigitizerId, Timestamp,
     app::sections::search::search_settings::{SearchBy, SearchMode},
     structs::DefaultData,
 };
@@ -18,6 +18,8 @@ pub(crate) struct SearchLevelContext {
     pub(crate) channels: RwSignal<Vec<Channel>>,
     pub(crate) digitiser_ids: RwSignal<Vec<DigitizerId>>,
     pub(crate) number: RwSignal<usize>,
+    pub(crate) backstep: RwSignal<usize>,
+    pub(crate) forward_distance: RwSignal<usize>,
 }
 
 impl SearchLevelContext {
@@ -34,6 +36,12 @@ impl SearchLevelContext {
             date: RwSignal::new(default_date),
             time: RwSignal::new(default_time),
             number: RwSignal::new(default_data.number.unwrap_or(1)),
+            backstep: RwSignal::new(100),
+            forward_distance: RwSignal::new(400),
         }
+    }
+
+    pub(crate) fn get_timestamp_with_utc(&self) -> Timestamp {
+        self.date.get().and_time(self.time.get()).and_utc()
     }
 }

--- a/trace-viewer/src/app/sections/search/context.rs
+++ b/trace-viewer/src/app/sections/search/context.rs
@@ -18,7 +18,7 @@ pub(crate) struct SearchLevelContext {
     pub(crate) channels: RwSignal<Vec<Channel>>,
     pub(crate) digitiser_ids: RwSignal<Vec<DigitizerId>>,
     pub(crate) number: RwSignal<usize>,
-    pub(crate) backstep: RwSignal<usize>,
+    pub(crate) backstep: RwSignal<i64>,
     pub(crate) forward_distance: RwSignal<usize>,
 }
 

--- a/trace-viewer/src/app/sections/search/search_section.rs
+++ b/trace-viewer/src/app/sections/search/search_section.rs
@@ -32,11 +32,12 @@ pub(crate) fn SearchSection() -> impl IntoView {
         let target = SearchTarget {
             mode: match search_level_context.search_mode.get() {
                 SearchMode::Timestamp => SearchTargetMode::Timestamp {
-                    timestamp: search_level_context
-                        .date
-                        .get()
-                        .and_time(search_level_context.time.get())
-                        .and_utc(),
+                    timestamp: search_level_context.get_timestamp_with_utc(),
+                },
+                SearchMode::Dragnet => SearchTargetMode::Dragnet {
+                    timestamp: search_level_context.get_timestamp_with_utc(),
+                    back_step: search_level_context.backstep.get(),
+                    forward_distance: search_level_context.forward_distance.get(),
                 },
             },
             by: match search_level_context.search_by.get() {

--- a/trace-viewer/src/app/sections/search/search_section.rs
+++ b/trace-viewer/src/app/sections/search/search_section.rs
@@ -36,7 +36,7 @@ pub(crate) fn SearchSection() -> impl IntoView {
                 },
                 SearchMode::Dragnet => SearchTargetMode::Dragnet {
                     timestamp: search_level_context.get_timestamp_with_utc(),
-                    back_step: search_level_context.backstep.get(),
+                    backstep: search_level_context.backstep.get(),
                     forward_distance: search_level_context.forward_distance.get(),
                 },
             },

--- a/trace-viewer/src/app/sections/search/search_settings.rs
+++ b/trace-viewer/src/app/sections/search/search_settings.rs
@@ -24,9 +24,6 @@ pub(crate) fn SearchSettings() -> impl IntoView {
                 on:change = {move |ev|search_level_context.time.set(event_target_value(&ev).parse().expect("Time should parse, this should never fail."))}
             />
         </label>
-
-        <MatchCriteria />
-        <MatchBy />
         <label for = "number">
             "Number:"
             <input name = "number" id = "number" type = "text"
@@ -34,6 +31,25 @@ pub(crate) fn SearchSettings() -> impl IntoView {
                 on:change = {move |ev|search_level_context.number.set(event_target_value(&ev).parse().expect("Number should parse, this should never fail."))}
             />
         </label>
+        <Show when = move|| matches!(search_level_context.search_mode.get(), SearchMode::Dragnet)>
+            <label for = "backstep">
+                "Backstep:"
+                <input name = "backstep" id = "backstep" type = "text"
+                    value = {move ||search_level_context.backstep.get().to_string()}
+                    on:change = {move |ev|search_level_context.backstep.set(event_target_value(&ev).parse().expect("Backstep should parse, this should never fail."))}
+                />
+            </label>
+            <label for = "forward-dist">
+                "Forward Distance:"
+                <input name = "forward-dist" id = "forward-dist" type = "text"
+                    value = {move ||search_level_context.forward_distance.get().to_string()}
+                    on:change = {move |ev|search_level_context.forward_distance.set(event_target_value(&ev).parse().expect("Forward Distance should parse, this should never fail."))}
+                />
+            </label>
+        </Show>
+
+        <MatchCriteria />
+        <MatchBy />
     }
 }
 
@@ -42,6 +58,8 @@ pub(crate) enum SearchMode {
     #[default]
     #[strum(to_string = "From Timestamp")]
     Timestamp,
+    #[strum(to_string = "Dragnet Search")]
+    Dragnet,
 }
 
 #[component]

--- a/trace-viewer/src/finder/search_engine.rs
+++ b/trace-viewer/src/finder/search_engine.rs
@@ -1,6 +1,6 @@
 use crate::{
     finder::{
-        task::{BinarySearchByTimestamp, SearchTask},
+        task::{BinarySearchByTimestamp, Dragnet, SearchTask},
         topic_searcher::{Searcher, SearcherError},
     },
     structs::{
@@ -107,6 +107,21 @@ impl SearchEngine {
             SearchTargetMode::Timestamp { timestamp } => {
                 SearchTask::<BinarySearchByTimestamp>::new(&self.consumer, &self.topics)
                     .search(timestamp, target.by, target.number)
+                    .await?
+            }
+            SearchTargetMode::Dragnet {
+                timestamp,
+                back_step,
+                forward_distance,
+            } => {
+                SearchTask::<Dragnet>::new(&self.consumer, &self.topics)
+                    .search(
+                        timestamp,
+                        back_step,
+                        forward_distance,
+                        target.by,
+                        target.number,
+                    )
                     .await?
             }
         })

--- a/trace-viewer/src/finder/search_engine.rs
+++ b/trace-viewer/src/finder/search_engine.rs
@@ -111,13 +111,13 @@ impl SearchEngine {
             }
             SearchTargetMode::Dragnet {
                 timestamp,
-                back_step,
+                backstep,
                 forward_distance,
             } => {
                 SearchTask::<Dragnet>::new(&self.consumer, &self.topics)
                     .search(
                         timestamp,
-                        back_step,
+                        backstep,
                         forward_distance,
                         target.by,
                         target.number,

--- a/trace-viewer/src/finder/task/binary_by_timestamp.rs
+++ b/trace-viewer/src/finder/task/binary_by_timestamp.rs
@@ -91,30 +91,14 @@ impl<'a> SearchTask<'a, BinarySearchByTimestamp> {
             })
             .await;
 
-        let digitiser_ids = {
-            let mut digitiser_ids = trace_results
-                .as_ref()
-                .map(|(trace_results, _)| {
-                    trace_results
-                        .iter()
-                        .map(TraceMessage::digitiser_id)
-                        .collect::<Vec<_>>()
-                })
-                .unwrap_or_default();
-            digitiser_ids.sort();
-            digitiser_ids.dedup();
-            digitiser_ids
-        };
-
         let mut cache = Cache::default();
-
-        info!("Digitiser Id(s) derived: {digitiser_ids:?}");
 
         if let Some((trace_results, offset)) = trace_results {
             // Find Digitiser Event Lists
             let searcher =
                 Searcher::new(self.consumer, &self.topics.digitiser_event_topic, offset)?;
 
+            let digitiser_ids = Self::get_digitiser_ids_from_traces(trace_results.as_slice());
             let eventlist_results = self
                 .search_topic(
                     searcher,

--- a/trace-viewer/src/finder/task/dragnet.rs
+++ b/trace-viewer/src/finder/task/dragnet.rs
@@ -1,0 +1,146 @@
+use crate::{
+    Timestamp,
+    finder::{
+        task::{SearchTask, TaskClass},
+        topic_searcher::{Searcher, SearcherError},
+    },
+    structs::{Cache, EventListMessage, FBMessage, SearchResults, SearchTargetBy, TraceMessage},
+};
+use rdkafka::consumer::StreamConsumer;
+use tracing::instrument;
+
+/// Size of each backstep when a target timestamp has been found
+const BACKSTEP_SIZE: i64 = 32; // Todo: should this be a runtime settings?
+
+pub(crate) struct Dragnet;
+impl TaskClass for Dragnet {}
+
+impl<'a> SearchTask<'a, Dragnet> {
+    /// Performs a binary tree search on a given topic, with generic filtering functions.
+    #[instrument(skip_all)]
+    async fn search_topic<M, A>(
+        &self,
+        searcher: Searcher<'a, M, StreamConsumer>,
+        target: Timestamp,
+        backstep: usize,
+        forward_distance: usize,
+        number: usize,
+        acquire_matches: A,
+    ) -> Option<(Vec<M>, i64)>
+    where
+        M: FBMessage<'a>,
+        A: Fn(&M) -> bool,
+    {
+        let mut iter = searcher.iter_binary(target);
+        iter.init().await;
+
+        if iter.empty() {
+            return None;
+        }
+
+        loop {
+            if iter
+                .bisect()
+                .await
+                .expect("bisect works, this should never fail.")
+            {
+                break;
+            }
+        }
+
+        let searcher = iter.collect();
+        let offset = searcher.get_offset();
+
+        let results: Vec<M> = searcher.iter_dragnet()
+            .backstep_by(backstep)
+            .acquire_matches(forward_distance, number, acquire_matches)
+            .await?
+            .collect()
+            .into();
+
+        Some((results, offset))
+    }
+
+    /// Performs a binary tree search.
+    /// # Parameters
+    /// - target: what to search for.
+    /// - by:
+    #[instrument(skip_all)]
+    pub(crate) async fn search(
+        self,
+        target_timestamp: Timestamp,
+        backstep: usize,
+        forward_distance: usize,
+        search_by: SearchTargetBy,
+        number: usize,
+    ) -> Result<SearchResults, SearcherError> {
+        // Find Digitiser Traces
+        let searcher = Searcher::new(self.consumer, &self.topics.trace_topic, 1)?;
+
+        let trace_results = self
+            .search_topic(
+                searcher,
+                target_timestamp,
+                backstep,
+                forward_distance,
+                number,
+                |msg: &TraceMessage| msg.filter_by(&search_by),
+            )
+            .await;
+
+        let digitiser_ids = {
+            let mut digitiser_ids = trace_results
+                .as_ref()
+                .map(|(trace_results, _)| {
+                    trace_results
+                        .iter()
+                        .map(TraceMessage::digitiser_id)
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default();
+            digitiser_ids.sort();
+            digitiser_ids.dedup();
+            digitiser_ids
+        };
+
+        let mut cache = Cache::default();
+
+        if let Some((trace_results, offset)) = trace_results {
+            // Find Digitiser Event Lists
+            let searcher =
+                Searcher::new(self.consumer, &self.topics.digitiser_event_topic, offset)?;
+
+            let eventlist_results = self
+                .search_topic(
+                    searcher,
+                    target_timestamp,
+                    backstep,
+                    forward_distance,
+                    number,
+                    |msg: &EventListMessage| msg.filter_by_digitiser_id(&digitiser_ids),
+                )
+                .await;
+
+            for trace in trace_results.iter() {
+                cache.push_trace(
+                    &trace
+                        .try_unpacked_message()
+                        .expect("Cannot Unpack Trace. TODO should be handled"),
+                )?;
+            }
+
+            if let Some((eventlist_results, _)) = eventlist_results {
+                for eventlist in eventlist_results.iter() {
+                    cache.push_events(
+                        &eventlist
+                            .try_unpacked_message()
+                            .expect("Cannot Unpack Eventlist. TODO should be handled"),
+                    )?;
+                }
+            }
+        }
+        cache.attach_event_lists_to_trace();
+
+        Ok(SearchResults::Successful { cache })
+    }
+}

--- a/trace-viewer/src/finder/task/dragnet.rs
+++ b/trace-viewer/src/finder/task/dragnet.rs
@@ -48,7 +48,7 @@ impl<'a> SearchTask<'a, Dragnet> {
         let offset = searcher.get_offset();
 
         let mut iter = searcher.iter_dragnet();
-            iter.backstep_by(backstep)
+        iter.backstep_by(backstep)
             .acquire_matches(forward_distance, number, acquire_matches)
             .await;
         let searcher = iter.collect();

--- a/trace-viewer/src/finder/task/mod.rs
+++ b/trace-viewer/src/finder/task/mod.rs
@@ -1,11 +1,13 @@
 //! Contains structs responsible for executing a particular search method.
 mod binary_by_timestamp;
+mod dragnet;
 
 use crate::structs::Topics;
 use rdkafka::consumer::StreamConsumer;
 use std::marker::PhantomData;
 
 pub(crate) use binary_by_timestamp::BinarySearchByTimestamp;
+pub(crate) use dragnet::Dragnet;
 
 pub(crate) trait TaskClass {}
 

--- a/trace-viewer/src/finder/task/mod.rs
+++ b/trace-viewer/src/finder/task/mod.rs
@@ -25,7 +25,7 @@ impl<'a, C: TaskClass> SearchTask<'a, C> {
             phantom: PhantomData,
         }
     }
-    
+
     /*fn get_digitiser_ids_from_traces(traces: Option<&[TraceMessage]>) {
         traces
             .as_ref()

--- a/trace-viewer/src/finder/task/mod.rs
+++ b/trace-viewer/src/finder/task/mod.rs
@@ -2,7 +2,7 @@
 mod binary_by_timestamp;
 mod dragnet;
 
-use crate::structs::Topics;
+use crate::structs::{Topics, TraceMessage};
 use rdkafka::consumer::StreamConsumer;
 use std::marker::PhantomData;
 
@@ -25,4 +25,19 @@ impl<'a, C: TaskClass> SearchTask<'a, C> {
             phantom: PhantomData,
         }
     }
+    
+    /*fn get_digitiser_ids_from_traces(traces: Option<&[TraceMessage]>) {
+        traces
+            .as_ref()
+            .map(|trace_results| {
+                trace_results
+                    .iter()
+                    .map(TraceMessage::digitiser_id)
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        digitiser_ids.sort();
+        digitiser_ids.dedup();
+        digitiser_ids
+    }*/
 }

--- a/trace-viewer/src/finder/task/mod.rs
+++ b/trace-viewer/src/finder/task/mod.rs
@@ -2,9 +2,13 @@
 mod binary_by_timestamp;
 mod dragnet;
 
-use crate::structs::{Topics, TraceMessage};
+use crate::{
+    DigitizerId,
+    structs::{FBMessage, Topics, TraceMessage},
+};
 use rdkafka::consumer::StreamConsumer;
 use std::marker::PhantomData;
+use tracing::info;
 
 pub(crate) use binary_by_timestamp::BinarySearchByTimestamp;
 pub(crate) use dragnet::Dragnet;
@@ -26,18 +30,15 @@ impl<'a, C: TaskClass> SearchTask<'a, C> {
         }
     }
 
-    /*fn get_digitiser_ids_from_traces(traces: Option<&[TraceMessage]>) {
-        traces
-            .as_ref()
-            .map(|trace_results| {
-                trace_results
-                    .iter()
-                    .map(TraceMessage::digitiser_id)
-                    .collect::<Vec<_>>()
-            })
-            .unwrap_or_default();
+    /// Extracts a sorted, deduplicated vector of Digitiser Ids from a slice of trace messages.
+    fn get_digitiser_ids_from_traces(traces: &[TraceMessage]) -> Vec<DigitizerId> {
+        let mut digitiser_ids = traces
+            .iter()
+            .map(TraceMessage::digitiser_id)
+            .collect::<Vec<_>>();
         digitiser_ids.sort();
         digitiser_ids.dedup();
+        info!("Digitiser Id(s) derived: {digitiser_ids:?}");
         digitiser_ids
-    }*/
+    }
 }

--- a/trace-viewer/src/finder/topic_searcher/iterators/dragnet.rs
+++ b/trace-viewer/src/finder/topic_searcher/iterators/dragnet.rs
@@ -1,0 +1,70 @@
+use crate::{
+    Timestamp,
+    finder::topic_searcher::{Searcher, searcher::SearcherError},
+    structs::FBMessage,
+};
+use rdkafka::consumer::StreamConsumer;
+use tracing::{error, info, instrument, warn};
+
+/// Performs a backwards search on the broker from the searcher's offset.
+///
+/// Note this iterator can only move the [Searcher]'s offset, it cannot accumulate results.
+/// Also note, this iterator is not a real iterator (as in it does not implement [Iterator]).
+/// Instead it's methods are inspired by those frequently found in actual iterators.
+pub(crate) struct DragNetIter<'a, M, C> {
+    pub(crate) inner: Searcher<'a, M, C>,
+}
+
+impl<'a, M, C> DragNetIter<'a, M, C> {
+    /// Consumes the iterator and returns the original [Searcher] object.
+    pub(crate) fn collect(self) -> Searcher<'a, M, C> {
+        self.inner
+    }
+}
+
+impl<'a, M> DragNetIter<'a, M, StreamConsumer> where M: FBMessage<'a> {
+    /// Moves the topic's offset back, clamping at the minimum offset.
+    #[instrument(skip_all)]
+    pub(crate) fn backstep_by(
+        &mut self,
+        step_size: i64,
+    ) -> &mut Self {
+        self.inner
+            .set_offset((self.inner.offset - step_size).min(self.inner.get_current_bounds().0));
+        self
+    }
+
+    /// Steps forward, message by message, ignoring timestamp order, acquiring messages which satisfy the predicate,
+    /// until the given number of messages have been tested.
+    ///
+    /// # Parameters
+    /// - f: a predicte taking a timestamp, it should return true when the timestamp is earlier than the target.
+    #[instrument(skip_all)]
+    pub(crate) async fn acquire_matches<F: Fn(&M) -> bool>(
+        &mut self,
+        message_num: usize,
+        max_timestamps: usize,
+        f: F,
+    ) -> Result<&mut Self, SearcherError> {
+        let mut timestamps = Vec::<Timestamp>::with_capacity(max_timestamps);
+        for _ in 0..message_num {
+            if let Some(msg) = self
+                .inner
+                .recv()
+                .await
+                .map(TryFrom::try_from)
+                .and_then(Result::ok)
+            {
+                if f(&msg) {
+                    if timestamps.contains(&msg.timestamp()) {
+                        self.inner.results.push(msg);
+                    } else if timestamps.len() < max_timestamps {
+                        timestamps.push(msg.timestamp());
+                        self.inner.results.push(msg);
+                    }
+                }
+            }
+        }
+        Ok(self)
+    }
+}

--- a/trace-viewer/src/finder/topic_searcher/iterators/dragnet.rs
+++ b/trace-viewer/src/finder/topic_searcher/iterators/dragnet.rs
@@ -4,7 +4,7 @@ use crate::{
     structs::FBMessage,
 };
 use rdkafka::consumer::StreamConsumer;
-use tracing::{error, info, instrument, warn};
+use tracing::{instrument, warn};
 
 /// Performs a backwards search on the broker from the searcher's offset.
 ///
@@ -45,7 +45,7 @@ impl<'a, M> DragNetIter<'a, M, StreamConsumer> where M: FBMessage<'a> {
         message_num: usize,
         max_timestamps: usize,
         f: F,
-    ) -> Result<&mut Self, SearcherError> {
+    ) -> &mut Self {
         let mut timestamps = Vec::<Timestamp>::with_capacity(max_timestamps);
         for _ in 0..message_num {
             if let Some(msg) = self
@@ -65,6 +65,6 @@ impl<'a, M> DragNetIter<'a, M, StreamConsumer> where M: FBMessage<'a> {
                 }
             }
         }
-        Ok(self)
+        self
     }
 }

--- a/trace-viewer/src/finder/topic_searcher/iterators/mod.rs
+++ b/trace-viewer/src/finder/topic_searcher/iterators/mod.rs
@@ -6,10 +6,12 @@
 //!
 mod back_step;
 mod binary;
+mod dragnet;
 mod forward;
 
 pub(crate) use back_step::BackstepIter;
 pub(crate) use binary::BinarySearchIter;
+pub(crate) use dragnet::DragNetIter;
 pub(crate) use forward::ForwardSearchIter;
 
 use crate::Timestamp;

--- a/trace-viewer/src/finder/topic_searcher/searcher.rs
+++ b/trace-viewer/src/finder/topic_searcher/searcher.rs
@@ -1,8 +1,9 @@
 use crate::{
     Timestamp,
-    finder::topic_searcher::{BackstepIter, BinarySearchIter, ForwardSearchIter},
-    structs::BorrowedMessageError,
-    structs::FBMessage,
+    finder::topic_searcher::{
+        BackstepIter, BinarySearchIter, ForwardSearchIter, iterators::DragNetIter,
+    },
+    structs::{BorrowedMessageError, FBMessage},
 };
 use rdkafka::{
     Offset, TopicPartitionList,
@@ -98,6 +99,12 @@ impl<'a, M> Searcher<'a, M, StreamConsumer> {
             max_bound: Default::default(),
             target,
         }
+    }
+
+    #[instrument(skip_all)]
+    /// Consumer the searcher and create a forward iterator.
+    pub(crate) fn iter_dragnet(self) -> DragNetIter<'a, M, StreamConsumer> {
+        DragNetIter { inner: self }
     }
 
     /// Sets the offset.

--- a/trace-viewer/src/finder/topic_searcher/searcher.rs
+++ b/trace-viewer/src/finder/topic_searcher/searcher.rs
@@ -103,8 +103,11 @@ impl<'a, M> Searcher<'a, M, StreamConsumer> {
 
     #[instrument(skip_all)]
     /// Consumer the searcher and create a forward iterator.
-    pub(crate) fn iter_dragnet(self) -> DragNetIter<'a, M, StreamConsumer> {
-        DragNetIter { inner: self }
+    pub(crate) fn iter_dragnet(self, number: usize) -> DragNetIter<'a, M, StreamConsumer> {
+        DragNetIter {
+            inner: self,
+            timestamps: Vec::with_capacity(number),
+        }
     }
 
     /// Sets the offset.

--- a/trace-viewer/src/structs/search.rs
+++ b/trace-viewer/src/structs/search.rs
@@ -15,7 +15,7 @@ pub enum SearchTargetMode {
     },
     Dragnet {
         timestamp: Timestamp,
-        back_step: usize,
+        backstep: i64,
         forward_distance: usize,
     },
 }

--- a/trace-viewer/src/structs/search.rs
+++ b/trace-viewer/src/structs/search.rs
@@ -10,7 +10,14 @@ pub struct SearchTarget {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum SearchTargetMode {
-    Timestamp { timestamp: Timestamp },
+    Timestamp {
+        timestamp: Timestamp,
+    },
+    Dragnet {
+        timestamp: Timestamp,
+        back_step: usize,
+        forward_distance: usize,
+    },
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary of changes

Adds a new search option (dragnet searching, name is a placeholder), which uses binary search to locate a given timestamp, jumps back the specified number of messages then searches forwards for the specified number of messages.

This is intended as a blunt instrument mode, which does not rely on messages being in chronological order. This allows the tool to be used to help diagnose issues with messages appearing out of order in the broker.

The layout on the webpage is confusing, but this will be updated in a future PR.

## Instruction for review/testing

General code review.
Please review after https://github.com/STFC-ICD-Research-and-Design/supermusr-data-pipeline/pull/409 is merged.
