### PR TITLE
Ignore RUSTSEC-2026-0173

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -7,6 +7,7 @@ ignore = [
   "RUSTSEC-2026-0047",
   "RUSTSEC-2026-0048",
   "RUSTSEC-2026-0097",
+  "RUSTSEC-2026-0173",
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary of changes

Add RUSTSEC-2026-0173 to ignored advisories. There is no straightforward migration from `proc-macro-error2` right now.

## Instruction for review/testing

- CI passes
