### PR TITLE
Aggregator: force non-repeating digitiser ids

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1365,6 +1365,7 @@ dependencies = [
  "metrics-exporter-prometheus",
  "miette",
  "rdkafka",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1361,6 +1361,7 @@ dependencies = [
  "digital-muon-common",
  "digital-muon-streaming-types",
  "git-version",
+ "itertools 0.14.0",
  "metrics",
  "metrics-exporter-prometheus",
  "miette",

--- a/digitiser-aggregator/Cargo.toml
+++ b/digitiser-aggregator/Cargo.toml
@@ -14,6 +14,7 @@ miette = { workspace = true, features = ["fancy"] }
 rdkafka.workspace = true
 digital-muon-common.workspace = true
 digital-muon-streaming-types.workspace = true
+thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 

--- a/digitiser-aggregator/Cargo.toml
+++ b/digitiser-aggregator/Cargo.toml
@@ -8,6 +8,7 @@ edition.workspace = true
 chrono.workspace = true
 clap.workspace = true
 git-version.workspace = true
+itertools.workspace = true
 metrics.workspace = true
 metrics-exporter-prometheus.workspace = true
 miette = { workspace = true, features = ["fancy"] }

--- a/digitiser-aggregator/src/frame/cache.rs
+++ b/digitiser-aggregator/src/frame/cache.rs
@@ -1,6 +1,9 @@
 //! Defines the cache stores frames as they are assembled from digitiser messages.
 use super::{AggregatedFrame, RejectMessageError, partial::PartialFrame};
-use crate::{data::{Accumulate, DigitiserData}, frame::FrameCacheError};
+use crate::{
+    data::{Accumulate, DigitiserData},
+    frame::FrameCacheError,
+};
 use chrono::{DateTime, Utc};
 use digital_muon_common::{
     DigitizerId, record_metadata_fields_to_span, spanned::SpannedAggregator,
@@ -34,9 +37,12 @@ where
     /// - expected_digitisers: list of digitisers that form a complete frame.
     ///
     /// Note that the function returns an error if `expected_digitisers` has any repetitions.
-    pub(crate) fn new(ttl: Duration, mut expected_digitisers: Vec<DigitizerId>) -> Result<Self, FrameCacheError> {
+    pub(crate) fn new(
+        ttl: Duration,
+        mut expected_digitisers: Vec<DigitizerId>,
+    ) -> Result<Self, FrameCacheError> {
         expected_digitisers.sort();
-        let validation_fn = |pair : &[DigitizerId]| {
+        let validation_fn = |pair: &[DigitizerId]| {
             let [first, second] = pair
                 .try_into()
                 .expect("Window slice is non-empty, this should never fail.");
@@ -170,19 +176,25 @@ mod test {
     fn test_repeated_digitiser_ids() {
         assert!(FrameCache::<EventData>::new(Duration::from_millis(100), vec![0, 1, 4, 8]).is_ok());
         assert!(FrameCache::<EventData>::new(Duration::from_millis(100), vec![0, 1, 8, 5]).is_ok());
-        assert!(FrameCache::<EventData>::new(Duration::from_millis(100), vec![0, 1, 4, 4]).is_err());
-        assert!(FrameCache::<EventData>::new(Duration::from_millis(100), vec![0, 8, 1, 8]).is_err());
+        assert!(
+            FrameCache::<EventData>::new(Duration::from_millis(100), vec![0, 1, 4, 4]).is_err()
+        );
+        assert!(
+            FrameCache::<EventData>::new(Duration::from_millis(100), vec![0, 8, 1, 8]).is_err()
+        );
     }
 
     #[test]
     fn test_digitiser_id_reordering() {
-        let cache = FrameCache::<EventData>::new(Duration::from_millis(100), vec![0, 1, 8, 5]).unwrap();
+        let cache =
+            FrameCache::<EventData>::new(Duration::from_millis(100), vec![0, 1, 8, 5]).unwrap();
         assert_eq!(cache.expected_digitisers, vec![0, 1, 5, 8]);
     }
 
     #[test]
     fn one_frame_in_one_frame_out() {
-        let mut cache = FrameCache::<EventData>::new(Duration::from_millis(100), vec![0, 1, 4, 8]).unwrap();
+        let mut cache =
+            FrameCache::<EventData>::new(Duration::from_millis(100), vec![0, 1, 4, 8]).unwrap();
 
         let frame_1 = FrameMetadata {
             timestamp: Utc::now(),
@@ -260,7 +272,8 @@ mod test {
 
     #[tokio::test]
     async fn one_frame_in_one_frame_out_missing_digitiser_timeout() {
-        let mut cache = FrameCache::<EventData>::new(Duration::from_millis(100), vec![0, 1, 4, 8]).unwrap();
+        let mut cache =
+            FrameCache::<EventData>::new(Duration::from_millis(100), vec![0, 1, 4, 8]).unwrap();
 
         let frame_1 = FrameMetadata {
             timestamp: Utc::now(),
@@ -329,7 +342,8 @@ mod test {
 
     #[tokio::test]
     async fn one_frame_in_one_frame_out_missing_digitiser_and_late_message_timeout() {
-        let mut cache = FrameCache::<EventData>::new(Duration::from_millis(100), vec![0, 1, 4, 8]).unwrap();
+        let mut cache =
+            FrameCache::<EventData>::new(Duration::from_millis(100), vec![0, 1, 4, 8]).unwrap();
 
         let frame_1 = FrameMetadata {
             timestamp: Utc::now(),
@@ -369,7 +383,8 @@ mod test {
 
     #[test]
     fn test_metadata_equality() {
-        let mut cache = FrameCache::<EventData>::new(Duration::from_millis(100), vec![1, 2]).unwrap();
+        let mut cache =
+            FrameCache::<EventData>::new(Duration::from_millis(100), vec![1, 2]).unwrap();
 
         let timestamp = Utc::now();
         let frame_1 = FrameMetadata {

--- a/digitiser-aggregator/src/frame/cache.rs
+++ b/digitiser-aggregator/src/frame/cache.rs
@@ -9,6 +9,7 @@ use digital_muon_common::{
     DigitizerId, record_metadata_fields_to_span, spanned::SpannedAggregator,
 };
 use digital_muon_streaming_types::FrameMetadata;
+use itertools::Itertools;
 use std::{collections::VecDeque, fmt::Debug, time::Duration};
 use tracing::{info_span, warn};
 
@@ -42,13 +43,12 @@ where
         mut expected_digitisers: Vec<DigitizerId>,
     ) -> Result<Self, FrameCacheError> {
         expected_digitisers.sort();
-        let validation_fn = |pair: &[DigitizerId]| {
-            let [first, second] = pair
-                .try_into()
-                .expect("Window slice is non-empty, this should never fail.");
-            first != second
-        };
-        if expected_digitisers.windows(2).all(validation_fn) {
+        let duplicates = expected_digitisers
+            .iter()
+            .duplicates()
+            .copied()
+            .collect::<Vec<_>>();
+        if duplicates.is_empty() {
             Ok(Self {
                 ttl,
                 expected_digitisers,
@@ -56,7 +56,7 @@ where
                 frames: Default::default(),
             })
         } else {
-            Err(FrameCacheError::DuplicateDigitiserId)
+            Err(FrameCacheError::DuplicateDigitiserId(duplicates))
         }
     }
 

--- a/digitiser-aggregator/src/frame/cache.rs
+++ b/digitiser-aggregator/src/frame/cache.rs
@@ -1,6 +1,6 @@
 //! Defines the cache stores frames as they are assembled from digitiser messages.
 use super::{AggregatedFrame, RejectMessageError, partial::PartialFrame};
-use crate::data::{Accumulate, DigitiserData};
+use crate::{data::{Accumulate, DigitiserData}, frame::FrameCacheError};
 use chrono::{DateTime, Utc};
 use digital_muon_common::{
     DigitizerId, record_metadata_fields_to_span, spanned::SpannedAggregator,
@@ -36,7 +36,7 @@ where
     /// Note that the function returns an error if `expected_digitisers` has any repetitions.
     pub(crate) fn new(ttl: Duration, mut expected_digitisers: Vec<DigitizerId>) -> Result<Self, FrameCacheError> {
         expected_digitisers.sort();
-        let validation_fn = |pair| {
+        let validation_fn = |pair : &[DigitizerId]| {
             let [first, second] = pair
                 .try_into()
                 .expect("Window slice is non-empty, this should never fail.");
@@ -50,7 +50,7 @@ where
                 frames: Default::default(),
             })
         } else {
-            Err(FrameCacheError::DuplicateDigitiserIdOnCommandLine)
+            Err(FrameCacheError::DuplicateDigitiserId)
         }
     }
 
@@ -72,7 +72,7 @@ where
                 "Frame's timestamp earlier than or equal to the latest frame dispatched: {0} <= {1}",
                 metadata.timestamp, latest_timestamp_dispatched
             );
-            return Err(Error::TimestampTooEarly);
+            return Err(RejectMessageError::TimestampTooEarly);
         }
         let frame = {
             match self
@@ -165,6 +165,20 @@ mod test {
     use super::*;
     use crate::data::EventData;
     use chrono::Utc;
+
+    #[test]
+    fn test_repeated_digitiser_ids() {
+        assert!(FrameCache::<EventData>::new(Duration::from_millis(100), vec![0, 1, 4, 8]).is_ok());
+        assert!(FrameCache::<EventData>::new(Duration::from_millis(100), vec![0, 1, 8, 5]).is_ok());
+        assert!(FrameCache::<EventData>::new(Duration::from_millis(100), vec![0, 1, 4, 4]).is_err());
+        assert!(FrameCache::<EventData>::new(Duration::from_millis(100), vec![0, 8, 1, 8]).is_err());
+    }
+
+    #[test]
+    fn test_digitiser_id_reordering() {
+        let cache = FrameCache::<EventData>::new(Duration::from_millis(100), vec![0, 1, 8, 5]).unwrap();
+        assert_eq!(cache.expected_digitisers, vec![0, 1, 5, 8]);
+    }
 
     #[test]
     fn one_frame_in_one_frame_out() {

--- a/digitiser-aggregator/src/frame/cache.rs
+++ b/digitiser-aggregator/src/frame/cache.rs
@@ -33,13 +33,24 @@ where
     /// - ttl: time-to-live duration
     /// - expected_digitisers: list of digitisers that form a complete frame.
     ///
-    /// Note that `expected_digitisers` should be increasing and without duplicates, this is not checked.
-    pub(crate) fn new(ttl: Duration, expected_digitisers: Vec<DigitizerId>) -> Self {
-        Self {
-            ttl,
-            expected_digitisers,
-            latest_timestamp_dispatched: None,
-            frames: Default::default(),
+    /// Note that the function returns an error if `expected_digitisers` has any repetitions.
+    pub(crate) fn new(ttl: Duration, mut expected_digitisers: Vec<DigitizerId>) -> Result<Self, FrameCacheError> {
+        expected_digitisers.sort();
+        let validation_fn = |pair| {
+            let [first, second] = pair
+                .try_into()
+                .expect("Window slice is non-empty, this should never fail.");
+            first != second
+        };
+        if expected_digitisers.windows(2).all(validation_fn) {
+            Ok(Self {
+                ttl,
+                expected_digitisers,
+                latest_timestamp_dispatched: None,
+                frames: Default::default(),
+            })
+        } else {
+            Err(FrameCacheError::DuplicateDigitiserIdOnCommandLine)
         }
     }
 
@@ -61,7 +72,7 @@ where
                 "Frame's timestamp earlier than or equal to the latest frame dispatched: {0} <= {1}",
                 metadata.timestamp, latest_timestamp_dispatched
             );
-            return Err(RejectMessageError::TimestampTooEarly);
+            return Err(Error::TimestampTooEarly);
         }
         let frame = {
             match self
@@ -157,7 +168,7 @@ mod test {
 
     #[test]
     fn one_frame_in_one_frame_out() {
-        let mut cache = FrameCache::<EventData>::new(Duration::from_millis(100), vec![0, 1, 4, 8]);
+        let mut cache = FrameCache::<EventData>::new(Duration::from_millis(100), vec![0, 1, 4, 8]).unwrap();
 
         let frame_1 = FrameMetadata {
             timestamp: Utc::now(),
@@ -235,7 +246,7 @@ mod test {
 
     #[tokio::test]
     async fn one_frame_in_one_frame_out_missing_digitiser_timeout() {
-        let mut cache = FrameCache::<EventData>::new(Duration::from_millis(100), vec![0, 1, 4, 8]);
+        let mut cache = FrameCache::<EventData>::new(Duration::from_millis(100), vec![0, 1, 4, 8]).unwrap();
 
         let frame_1 = FrameMetadata {
             timestamp: Utc::now(),
@@ -304,7 +315,7 @@ mod test {
 
     #[tokio::test]
     async fn one_frame_in_one_frame_out_missing_digitiser_and_late_message_timeout() {
-        let mut cache = FrameCache::<EventData>::new(Duration::from_millis(100), vec![0, 1, 4, 8]);
+        let mut cache = FrameCache::<EventData>::new(Duration::from_millis(100), vec![0, 1, 4, 8]).unwrap();
 
         let frame_1 = FrameMetadata {
             timestamp: Utc::now(),
@@ -344,7 +355,7 @@ mod test {
 
     #[test]
     fn test_metadata_equality() {
-        let mut cache = FrameCache::<EventData>::new(Duration::from_millis(100), vec![1, 2]);
+        let mut cache = FrameCache::<EventData>::new(Duration::from_millis(100), vec![1, 2]).unwrap();
 
         let timestamp = Utc::now();
         let frame_1 = FrameMetadata {

--- a/digitiser-aggregator/src/frame/mod.rs
+++ b/digitiser-aggregator/src/frame/mod.rs
@@ -6,6 +6,7 @@ mod aggregated;
 mod cache;
 mod partial;
 
+use digital_muon_common::DigitizerId;
 use thiserror::Error;
 
 pub(crate) use aggregated::AggregatedFrame;
@@ -15,8 +16,8 @@ pub(crate) use cache::FrameCache;
 #[derive(Debug, Error)]
 pub(crate) enum FrameCacheError {
     /// If the user specifies the same digitiser id more than once on the command line.
-    #[error("Duplicate Digitiser Id On Command Line")]
-    DuplicateDigitiserId,
+    #[error("Duplicate Digitiser Id(s) On Command Line: {0:?}")]
+    DuplicateDigitiserId(Vec<DigitizerId>),
 }
 
 /// Represents the reason why a digitiser event list message is rejected

--- a/digitiser-aggregator/src/frame/mod.rs
+++ b/digitiser-aggregator/src/frame/mod.rs
@@ -16,7 +16,7 @@ pub(crate) use cache::FrameCache;
 pub(crate) enum FrameCacheError {
     /// If the user specifies the same digitiser id more than once on the command line.
     #[error("Duplicate Digitiser Id On Command Line")]
-    DuplicateDigitiserId
+    DuplicateDigitiserId,
 }
 
 /// Represents the reason why a digitiser event list message is rejected

--- a/digitiser-aggregator/src/frame/mod.rs
+++ b/digitiser-aggregator/src/frame/mod.rs
@@ -6,13 +6,17 @@ mod aggregated;
 mod cache;
 mod partial;
 
+use thiserror::Error;
+
 pub(crate) use aggregated::AggregatedFrame;
 pub(crate) use cache::FrameCache;
 
 /// Represents errors in the [FrameCache] object.
+#[derive(Debug, Error)]
 pub(crate) enum FrameCacheError {
     /// If the user specifies the same digitiser id more than once on the command line.
-    DuplicateDigitiserIdOnCommandLine
+    #[error("Duplicate Digitiser Id On Command Line")]
+    DuplicateDigitiserId
 }
 
 /// Represents the reason why a digitiser event list message is rejected

--- a/digitiser-aggregator/src/frame/mod.rs
+++ b/digitiser-aggregator/src/frame/mod.rs
@@ -9,6 +9,12 @@ mod partial;
 pub(crate) use aggregated::AggregatedFrame;
 pub(crate) use cache::FrameCache;
 
+/// Represents errors in the [FrameCache] object.
+pub(crate) enum FrameCacheError {
+    /// If the user specifies the same digitiser id more than once on the command line.
+    DuplicateDigitiserIdOnCommandLine
+}
+
 /// Represents the reason why a digitiser event list message is rejected
 pub(crate) enum RejectMessageError {
     /// The frame has already encountered an event list from this digitiser.

--- a/digitiser-aggregator/src/main.rs
+++ b/digitiser-aggregator/src/main.rs
@@ -166,8 +166,8 @@ async fn main() -> miette::Result<()> {
 
     let ttl = Duration::from_millis(args.frame_ttl_ms);
 
-    let mut cache = FrameCache::<EventData>::new(ttl, args.digitiser_ids.clone())
-        .into_diagnostic()?;
+    let mut cache =
+        FrameCache::<EventData>::new(ttl, args.digitiser_ids.clone()).into_diagnostic()?;
 
     // Install exporter and register metrics
     let builder = PrometheusBuilder::new();

--- a/digitiser-aggregator/src/main.rs
+++ b/digitiser-aggregator/src/main.rs
@@ -103,7 +103,7 @@ struct Cli {
 
     /// A list of expected digitiser IDs. Can be passed as `-d0 -d1 ...` or `-d=0,1,...`.
     /// A frame is only "complete" when a message has been received from each of these IDs.
-    /// This sequence must be passed in increasing order, with no repetitions, otherwise the program will panic.
+    /// This sequence must be passed with no repetitions, otherwise the program will panic.
     #[clap(short, long, value_delimiter = ',')]
     digitiser_ids: Vec<DigitizerId>,
 
@@ -135,43 +135,10 @@ struct Cli {
     otel_namespace: String,
 }
 
-/// Validate digitiser ids by checking `args.digitiser_ids` is a strictly increasing sequence.
-/// If any consecutive ids are decreasing, or equal, then we issue a panic with a suitable warning to the user.
-/// # Parameters
-/// - digitiser_ids: the ids to validate
-///
-/// # Return
-/// If the list is invalid, the position of the first error, and the erroneous ids are returned,
-/// otherwise None is returned.
-fn validate_digitiser_ids(digitiser_ids: &[DigitizerId]) -> Option<(usize, &[DigitizerId])> {
-    let is_pair_weakly_decreasing = |ids_pair: &[DigitizerId]| {
-        let first = ids_pair
-            .first()
-            .expect("Window slice is non-empty, this should never fail.");
-        let second = ids_pair
-            .get(1)
-            .expect("Window slice has len 2, this should never fail.");
-        first >= second
-    };
-    digitiser_ids
-        .windows(2)
-        .enumerate()
-        .find(|(_, p)| is_pair_weakly_decreasing(p))
-}
-
 /// Entry point.
 #[tokio::main]
 async fn main() -> miette::Result<()> {
     let args = Cli::parse();
-
-    // Validate digitiser ids, and panic if they are out of order.
-    if let Some((index, pair)) = validate_digitiser_ids(&args.digitiser_ids) {
-        miette::bail!(
-            "--digitiser-ids {:?} should be a strictly-increasing sequence, but {:?} at position {index} is weakly-decreasing.",
-            args.digitiser_ids,
-            pair
-        );
-    }
 
     let tracer = init_tracer!(TracerOptions::new(
         args.otel_endpoint.as_deref(),
@@ -199,7 +166,8 @@ async fn main() -> miette::Result<()> {
 
     let ttl = Duration::from_millis(args.frame_ttl_ms);
 
-    let mut cache = FrameCache::<EventData>::new(ttl, args.digitiser_ids.clone());
+    let mut cache = FrameCache::<EventData>::new(ttl, args.digitiser_ids.clone())
+        .into_diagnostic()?;
 
     // Install exporter and register metrics
     let builder = PrometheusBuilder::new();

--- a/digitiser-aggregator/src/main.rs
+++ b/digitiser-aggregator/src/main.rs
@@ -101,9 +101,9 @@ struct Cli {
     #[clap(long)]
     output_topic: String,
 
-    /// A list of expected digitiser IDs.
-    /// Can be passed as `-d0 -d1 ...` or `-d=0,1,...`
+    /// A list of expected digitiser IDs. Can be passed as `-d0 -d1 ...` or `-d=0,1,...`.
     /// A frame is only "complete" when a message has been received from each of these IDs.
+    /// This sequence must be passed in increasing order, with no repetitions, otherwise the program will panic.
     #[clap(short, long, value_delimiter = ',')]
     digitiser_ids: Vec<DigitizerId>,
 
@@ -135,20 +135,42 @@ struct Cli {
     otel_namespace: String,
 }
 
+/// Validate digitiser ids by checking `args.digitiser_ids` is a strictly increasing sequence.
+/// If any consecutive ids are decreasing, or equal, then we issue a panic with a suitable warning to the user.
+/// # Parameters
+/// - digitiser_ids: the ids to validate
+///
+/// # Return
+/// If the list is invalid, the position of the first error, and the erroneous ids are returned,
+/// otherwise None is returned.
+fn validate_digitiser_ids(digitiser_ids: &[DigitizerId]) -> Option<(usize, &[DigitizerId])> {
+    let is_pair_weakly_decreasing = |ids_pair: &[DigitizerId]| {
+        let first = ids_pair
+            .first()
+            .expect("Window slice is non-empty, this should never fail.");
+        let second = ids_pair
+            .get(1)
+            .expect("Window slice has len 2, this should never fail.");
+        first >= second
+    };
+    digitiser_ids
+        .windows(2)
+        .enumerate()
+        .find(|(_, p)| is_pair_weakly_decreasing(p))
+}
+
 /// Entry point.
 #[tokio::main]
 async fn main() -> miette::Result<()> {
     let args = Cli::parse();
 
-    let is_pair_weakly_decreasing = |ids_pair: &[DigitizerId]| {
-        let first = ids_pair.first()
-            .expect("Window slice is non-empty, this should never fail.");
-        let second = ids_pair.get(1)
-            .expect("Window slice has len 2, this should never fail.");
-        first >= second
-    };
-    if args.digitiser_ids.windows(2).any(is_pair_weakly_decreasing) {
-        panic!("Digitiser Ids {:?} should be a strictly increasing sequence on the command line.", args.digitiser_ids);
+    // Validate digitiser ids, and panic if they are out of order.
+    if let Some((index, pair)) = validate_digitiser_ids(&args.digitiser_ids) {
+        miette::bail!(
+            "--digitiser-ids {:?} should be a strictly-increasing sequence, but {:?} at position {index} is weakly-decreasing.",
+            args.digitiser_ids,
+            pair
+        );
     }
 
     let tracer = init_tracer!(TracerOptions::new(

--- a/digitiser-aggregator/src/main.rs
+++ b/digitiser-aggregator/src/main.rs
@@ -140,6 +140,17 @@ struct Cli {
 async fn main() -> miette::Result<()> {
     let args = Cli::parse();
 
+    let is_pair_weakly_decreasing = |ids_pair: &[DigitizerId]| {
+        let first = ids_pair.first()
+            .expect("Window slice is non-empty, this should never fail.");
+        let second = ids_pair.get(1)
+            .expect("Window slice has len 2, this should never fail.");
+        first >= second
+    };
+    if args.digitiser_ids.windows(2).any(is_pair_weakly_decreasing) {
+        panic!("Digitiser Ids {:?} should be a strictly increasing sequence on the command line.", args.digitiser_ids);
+    }
+
     let tracer = init_tracer!(TracerOptions::new(
         args.otel_endpoint.as_deref(),
         args.otel_namespace


### PR DESCRIPTION
## Summary of changes

Adds validation step that checks the user has passed digitiser ids as a ~~strictly increasing~~ non-repeating sequence, and bails otherwise.

Forcing the user to adhere to this format rather than fixing it silently is more likely to catch user cli typos.

## Instruction for review/testing

Check `cargo run -p digitiser-aggregator -- --broker 0 --group 1 --input-topic a --output-topic b -d0,1,2,3,4,6,8` works,
and that `cargo run -p digitiser-aggregator -- --broker 0 --group 1 --input-topic a --output-topic b -d0,1,2,3,4,6,8` works,
and `cargo run -p digitiser-aggregator -- --broker 0 --group 1 --input-topic a --output-topic b -d0,1,2,4,3,6,6` doesn't.

Closes https://github.com/ISISNeutronMuon/digital-muon-pipeline/issues/338.