### PR TITLE
Fix inter-processes traces

### DIFF
--- a/common/src/tracer/propagator.rs
+++ b/common/src/tracer/propagator.rs
@@ -1,4 +1,4 @@
-use opentelemetry::propagation::{Extractor, Injector};
+use opentelemetry::{Context, ContextGuard, propagation::{Extractor, Injector}};
 use rdkafka::{
     message::{BorrowedHeaders, Headers, OwnedHeaders},
     producer::FutureRecord,
@@ -89,6 +89,7 @@ impl FutureRecordTracerExt for FutureRecord<'_, str, [u8]> {
 pub trait OptionalHeaderTracerExt {
     fn conditional_extract_to_current_span(self, use_otel: bool);
     fn conditional_extract_to_span(self, use_otel: bool, span: &Span);
+    fn conditional_attach_context(self, use_otel: bool);
 }
 
 impl OptionalHeaderTracerExt for Option<&BorrowedHeaders> {
@@ -106,6 +107,14 @@ impl OptionalHeaderTracerExt for Option<&BorrowedHeaders> {
             )) {
                 warn!("{e}");
             }
+        }
+    }
+
+    fn conditional_attach_context(self, use_otel: bool) {
+        if let Some(headers) = self && use_otel {
+            opentelemetry::global::get_text_map_propagator(|propagator|
+                    propagator.extract(&HeaderExtractor(headers)))
+                    .attach();
         }
     }
 }

--- a/common/src/tracer/propagator.rs
+++ b/common/src/tracer/propagator.rs
@@ -1,4 +1,4 @@
-use opentelemetry::{Context, ContextGuard, propagation::{Extractor, Injector}};
+use opentelemetry::propagation::{Extractor, Injector};
 use rdkafka::{
     message::{BorrowedHeaders, Headers, OwnedHeaders},
     producer::FutureRecord,
@@ -87,16 +87,10 @@ impl FutureRecordTracerExt for FutureRecord<'_, str, [u8]> {
 /// indicating whether OpenTelemetry is used.
 /// If this is false, the methods usually do nothing.
 pub trait OptionalHeaderTracerExt {
-    fn conditional_extract_to_current_span(self, use_otel: bool);
     fn conditional_extract_to_span(self, use_otel: bool, span: &Span);
-    fn conditional_attach_context(self, use_otel: bool);
 }
 
 impl OptionalHeaderTracerExt for Option<&BorrowedHeaders> {
-    fn conditional_extract_to_current_span(self, use_otel: bool) {
-        self.conditional_extract_to_span(use_otel, &tracing::Span::current())
-    }
-
     fn conditional_extract_to_span(self, use_otel: bool, span: &Span) {
         if let Some(headers) = self
             && use_otel
@@ -107,14 +101,6 @@ impl OptionalHeaderTracerExt for Option<&BorrowedHeaders> {
             )) {
                 warn!("{e}");
             }
-        }
-    }
-
-    fn conditional_attach_context(self, use_otel: bool) {
-        if let Some(headers) = self && use_otel {
-            opentelemetry::global::get_text_map_propagator(|propagator|
-                    propagator.extract(&HeaderExtractor(headers)))
-                    .attach();
         }
     }
 }

--- a/digitiser-aggregator/src/main.rs
+++ b/digitiser-aggregator/src/main.rs
@@ -217,7 +217,13 @@ async fn main() -> miette::Result<()> {
             event = consumer.recv() => {
                 match event {
                     Ok(msg) => {
-                        process_kafka_message(tracer.use_otel(), &channel_send, &mut cache, &msg).await.into_diagnostic().wrap_err("Failed to process incomming message")?;
+                        //let span = info_span!("digitiser_aggregator");
+                        let _guard = msg.headers().conditional_attach_context(tracer.use_otel());
+                        process_kafka_message(&channel_send, &mut cache, &msg)
+                            .await
+                            .into_diagnostic()
+                            .wrap_err("Failed to process incomming message")?;
+
                         consumer.commit_message(&msg, CommitMode::Async)
                             .expect("Message should commit");
                     }
@@ -247,7 +253,6 @@ fn spanned_root_as_digitizer_event_list_message(
 
 /// Extracts the payload of a Kafka message and passes it to [process_digitiser_event_list_message]
 /// # Parameters
-/// - use_otel: if true, then attempts to extract a parent [Span] from the Kafka headers.
 /// - channel_send: send channel which takes [AggregatedFrame] objects to dispatch.
 /// - cache: the cache in which frames are stored whilst awaiting digitiser messages.
 /// - msg: the message.
@@ -255,13 +260,10 @@ fn spanned_root_as_digitizer_event_list_message(
 /// [Span]: tracing::Span
 #[instrument(skip_all, level = "info", err(level = "warn"))]
 async fn process_kafka_message(
-    use_otel: bool,
     channel_send: &AggregatedFrameToBufferSender,
     cache: &mut FrameCache<EventData>,
     msg: &BorrowedMessage<'_>,
 ) -> Result<(), SendAggregatedFrameError> {
-    msg.headers().conditional_extract_to_current_span(use_otel);
-
     if let Some(payload) = msg.payload() {
         if digitizer_event_list_message_buffer_has_identifier(payload) {
             counter!(

--- a/digitiser-aggregator/src/main.rs
+++ b/digitiser-aggregator/src/main.rs
@@ -217,8 +217,9 @@ async fn main() -> miette::Result<()> {
             event = consumer.recv() => {
                 match event {
                     Ok(msg) => {
-                        //let span = info_span!("digitiser_aggregator");
-                        let _guard = msg.headers().conditional_attach_context(tracer.use_otel());
+                        let span = info_span!("message_received");
+                        msg.headers().conditional_extract_to_span(tracer.use_otel(), &span);
+                        let _guard = span.enter();
                         process_kafka_message(&channel_send, &mut cache, &msg)
                             .await
                             .into_diagnostic()

--- a/digitiser-aggregator/src/main.rs
+++ b/digitiser-aggregator/src/main.rs
@@ -253,7 +253,7 @@ fn spanned_root_as_digitizer_event_list_message(
 /// - msg: the message.
 ///
 /// [Span]: tracing::Span
-#[instrument(skip_all, level = "debug", err(level = "warn"))]
+#[instrument(skip_all, level = "info", err(level = "warn"))]
 async fn process_kafka_message(
     use_otel: bool,
     channel_send: &AggregatedFrameToBufferSender,

--- a/nexus-writer/src/main.rs
+++ b/nexus-writer/src/main.rs
@@ -53,7 +53,7 @@ use tokio::{
     signal::unix::{SignalKind, signal},
     time,
 };
-use tracing::{debug, error, warn};
+use tracing::{debug, error, info_span, warn};
 
 /// [clap] derived struct to handle command line parameters.
 #[derive(Debug, Parser)]
@@ -248,10 +248,13 @@ async fn main() -> miette::Result<()> {
                         warn!("{e}")
                     },
                     Ok(msg) => {
-                        let _guard = msg.headers().conditional_attach_context(tracer.use_otel());
+                        let span = info_span!("message_received");
+                        msg.headers().conditional_extract_to_span(tracer.use_otel(), &span);
+                        let _guard = span.enter();
+
                         process_kafka_message(&topics, &mut nexus_engine, &msg);
 
-                        if let Err(e) = consumer.commit_message(&msg, CommitMode::Async){
+                        if let Err(e) = consumer.commit_message(&msg, CommitMode::Async) {
                             error!("Failed to commit Kafka message consumption: {e}");
                         }
                     }

--- a/nexus-writer/src/main.rs
+++ b/nexus-writer/src/main.rs
@@ -248,7 +248,8 @@ async fn main() -> miette::Result<()> {
                         warn!("{e}")
                     },
                     Ok(msg) => {
-                        process_kafka_message(&topics, &mut nexus_engine, tracer.use_otel(), &msg);
+                        let _guard = msg.headers().conditional_attach_context(tracer.use_otel());
+                        process_kafka_message(&topics, &mut nexus_engine, &msg);
 
                         if let Err(e) = consumer.commit_message(&msg, CommitMode::Async){
                             error!("Failed to commit Kafka message consumption: {e}");
@@ -273,22 +274,19 @@ async fn main() -> miette::Result<()> {
 /// # Parameters
 /// - topics: contains the topic names.
 /// - nexus_engine: the engine to push the message to.
-/// - use_otel: if true, then attempts to extract a parent [Span] from the Kafka headers.
 /// - msg: the message.
 ///
 /// [Span]: tracing::Span
-#[tracing::instrument(skip_all, level="info", fields(
+#[tracing::instrument(skip_all, level="info",
+    fields(
     num_cached_runs = nexus_engine.get_num_cached_runs(),
     kafka_message_timestamp_ms = msg.timestamp().to_millis()
 ))]
 fn process_kafka_message(
     topics: &Topics,
     nexus_engine: &mut NexusEngine<EngineDependencies>,
-    use_otel: bool,
     msg: &BorrowedMessage,
 ) {
-    msg.headers().conditional_extract_to_current_span(use_otel);
-
     debug!(
         "key: '{:?}', topic: {}, partition: {}, offset: {}, timestamp: {:?}",
         msg.key(),

--- a/nexus-writer/src/main.rs
+++ b/nexus-writer/src/main.rs
@@ -277,7 +277,7 @@ async fn main() -> miette::Result<()> {
 /// - msg: the message.
 ///
 /// [Span]: tracing::Span
-#[tracing::instrument(skip_all, level="debug", fields(
+#[tracing::instrument(skip_all, level="info", fields(
     num_cached_runs = nexus_engine.get_num_cached_runs(),
     kafka_message_timestamp_ms = msg.timestamp().to_millis()
 ))]

--- a/trace-to-events/src/main.rs
+++ b/trace-to-events/src/main.rs
@@ -244,7 +244,7 @@ fn spanned_root_as_digitizer_analog_trace_message(
 /// - m: the message.
 ///
 /// [Span]: tracing::Span
-#[instrument(skip_all, level = "debug", err(level = "warn"))]
+#[instrument(skip_all, level = "info", err(level = "warn"))]
 fn process_kafka_message(
     tracer: &TracerEngine,
     sender_parameters: &SenderParameters,

--- a/trace-to-events/src/main.rs
+++ b/trace-to-events/src/main.rs
@@ -46,7 +46,7 @@ use parameters::{DetectorSettings, Mode, Polarity};
 use rdkafka::{
     Message,
     consumer::{CommitMode, Consumer},
-    message::{BorrowedHeaders, BorrowedMessage},
+    message::BorrowedMessage,
     producer::{DeliveryFuture, FutureProducer, FutureRecord},
 };
 use std::net::SocketAddr;
@@ -56,7 +56,7 @@ use tokio::{
     sync::mpsc::{Receiver, Sender, error::TrySendError},
     task::JoinHandle,
 };
-use tracing::{debug, error, info, instrument, trace, warn};
+use tracing::{debug, error, info, info_span, instrument, trace, warn};
 
 type InstrumentedDeliveryFuture = tracing::instrument::Instrumented<DeliveryFuture>;
 type DigitiserEventListToBufferSender = Sender<InstrumentedDeliveryFuture>;
@@ -207,12 +207,16 @@ async fn main() -> miette::Result<()> {
         tokio::select! {
             msg = consumer.recv() => match msg {
                 Ok(m) => {
+                    let span = info_span!("message_received");
+                    m.headers().conditional_extract_to_span(tracer.use_otel(), &span);
+                    let _guard = span.enter();
                     process_kafka_message(
                         &tracer,
                         &sender_parameters,
                         &mut message_processor,
                         &m,
                     ).into_diagnostic()?;
+
                     consumer.commit_message(&m, CommitMode::Async).unwrap();
                 }
                 Err(e) => warn!("Kafka error: {}", e)
@@ -268,7 +272,6 @@ fn process_kafka_message(
                     process_digitiser_trace_message(
                         tracer,
                         kafka_timestamp_ms,
-                        message.headers(),
                         sender_parameters,
                         message_processor,
                         trace_message,
@@ -321,7 +324,6 @@ fn process_kafka_message(
 fn process_digitiser_trace_message(
     tracer: &TracerEngine,
     kafka_timestamp_ms: i64,
-    headers: Option<&BorrowedHeaders>,
     sender_parameters: &SenderParameters,
     message_processor: &mut DigitiserMessageProcessor,
     message: DigitizerAnalogTraceMessage,
@@ -376,8 +378,7 @@ fn process_digitiser_trace_message(
         })
         .ok();
 
-    headers.conditional_extract_to_current_span(tracer.use_otel());
-    let mut fbb = FlatBufferBuilder::new();
+    let mut fbb: FlatBufferBuilder<'_> = FlatBufferBuilder::new();
     let num_total_pulses = message_processor.process(&mut fbb, &message);
     tracing::Span::current().record("num_total_pulses", num_total_pulses);
     tracing::Span::current().record(


### PR DESCRIPTION
## Summary of changes

~~Revert change made in commit https://github.com/ISISNeutronMuon/digital-muon-pipeline/commit/3e2e9a4810e7d3c691a49f57a9965b585acd37f7, which broke tracing across process boundaries.~~

A new version of OpenTelemetry changed the way traces are linked across process boundaries. Code changed in all three components and the common crate to reflect this.

## Instruction for review/testing

General code review.
Has been tested with simulated data.
