### PR TITLE
Simulator generate trace and eventlist

### DIFF
--- a/simulator/src/integrated/simulation_elements/event_list.rs
+++ b/simulator/src/integrated/simulation_elements/event_list.rs
@@ -102,7 +102,7 @@ impl<'a> Clone for EventList<'a> {
         Self {
             span: SpanOnce::Spanned(tracing::Span::current()),
             pulses: self.pulses.clone(),
-            noises: self.noises
+            noises: self.noises,
         }
     }
 }

--- a/simulator/src/integrated/simulation_elements/event_list.rs
+++ b/simulator/src/integrated/simulation_elements/event_list.rs
@@ -97,6 +97,16 @@ pub(crate) struct EventList<'a> {
     pub(crate) noises: &'a [NoiseSource],
 }
 
+impl<'a> Clone for EventList<'a> {
+    fn clone(&self) -> Self {
+        Self {
+            span: SpanOnce::Spanned(tracing::Span::current()),
+            pulses: self.pulses.clone(),
+            noises: self.noises
+        }
+    }
+}
+
 impl<'a> EventList<'a> {
     #[instrument(skip_all, level = "debug", "New Event List", err(level = "error"))]
     pub(crate) fn new(

--- a/simulator/src/integrated/simulation_elements/pulses.rs
+++ b/simulator/src/integrated/simulation_elements/pulses.rs
@@ -32,7 +32,7 @@ pub(crate) enum PulseTemplate {
     },
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub(crate) enum PulseEvent {
     Flat {
         start: f64,

--- a/simulator/src/integrated/simulation_engine/actions.rs
+++ b/simulator/src/integrated/simulation_engine/actions.rs
@@ -138,6 +138,7 @@ pub(crate) enum DigitiserAction {
     //
     GenerateTrace(GenerateTrace),
     GenerateEventList(GenerateEventList),
+    GenerateEventListAndTraces(GenerateEventList),
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/simulator/src/integrated/simulation_engine/engine.rs
+++ b/simulator/src/integrated/simulation_engine/engine.rs
@@ -186,6 +186,24 @@ fn generate_event_lists_push_to_cache(
     Ok(())
 }
 
+#[instrument(skip_all, level = "debug", err(level = "error"))]
+fn generate_event_lists_and_traces_push_to_cache(
+    engine: &mut SimulationEngine,
+    generate_event: &GenerateEventList,
+) -> Result<(), SimulationError> {
+    let event_lists = engine.simulation.generate_event_lists(
+        generate_event.event_list_index,
+        engine.state.metadata.frame_number,
+        generate_event.repeat,
+    )?;
+    engine.event_list_cache.extend(event_lists.clone());
+    let traces = engine
+        .simulation
+        .generate_traces(event_lists.as_slice(), engine.state.metadata.frame_number)?;
+    engine.trace_cache.extend(traces);
+    Ok(())
+}
+
 #[instrument(skip_all, level = "debug")]
 fn tracing_event(event: &TracingEvent) {
     match event.level {
@@ -391,6 +409,9 @@ pub(crate) fn run_digitiser(
             }
             DigitiserAction::GenerateEventList(generate_event) => {
                 generate_event_lists_push_to_cache(engine, generate_event)?
+            }
+            DigitiserAction::GenerateEventListAndTraces(generate_event) => {
+                generate_event_lists_and_traces_push_to_cache(engine, generate_event)?
             }
             DigitiserAction::Comment(_) => (),
         }


### PR DESCRIPTION
## Summary of changes

Allows simulator to emit the same events as a trace and eventlist.

## Instruction for review/testing

General code review.
Has been tested in pipeline.
