### PR TITLE
Make search_by default value depend on cli

### DIFF
--- a/trace-viewer/src/app/sections/search/context.rs
+++ b/trace-viewer/src/app/sections/search/context.rs
@@ -27,10 +27,17 @@ impl SearchLevelContext {
         let default_timestamp = default_data.timestamp.unwrap_or_else(Utc::now);
         let default_date = default_timestamp.date_naive();
         let default_time = default_timestamp.time();
+        let search_by = if default_data.channels.is_some() {
+            SearchBy::ByChannels
+        } else if default_data.digitiser_ids.is_some() {
+            SearchBy::ByDigitiserIds
+        } else {
+            SearchBy::All
+        };
 
         Self {
-            search_mode: RwSignal::new(SearchMode::Timestamp),
-            search_by: RwSignal::new(SearchBy::ByChannels),
+            search_mode: RwSignal::new(SearchMode::default()),
+            search_by: RwSignal::new(search_by),
             channels: RwSignal::new(default_data.channels.clone().unwrap_or_default()),
             digitiser_ids: RwSignal::new(default_data.digitiser_ids.clone().unwrap_or_default()),
             date: RwSignal::new(default_date),


### PR DESCRIPTION
## Summary of changes

Changes default value of the SearchBy search option from ByChannels, to a value depending on the default Channels/Digitiser Ids in the CLI, prioritising Channels. If no default channels or digitiser ids are provided, the default is MatchAll.

## Instruction for review/testing

General code review.
Has been tested with cli arguments:
 - `--broker=130.246.55.29:9092  --consumer-group=viewer --trace-topic=daq-traces-in --digitiser-event-topic=daq-events --name=Test  --channels=14  --broker-name=HiFi  --public-url=http://localhost:3000/`
 - `--broker=130.246.55.29:9092  --consumer-group=viewer --trace-topic=daq-traces-in --digitiser-event-topic=daq-events --name=Test  --digitiser-ids=14  --broker-name=HiFi  --public-url=http://localhost:3000/`
 - `--broker=130.246.55.29:9092  --consumer-group=viewer --trace-topic=daq-traces-in --digitiser-event-topic=daq-events --name=Test  --broker-name=HiFi  --public-url=http://localhost:3000/`
