### PR TITLE
Add trace-writer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     branches:
       - main
     tags:
-      - 'v*'
+      - "v*"
   pull_request:
 
 jobs:
@@ -85,6 +85,7 @@ jobs:
           - simulator
           - trace-reader
           - trace-to-events
+          - trace-writer
 
     uses: ./.github/workflows/component.yml
     with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5435,6 +5435,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "trace-writer"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "clap",
+ "digital-muon-common",
+ "digital-muon-streaming-types",
+ "git-version",
+ "hdf5-metno",
+ "isis_streaming_data_types",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "miette",
+ "ndarray",
+ "rdkafka",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
   "trace-reader",
   "trace-to-events",
   "trace-viewer",
+  "trace-writer",
 ]
 
 [workspace.package]

--- a/common/src/tracer/mod.rs
+++ b/common/src/tracer/mod.rs
@@ -18,7 +18,7 @@ macro_rules! init_tracer {
         // to ensure the warning is emitted in the correct module.
         if tracer.use_otel() {
             if let Some(e) = tracer.get_otel_setup_error() {
-                warn!("{e}");
+                tracing::warn!("{e}");
             }
         }
         tracer

--- a/simulator/src/main.rs
+++ b/simulator/src/main.rs
@@ -37,7 +37,7 @@ use std::{
     time::{Duration, SystemTime},
 };
 use tokio::time;
-use tracing::{debug, error, info, warn};
+use tracing::{debug, error, info};
 
 #[derive(Clone, Parser)]
 #[clap(author, version = digital_muon_common::version!(), about)]

--- a/trace-writer/Cargo.toml
+++ b/trace-writer/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "trace-writer"
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+
+[dependencies]
+chrono.workspace = true
+clap.workspace = true
+git-version.workspace = true
+hdf5.workspace = true
+isis_streaming_data_types.workspace = true
+metrics.workspace = true
+metrics-exporter-prometheus.workspace = true
+miette = { workspace = true, features = ["fancy"] }
+ndarray.workspace = true
+rdkafka.workspace = true
+thiserror.workspace = true
+digital-muon-common.workspace = true
+digital-muon-streaming-types.workspace = true
+tokio.workspace = true
+tracing.workspace = true
+
+[lints.clippy]
+fallible_impl_from = "deny"

--- a/trace-writer/README.md
+++ b/trace-writer/README.md
@@ -1,0 +1,1 @@
+# trace-writer

--- a/trace-writer/src/error.rs
+++ b/trace-writer/src/error.rs
@@ -1,0 +1,16 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub(crate) enum TraceWriterError {
+    #[error("HDF5 error: {0}")]
+    Hdf5(#[from] hdf5::Error),
+
+    #[error("Missing flatbuffer field: {0}")]
+    MissingField(&'static str),
+
+    #[error("GPS timestamp conversion failed")]
+    TimestampConversionFailed,
+
+    #[error("String could not be written as HDF5 unicode: {0}")]
+    UnicodeConversionFailed(String),
+}

--- a/trace-writer/src/file_writer.rs
+++ b/trace-writer/src/file_writer.rs
@@ -1,0 +1,196 @@
+//! HDF5 file writer for digitiser analog trace data.
+//!
+//! Each [TraceFileWriter] owns one open HDF5 file. Digitiser groups and channel datasets
+//! are created lazily on first use.
+//!
+//! # HDF5 layout
+//! ```text
+//! /
+//!   digitiser_{id}/
+//!     frame_number  : [u32]              – one entry per received message
+//!     timestamp     : [VarLenUnicode]    – RFC3339 timestamp per message
+//!     period_number : [u64]              – one entry per received message
+//!     channel_{n}   : [VarLenArray<u16>] – voltage trace per message (variable length)
+//! ```
+
+use crate::error::TraceWriterError;
+use chrono::{DateTime, Utc};
+use digital_muon_streaming_types::dat2_digitizer_analog_trace_v2_generated::DigitizerAnalogTraceMessage;
+use hdf5::{
+    Dataset, File, Group, SimpleExtents,
+    types::{VarLenArray, VarLenUnicode},
+};
+use ndarray::s;
+use std::{collections::HashMap, path::Path};
+
+/// Appends a single value to a resizable 1-D HDF5 dataset.
+fn append_value<T: hdf5::H5Type>(ds: &Dataset, value: T) -> Result<(), hdf5::Error> {
+    let cur = ds.size();
+    ds.resize(cur + 1)?;
+    ds.write_slice(&[value], s![cur..cur + 1])?;
+    Ok(())
+}
+
+/// Creates a resizable 1-D HDF5 dataset of the given type.
+fn make_resizable_dataset<T: hdf5::H5Type>(
+    group: &Group,
+    name: &str,
+    chunk_size: usize,
+) -> Result<Dataset, hdf5::Error> {
+    group
+        .new_dataset::<T>()
+        .shape(SimpleExtents::resizable(vec![0]))
+        .chunk(vec![chunk_size])
+        .create(name)
+}
+
+/// Owns the HDF5 group and datasets for one digitiser.
+struct DigitizerData {
+    /// HDF5 group for this digitiser.
+    group: Group,
+    /// 1-D resizable dataset: frame number per message.
+    frame_number: Dataset,
+    /// 1-D resizable dataset: RFC3339 timestamp string per message.
+    timestamp: Dataset,
+    /// 1-D resizable dataset: period number per message.
+    period_number: Dataset,
+    /// Per-channel voltage datasets, keyed by channel number.
+    channels: HashMap<u32, Dataset>,
+}
+
+impl DigitizerData {
+    /// Creates the HDF5 group and metadata datasets for a new digitiser.
+    fn new(parent: &Group, digitizer_id: u8, chunk_size: usize) -> Result<Self, hdf5::Error> {
+        let group = parent.create_group(&format!("digitiser_{digitizer_id}"))?;
+
+        let frame_number = make_resizable_dataset::<u32>(&group, "frame_number", chunk_size)?;
+        let timestamp = make_resizable_dataset::<VarLenUnicode>(&group, "timestamp", chunk_size)?;
+        let period_number = make_resizable_dataset::<u64>(&group, "period_number", chunk_size)?;
+
+        Ok(Self {
+            group,
+            frame_number,
+            timestamp,
+            period_number,
+            channels: HashMap::new(),
+        })
+    }
+
+    /// Writes one [DigitizerAnalogTraceMessage] into this digitiser's datasets.
+    fn write_trace(
+        &mut self,
+        msg: &DigitizerAnalogTraceMessage<'_>,
+        chunk_size: usize,
+    ) -> Result<(), TraceWriterError> {
+        let metadata = msg.metadata();
+
+        append_value(&self.frame_number, metadata.frame_number())?;
+        append_value(&self.period_number, metadata.period_number())?;
+
+        let timestamp = metadata
+            .timestamp()
+            .copied()
+            .ok_or(TraceWriterError::MissingField("timestamp"))?;
+        let timestamp: DateTime<Utc> = timestamp
+            .try_into()
+            .map_err(|_| TraceWriterError::TimestampConversionFailed)?;
+        let timestamp = timestamp.to_rfc3339();
+        let timestamp: VarLenUnicode = timestamp
+            .parse()
+            .map_err(|_| TraceWriterError::UnicodeConversionFailed(timestamp.clone()))?;
+        append_value(&self.timestamp, timestamp)?;
+
+        let Some(channels) = msg.channels() else {
+            return Ok(());
+        };
+
+        for channel_trace in channels.iter() {
+            let channel_num = channel_trace.channel();
+
+            // Lazily create a dataset for this channel.
+            if !self.channels.contains_key(&channel_num) {
+                let ds = make_resizable_dataset::<VarLenArray<u16>>(
+                    &self.group,
+                    &format!("channel_{channel_num}"),
+                    chunk_size,
+                )?;
+                self.channels.insert(channel_num, ds);
+            }
+            let ds = self
+                .channels
+                .get(&channel_num)
+                .expect("channel was just inserted");
+
+            let voltage: Vec<u16> = channel_trace
+                .voltage()
+                .map(|v| v.iter().collect())
+                .unwrap_or_default();
+            let vla = VarLenArray::from_slice(&voltage);
+            append_value(ds, vla)?;
+        }
+
+        Ok(())
+    }
+}
+
+/// Manages one open HDF5 file for writing digitiser trace data.
+///
+/// Digitiser groups and channel datasets are created lazily the first time
+/// a message from that digitiser / channel is received.
+pub(crate) struct TraceFileWriter {
+    file: File,
+    chunk_size: usize,
+    digitizers: HashMap<u8, DigitizerData>,
+}
+
+impl TraceFileWriter {
+    /// Creates a new HDF5 file at `path` and prepares it for writing.
+    pub(crate) fn new(path: &Path, chunk_size: usize) -> Result<Self, TraceWriterError> {
+        let file = File::create(path)?;
+        Ok(Self {
+            file,
+            chunk_size,
+            digitizers: HashMap::new(),
+        })
+    }
+
+    /// Writes one [DigitizerAnalogTraceMessage] into the file.
+    ///
+    /// The digitiser group and any required channel datasets are created on first use.
+    pub(crate) fn write_trace_message(
+        &mut self,
+        msg: &DigitizerAnalogTraceMessage<'_>,
+    ) -> Result<(), TraceWriterError> {
+        let digitizer_id = msg.digitizer_id();
+
+        if !self.digitizers.contains_key(&digitizer_id) {
+            // `&self.file` coerces to `&Group` via Deref; the returned DigitizerData
+            // owns its HDF5 handles independently of `self.file`.
+            let dig_data = DigitizerData::new(&self.file, digitizer_id, self.chunk_size)?;
+            self.digitizers.insert(digitizer_id, dig_data);
+        }
+
+        let chunk_size = self.chunk_size;
+        let dig_data = self
+            .digitizers
+            .get_mut(&digitizer_id)
+            .expect("digitizer was just inserted");
+        dig_data.write_trace(msg, chunk_size)?;
+
+        Ok(())
+    }
+
+    /// Flushes all pending writes to disk.
+    #[allow(dead_code)]
+    pub(crate) fn flush(&self) -> Result<(), TraceWriterError> {
+        self.file.flush()?;
+        Ok(())
+    }
+
+    /// Flushes and closes the HDF5 file, consuming `self`.
+    pub(crate) fn close(self) -> Result<(), TraceWriterError> {
+        self.file.flush()?;
+        self.file.close()?;
+        Ok(())
+    }
+}

--- a/trace-writer/src/main.rs
+++ b/trace-writer/src/main.rs
@@ -1,0 +1,453 @@
+//! # Trace Writer
+//!
+//! Subscribes to a Kafka topic carrying digitiser analog trace messages (`dat2`) and
+//! writes the data to an HDF5 file.
+//!
+//! ## Modes
+//!
+//! **Continuous mode** (`--control-topic` is not set):
+//! - A single HDF5 file is created at startup (path given by `--output`).
+//! - Traces are appended until the process receives SIGINT.
+//!
+//! **Run-bounded mode** (`--control-topic` is set):
+//! - `--output` is treated as a directory.
+//! - A new HDF5 file is created for each `RunStart` message received on the
+//!   control topic. The file is named `<run_name>.h5` inside `--output`.
+//! - The current file is closed on every `RunStop` message.
+//! - Trace messages that arrive when no file is open are warned about and
+//!   discarded.
+
+mod error;
+mod file_writer;
+
+use chrono::{DateTime, Utc};
+use clap::Parser;
+use digital_muon_common::{
+    CommonKafkaOpts, init_tracer,
+    metrics::{
+        component_info_metric,
+        failures::{self, FailureKind},
+        messages_received::{self, MessageKind},
+        names::{
+            FAILURES, LAST_MESSAGE_FRAME_NUMBER, LAST_MESSAGE_TIMESTAMP, MESSAGES_PROCESSED,
+            MESSAGES_RECEIVED,
+        },
+    },
+    tracer::{OptionalHeaderTracerExt, TracerEngine, TracerOptions},
+};
+use digital_muon_streaming_types::dat2_digitizer_analog_trace_v2_generated::{
+    digitizer_analog_trace_message_buffer_has_identifier, root_as_digitizer_analog_trace_message,
+};
+use file_writer::TraceFileWriter;
+use isis_streaming_data_types::flatbuffers_generated::{
+    run_start_pl72::{root_as_run_start, run_start_buffer_has_identifier},
+    run_stop_6s4t::{root_as_run_stop, run_stop_buffer_has_identifier},
+};
+use metrics::{counter, describe_counter, describe_gauge, gauge};
+use metrics_exporter_prometheus::PrometheusBuilder;
+use miette::IntoDiagnostic;
+use rdkafka::{
+    consumer::{CommitMode, Consumer},
+    message::Message,
+};
+use std::{net::SocketAddr, path::PathBuf};
+use tokio::signal::unix::{SignalKind, signal};
+use tracing::{error, info, info_span, warn};
+
+/// Command-line interface for the trace-writer.
+#[derive(Debug, Parser)]
+#[clap(author, version = digital_muon_common::version!(), about)]
+struct Cli {
+    #[clap(flatten)]
+    common_kafka_options: CommonKafkaOpts,
+
+    /// Kafka consumer group.
+    #[clap(long)]
+    consumer_group: String,
+
+    /// The Kafka topic that digitiser analog trace messages (`dat2`) are consumed from.
+    #[clap(long)]
+    trace_topic: String,
+
+    /// Optional Kafka control topic.
+    ///
+    /// When set, `RunStart` messages cause a new HDF5 file to be opened and
+    /// `RunStop` messages close the current file. `--output` is treated as a
+    /// directory in this mode.
+    ///
+    /// When not set, a single HDF5 file is written continuously and `--output`
+    /// is the full path to that file.
+    #[clap(long)]
+    control_topic: Option<String>,
+
+    /// Output path.
+    ///
+    /// - **Continuous mode** (no `--control-topic`): full path to the HDF5 output file.
+    /// - **Run-bounded mode** (`--control-topic` set): directory in which per-run HDF5
+    ///   files are created.
+    #[clap(long)]
+    output: PathBuf,
+
+    /// HDF5 chunk size (number of elements) used when creating resizable datasets.
+    #[clap(long, default_value = "1024")]
+    chunk_size: usize,
+
+    /// Endpoint on which OpenMetrics flavour metrics are available.
+    #[clap(long, env, default_value = "127.0.0.1:9090")]
+    observability_address: SocketAddr,
+
+    /// If set, OpenTelemetry traces are sent to this endpoint URL.
+    /// Otherwise the standard tracing subscriber is used.
+    #[clap(long)]
+    otel_endpoint: Option<String>,
+
+    /// OpenTelemetry `service.namespace` attribute. Used to distinguish
+    /// parallel pipeline instances.
+    #[clap(long, default_value = "")]
+    otel_namespace: String,
+}
+
+#[tokio::main]
+async fn main() -> miette::Result<()> {
+    let args = Cli::parse();
+
+    let tracer = init_tracer!(TracerOptions::new(
+        args.otel_endpoint.as_deref(),
+        args.otel_namespace.clone()
+    ));
+
+    let kafka_opts = &args.common_kafka_options;
+
+    // Build the list of topics to subscribe to.
+    let mut topics: Vec<&str> = vec![args.trace_topic.as_str()];
+    if let Some(ct) = &args.control_topic {
+        topics.push(ct.as_str());
+    }
+
+    let consumer = digital_muon_common::create_default_consumer(
+        &kafka_opts.broker,
+        &kafka_opts.username,
+        &kafka_opts.password,
+        &args.consumer_group,
+        Some(&topics),
+    )
+    .into_diagnostic()?;
+
+    // Install Prometheus metrics exporter.
+    PrometheusBuilder::new()
+        .with_http_listener(args.observability_address)
+        .install()
+        .into_diagnostic()?;
+
+    describe_counter!(
+        MESSAGES_RECEIVED,
+        metrics::Unit::Count,
+        "Number of messages received"
+    );
+    describe_counter!(
+        MESSAGES_PROCESSED,
+        metrics::Unit::Count,
+        "Number of messages successfully processed"
+    );
+    describe_counter!(FAILURES, metrics::Unit::Count, "Number of failures");
+    describe_gauge!(
+        LAST_MESSAGE_TIMESTAMP,
+        "GPS timestamp (ns) of the last received trace message per digitiser"
+    );
+    describe_gauge!(
+        LAST_MESSAGE_FRAME_NUMBER,
+        "Frame number of the last received trace message per digitiser"
+    );
+
+    component_info_metric("trace-writer");
+
+    // Prepare the initial writer state.
+    let mut writer: Option<TraceFileWriter> = if args.control_topic.is_none() {
+        // Continuous mode: open the output file immediately.
+        let w = TraceFileWriter::new(&args.output, args.chunk_size)
+            .map_err(|e| miette::miette!("{e}"))?;
+        info!("Opened HDF5 file for continuous writing: {:?}", args.output);
+        Some(w)
+    } else {
+        // Run-bounded mode: make sure the output directory exists.
+        std::fs::create_dir_all(&args.output).into_diagnostic()?;
+        info!(
+            "Run-bounded mode: HDF5 files will be written to {:?}",
+            args.output
+        );
+        None
+    };
+
+    let mut sigint = signal(SignalKind::interrupt()).into_diagnostic()?;
+
+    loop {
+        tokio::select! {
+            event = consumer.recv() => {
+                match event {
+                    Err(e) => warn!("Kafka error: {e}"),
+                    Ok(msg) => {
+                        let span = info_span!("message_received");
+                        msg.headers()
+                            .conditional_extract_to_span(tracer.use_otel(), &span);
+                        let _guard = span.enter();
+
+                        if let Some(payload) = msg.payload() {
+                            if msg.topic() == args.trace_topic {
+                                handle_trace_message(payload, &mut writer);
+                            } else if args.control_topic.as_deref() == Some(msg.topic()) {
+                                handle_control_message(
+                                    payload,
+                                    &mut writer,
+                                    &args.output,
+                                    args.chunk_size,
+                                );
+                            } else {
+                                warn!("Message received on unexpected topic: {}", msg.topic());
+                                counter!(
+                                    MESSAGES_RECEIVED,
+                                    &[messages_received::get_label(MessageKind::Unexpected)]
+                                )
+                                .increment(1);
+                            }
+                        }
+
+                        if let Err(e) = consumer.commit_message(&msg, CommitMode::Async) {
+                            error!("Failed to commit Kafka message offset: {e}");
+                        }
+                    }
+                }
+            }
+            _ = sigint.recv() => {
+                info!("Received SIGINT, flushing and closing HDF5 file");
+                if let Some(w) = writer.take()
+                    && let Err(e) = w.close() {
+                        error!("Failed to close HDF5 file on shutdown: {e}");
+                    }
+                return Ok(());
+            }
+        }
+    }
+}
+
+/// Handles a message received on the trace topic.
+///
+/// Decodes it as a [`DigitizerAnalogTraceMessage`], updates metrics, and
+/// appends the trace data to the current HDF5 file (if one is open).
+#[tracing::instrument(skip_all, fields(payload_size = payload.len()))]
+fn handle_trace_message(payload: &[u8], writer: &mut Option<TraceFileWriter>) {
+    if !digitizer_analog_trace_message_buffer_has_identifier(payload) {
+        warn!("Message on trace topic has unexpected identifier");
+        counter!(
+            MESSAGES_RECEIVED,
+            &[messages_received::get_label(MessageKind::Unexpected)]
+        )
+        .increment(1);
+        return;
+    }
+
+    counter!(
+        MESSAGES_RECEIVED,
+        &[messages_received::get_label(MessageKind::Trace)]
+    )
+    .increment(1);
+
+    let trace = match root_as_digitizer_analog_trace_message(payload) {
+        Ok(t) => t,
+        Err(e) => {
+            warn!("Failed to decode trace message: {e}");
+            counter!(
+                FAILURES,
+                &[failures::get_label(FailureKind::UnableToDecodeMessage)]
+            )
+            .increment(1);
+            return;
+        }
+    };
+
+    // Update per-digitiser metrics.
+    let did = trace.digitizer_id().to_string();
+
+    if let Some(dt) = trace
+        .metadata()
+        .timestamp()
+        .copied()
+        .and_then(|t| DateTime::<Utc>::try_from(t).ok())
+        && let Some(ns) = dt.timestamp_nanos_opt()
+    {
+        gauge!(
+            LAST_MESSAGE_TIMESTAMP,
+            &[
+                messages_received::get_label(MessageKind::Trace),
+                ("digitizer_id", did.clone())
+            ]
+        )
+        .set(ns as f64);
+    }
+    gauge!(
+        LAST_MESSAGE_FRAME_NUMBER,
+        &[
+            messages_received::get_label(MessageKind::Trace),
+            ("digitizer_id", did)
+        ]
+    )
+    .set(trace.metadata().frame_number() as f64);
+
+    // Write to the open HDF5 file.
+    let Some(w) = writer.as_mut() else {
+        warn!(
+            "Trace message (digitiser {}, frame {}) received but no HDF5 file is open \
+             — is a RunStart message missing?",
+            trace.digitizer_id(),
+            trace.metadata().frame_number(),
+        );
+        counter!(
+            FAILURES,
+            &[failures::get_label(FailureKind::FileWriteFailed)]
+        )
+        .increment(1);
+        return;
+    };
+
+    match w.write_trace_message(&trace) {
+        Ok(()) => {
+            counter!(
+                MESSAGES_PROCESSED,
+                &[messages_received::get_label(MessageKind::Trace)]
+            )
+            .increment(1);
+        }
+        Err(e) => {
+            warn!("Failed to write trace message to HDF5 file: {e}");
+            counter!(
+                FAILURES,
+                &[failures::get_label(FailureKind::FileWriteFailed)]
+            )
+            .increment(1);
+        }
+    }
+}
+
+/// Handles a message received on the control topic.
+///
+/// `RunStart` closes any currently open HDF5 file and opens a new one named
+/// after the run. `RunStop` closes the current file.
+#[tracing::instrument(skip_all, fields(payload_size = payload.len()))]
+fn handle_control_message(
+    payload: &[u8],
+    writer: &mut Option<TraceFileWriter>,
+    output_dir: &std::path::Path,
+    chunk_size: usize,
+) {
+    if run_start_buffer_has_identifier(payload) {
+        counter!(
+            MESSAGES_RECEIVED,
+            &[messages_received::get_label(MessageKind::RunStart)]
+        )
+        .increment(1);
+
+        match root_as_run_start(payload) {
+            Ok(run_start) => {
+                // Close any file that is currently open.
+                if let Some(old) = writer.take()
+                    && let Err(e) = old.close()
+                {
+                    warn!("Failed to close previous HDF5 file before RunStart: {e}");
+                }
+
+                // Derive a safe file name from the run name.
+                let run_name = run_start.run_name().unwrap_or("unknown_run");
+                let safe_name: String = run_name
+                    .chars()
+                    .map(|c| {
+                        if c.is_alphanumeric() || c == '_' || c == '-' {
+                            c
+                        } else {
+                            '_'
+                        }
+                    })
+                    .collect();
+                let path = output_dir.join(format!("{safe_name}.h5"));
+
+                info!("RunStart received (run={run_name:?}), creating HDF5 file: {path:?}");
+
+                match TraceFileWriter::new(&path, chunk_size) {
+                    Ok(w) => {
+                        *writer = Some(w);
+                        counter!(
+                            MESSAGES_PROCESSED,
+                            &[messages_received::get_label(MessageKind::RunStart)]
+                        )
+                        .increment(1);
+                    }
+                    Err(e) => {
+                        warn!("Failed to create HDF5 file {path:?}: {e}");
+                        counter!(
+                            FAILURES,
+                            &[failures::get_label(FailureKind::FileWriteFailed)]
+                        )
+                        .increment(1);
+                    }
+                }
+            }
+            Err(e) => {
+                warn!("Failed to decode RunStart message: {e}");
+                counter!(
+                    FAILURES,
+                    &[failures::get_label(FailureKind::UnableToDecodeMessage)]
+                )
+                .increment(1);
+            }
+        }
+    } else if run_stop_buffer_has_identifier(payload) {
+        counter!(
+            MESSAGES_RECEIVED,
+            &[messages_received::get_label(MessageKind::RunStop)]
+        )
+        .increment(1);
+
+        match root_as_run_stop(payload) {
+            Ok(run_stop) => {
+                let run_name = run_stop.run_name().unwrap_or("?");
+                info!("RunStop received (run={run_name:?}), closing HDF5 file");
+
+                match writer.take() {
+                    Some(w) => match w.close() {
+                        Ok(()) => {
+                            counter!(
+                                MESSAGES_PROCESSED,
+                                &[messages_received::get_label(MessageKind::RunStop)]
+                            )
+                            .increment(1);
+                        }
+                        Err(e) => {
+                            warn!("Failed to close HDF5 file on RunStop: {e}");
+                            counter!(
+                                FAILURES,
+                                &[failures::get_label(FailureKind::FileWriteFailed)]
+                            )
+                            .increment(1);
+                        }
+                    },
+                    None => warn!(
+                        "RunStop received (run={run_name:?}) but no HDF5 file is currently open"
+                    ),
+                }
+            }
+            Err(e) => {
+                warn!("Failed to decode RunStop message: {e}");
+                counter!(
+                    FAILURES,
+                    &[failures::get_label(FailureKind::UnableToDecodeMessage)]
+                )
+                .increment(1);
+            }
+        }
+    } else {
+        warn!("Message on control topic has unexpected identifier");
+        counter!(
+            MESSAGES_RECEIVED,
+            &[messages_received::get_label(MessageKind::Unexpected)]
+        )
+        .increment(1);
+    }
+}


### PR DESCRIPTION
## Summary of changes

Adds a tool to save trace data to HDF5 files.

The HDF5 structure is not the most pleasant, but it does move some complexity and error handling from write time to read time, which when the goal is just having a record of the traces is probably fine.

Fixes #491

## Instruction for review/testing

- Run `trace-saver`, supplying only the trace topic and a filename, see that received traces end up in the HDF5 file.
- Run it again, but also supplying the control topic, nothing should be written until a run start is received, at which point data should be written into a file matching the run name until the corresponding run stop is received.
