### PR TITLE
correct type for selog 'time' dataset and add seconds as units

### DIFF
--- a/nexus-writer/src/nexus_structure/logs/log.rs
+++ b/nexus-writer/src/nexus_structure/logs/log.rs
@@ -1,6 +1,8 @@
 //! Implements the [Log] struct which represents a NeXus group of class `NXLog`.
 //! This struct appears in both `RunLog` and `SELog` messages.
 
+use crate::hdf5_handlers::HasAttributesExt;
+use crate::nexus::NexusUnits::Seconds;
 use crate::{
     error::FlatBufferMissingError,
     hdf5_handlers::{DatasetExt, GroupExt, NexusHDF5Error, NexusHDF5Result},
@@ -49,8 +51,12 @@ impl NexusSchematic for Log {
             chunk_size,
         }: &Self::Settings,
     ) -> NexusHDF5Result<Self> {
+        let time_dataset = group.create_resizable_empty_dataset::<f64>("time", *chunk_size)?;
+
+        time_dataset.add_constant_string_attribute("units", &Seconds.to_string())?;
+
         Ok(Self {
-            time: group.create_resizable_empty_dataset::<i64>("time", *chunk_size)?,
+            time: time_dataset,
             value: group.create_dynamic_resizable_empty_dataset(
                 "value",
                 type_descriptor,


### PR DESCRIPTION
## Summary of changes

As it's in seconds we can get much finer granularity on epics update timestamps by using a float (the icp does this) - also adds attribute for units as `second`

## Instruction for review/testing

Test with f144 blobs - i have done this and it seems to work