### PR TITLE
Handle empty periods string in Nexus Writer

### DIFF
--- a/nexus-writer/src/nexus_structure/entry/period.rs
+++ b/nexus-writer/src/nexus_structure/entry/period.rs
@@ -51,7 +51,8 @@ impl Period {
                 .map(str::parse)
                 .collect::<Result<_, _>>()
                 .map_err(Into::into)
-        }    }
+        }
+    }
 }
 
 impl NexusSchematic for Period {


### PR DESCRIPTION
## Summary of changes

Resuming Runs with an empty `periods` string crashes, rather than interprets it as an empty list.

## Instruction for review/testing

General code review.
Has been tested on simulated pipeline.
