### PR TITLE
Upgrade anyhow to fix cargo deny issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,9 +352,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "ascii"
@@ -1462,7 +1462,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2165,7 +2165,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.1",
  "tokio",
  "tower-service",
  "tracing",
@@ -3144,7 +3144,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4328,7 +4328,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6081,7 +6081,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ edition = "2024"
 [workspace.dependencies]
 actix-files = "0.6"
 actix-web = { version = "4", features = ["macros"] }
+anyhow = "1.0.103"
 assert_approx_eq = "1.1.0"
 cfg-if = "1"
 chrono = { version = "0.4.44", features = ["serde"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,6 @@ edition = "2024"
 [workspace.dependencies]
 actix-files = "0.6"
 actix-web = { version = "4", features = ["macros"] }
-anyhow = "1.0.103"
 assert_approx_eq = "1.1.0"
 cfg-if = "1"
 chrono = { version = "0.4.44", features = ["serde"] }


### PR DESCRIPTION
## Summary of changes

Pins anyhow version in `cargo.toml` to fix issue with `cargo deny check`. A bug in `anyhow 1.0.100` may affect crates using it such as `leptos`.

## Instruction for review/testing

Ensure `cargo deny check` runs.
