### PR TITLE
Allow period, veto, and protons-per-pulse to be set by env vars

### DIFF
--- a/simulator/src/integrated/simulation_engine/actions.rs
+++ b/simulator/src/integrated/simulation_engine/actions.rs
@@ -98,9 +98,9 @@ pub(crate) enum Action {
     LogLoop(Loop<LogAction>),
     //
     SetTimestamp(Timestamp),
-    SetVetoFlags(u16),
-    SetPeriod(u64),
-    SetProtonsPerPulse(u8),
+    SetVetoFlags(NumConstant<u16>),
+    SetPeriod(NumConstant<u64>),
+    SetProtonsPerPulse(NumConstant<u8>),
     SetRunning(bool),
     //
     GenerateTrace(GenerateTrace),

--- a/simulator/src/integrated/simulation_engine/engine.rs
+++ b/simulator/src/integrated/simulation_engine/engine.rs
@@ -249,13 +249,13 @@ pub(crate) fn run_schedule(engine: &mut SimulationEngine) -> Result<(), Simulati
                 )?;
             }
             Action::SetVetoFlags(vetoes) => {
-                engine.state.metadata.veto_flags = *vetoes;
+                engine.state.metadata.veto_flags = vetoes.value()?;
             }
             Action::SetPeriod(period) => {
-                engine.state.metadata.period_number = *period;
+                engine.state.metadata.period_number = period.value()?;
             }
             Action::SetProtonsPerPulse(ppp) => {
-                engine.state.metadata.protons_per_pulse = *ppp;
+                engine.state.metadata.protons_per_pulse = ppp.value()?;
             }
             Action::SetRunning(running) => {
                 engine.state.metadata.running = *running;


### PR DESCRIPTION
## Summary of changes

Allows simulator to use env vars when setting period, veto, and protons-per-pulse values in status packet messages.

## Instruction for review/testing

General code review.
Has been tested in simulated pipeline.
