### PR TITLE
Trace reader: bug fixes and overwrite options

### DIFF
--- a/trace-reader/src/hdf5trace/digitiser.rs
+++ b/trace-reader/src/hdf5trace/digitiser.rs
@@ -288,6 +288,8 @@ impl Hdf5Digitiser {
             timestamp = timestamp
                 .with_day(Utc::now().day())
                 .expect("Timestamp with current day should be possible, this should never fail.")
+                .with_month(Utc::now().month())
+                .expect("Timestamp with current month should be possible, this should never fail.")
                 .with_year(Utc::now().year())
                 .expect("Timestamp with current year should be possible, this should never fail.");
         }

--- a/trace-reader/src/hdf5trace/digitiser.rs
+++ b/trace-reader/src/hdf5trace/digitiser.rs
@@ -1,8 +1,11 @@
-use crate::hdf5trace::{
-    Error,
-    cached_dataset::CachedDataset,
-    channel::{Hdf5AllChannels, Hdf5Channel},
-    extract_from_dataset_name,
+use crate::{
+    OverwriteFields,
+    hdf5trace::{
+        Error,
+        cached_dataset::CachedDataset,
+        channel::{Hdf5AllChannels, Hdf5Channel},
+        extract_from_dataset_name,
+    },
 };
 use chrono::{DateTime, Datelike, Utc};
 use digital_muon_common::{Channel, DigitizerId, FrameNumber};
@@ -261,11 +264,7 @@ impl Hdf5Digitiser {
         fbb: &mut FlatBufferBuilder<'_>,
         index: usize,
         sample_rate: u64,
-        shift_timestamp_date_to_today: bool,
-        overwrite_period_number: Option<u64>,
-        overwrite_veto_flags: Option<u16>,
-        overwrite_protons_per_pulse: Option<u8>,
-        overwrite_running: Option<bool>,
+        overwrite_fields: &OverwriteFields,
     ) -> Result<(), Error> {
         if index >= self.num_frames {
             Err(Error::FrameIndexTooLarge(index, self.num_frames))?;
@@ -288,7 +287,7 @@ impl Hdf5Digitiser {
                     .expect("Index should be in range, this should never fail."),
             ),
         };
-        if shift_timestamp_date_to_today {
+        if overwrite_fields.shift_to_today {
             timestamp = timestamp
                 .with_day(Utc::now().day())
                 .expect("Timestamp with current day should be possible, this should never fail.")
@@ -312,11 +311,13 @@ impl Hdf5Digitiser {
         let gps_time = GpsTime::from(timestamp);
         let metadata: FrameMetadataV2Args = FrameMetadataV2Args {
             frame_number,
-            period_number: overwrite_period_number.unwrap_or(period_number),
-            protons_per_pulse: overwrite_protons_per_pulse.unwrap_or(0),
-            running: overwrite_running.unwrap_or(true),
+            period_number: overwrite_fields
+                .overwrite_period_number
+                .unwrap_or(period_number),
+            protons_per_pulse: overwrite_fields.overwrite_protons_per_pulse.unwrap_or(0),
+            running: overwrite_fields.overwrite_running.unwrap_or(true),
             timestamp: Some(&gps_time),
-            veto_flags: overwrite_veto_flags.unwrap_or(0),
+            veto_flags: overwrite_fields.overwrite_veto_flags.unwrap_or(0),
         };
         let metadata: WIPOffset<FrameMetadataV2> = FrameMetadataV2::create(fbb, &metadata);
 

--- a/trace-reader/src/hdf5trace/digitiser.rs
+++ b/trace-reader/src/hdf5trace/digitiser.rs
@@ -262,6 +262,10 @@ impl Hdf5Digitiser {
         index: usize,
         sample_rate: u64,
         shift_timestamp_date_to_today: bool,
+        overwrite_period_number: Option<u64>,
+        overwrite_veto_flags: Option<u16>,
+        overwrite_protons_per_pulse: Option<u8>,
+        overwrite_running: Option<bool>,
     ) -> Result<(), Error> {
         if index >= self.num_frames {
             Err(Error::FrameIndexTooLarge(index, self.num_frames))?;
@@ -308,11 +312,11 @@ impl Hdf5Digitiser {
         let gps_time = GpsTime::from(timestamp);
         let metadata: FrameMetadataV2Args = FrameMetadataV2Args {
             frame_number,
-            period_number,
-            protons_per_pulse: 0,
-            running: true,
+            period_number: overwrite_period_number.unwrap_or(period_number),
+            protons_per_pulse: overwrite_protons_per_pulse.unwrap_or(0),
+            running: overwrite_running.unwrap_or(true),
             timestamp: Some(&gps_time),
-            veto_flags: 0,
+            veto_flags: overwrite_veto_flags.unwrap_or(0),
         };
         let metadata: WIPOffset<FrameMetadataV2> = FrameMetadataV2::create(fbb, &metadata);
 

--- a/trace-reader/src/hdf5trace/mod.rs
+++ b/trace-reader/src/hdf5trace/mod.rs
@@ -224,7 +224,7 @@ impl DigitiserReader {
     ) -> Result<(), Error> {
         let mut fbb = FlatBufferBuilder::new();
         self.digitiser
-            .create_message(&mut fbb, self.from_index + index, args.sample_rate, args.shift_to_today)?;
+            .create_message(&mut fbb, self.from_index + index, args.sample_rate, args.shift_to_today, args.overwrite_period_number, args.overwrite_veto_flag, args.overwrite_protons_per_pulse, args.overwrite_running)?;
         info_span!("Send").in_scope(|| self.send_record(&mut fbb, trace_topic, key));
         Ok(())
     }
@@ -349,7 +349,7 @@ mod tests {
         // First Message
         assert!(
             digitisers[0]
-                .create_message(&mut fbb, 0, 1_000_000_000, false)
+                .create_message(&mut fbb, 0, 1_000_000_000, false, None, None, None, None)
                 .is_ok()
         );
         let dat_test = root_as_digitizer_analog_trace_message(fbb.unfinished_data()).unwrap();
@@ -398,7 +398,7 @@ mod tests {
         fbb.reset();
         assert!(
             digitisers[0]
-                .create_message(&mut fbb, 1, 1_000_000_000, false)
+                .create_message(&mut fbb, 1, 1_000_000_000, false, None, None, None, None)
                 .is_ok()
         );
         let dat_test = root_as_digitizer_analog_trace_message(fbb.unfinished_data()).unwrap();

--- a/trace-reader/src/hdf5trace/mod.rs
+++ b/trace-reader/src/hdf5trace/mod.rs
@@ -224,7 +224,7 @@ impl DigitiserReader {
     ) -> Result<(), Error> {
         let mut fbb = FlatBufferBuilder::new();
         self.digitiser
-            .create_message(&mut fbb, index, args.sample_rate, args.shift_to_today)?;
+            .create_message(&mut fbb, self.from_index + index, args.sample_rate, args.shift_to_today)?;
         info_span!("Send").in_scope(|| self.send_record(&mut fbb, trace_topic, key));
         Ok(())
     }
@@ -252,6 +252,18 @@ impl DigitiserReader {
         } else {
             ids.contains(&self.digitiser.get_id())
         }
+    }
+
+    /// Given an index, ensure the necessary data is in the cache.
+    /// This should each time before the `create_message` method is used.
+    ///
+    /// This method is idempotent, so does nothing if the required index is already cached.
+    ///
+    /// # Parameters
+    /// - index: the index to ensure is cached.
+    #[tracing::instrument(skip_all)]
+    pub(crate) fn ensure_elements_cached(&mut self, index: usize) {
+        self.digitiser.ensure_elements_cached(self.from_index + index);
     }
 }
 
@@ -285,17 +297,14 @@ async fn read_hdf5_at_index(
         .collect::<Vec<_>>();
 
     spanned_digitisers.iter_mut().for_each(|spanned_digitiser| {
-        let index_on_digitiser = index + spanned_digitiser.from_index;
-        let span = spanned_digitiser
+        spanned_digitiser
             .span()
             .get()
-            .expect("Digitiser has span")
-            .clone();
-        span.in_scope(|| {
-            spanned_digitiser
-                .digitiser
-                .ensure_elements_cached(index_on_digitiser)
-        });
+            .expect("Digitiser has span, this should never fail.")
+            .clone()
+            .in_scope(||
+                spanned_digitiser.ensure_elements_cached(index)
+            );
     });
 
     spanned_digitisers

--- a/trace-reader/src/hdf5trace/mod.rs
+++ b/trace-reader/src/hdf5trace/mod.rs
@@ -14,11 +14,11 @@ use rayon::iter::{IntoParallelRefMutIterator, ParallelIterator};
 use rdkafka::{
     ClientConfig,
     error::KafkaError,
-    producer::{BaseRecord, DefaultProducerContext, ThreadedProducer},
+    producer::{BaseRecord, DefaultProducerContext, Producer, ThreadedProducer}, util::Timeout,
 };
 use std::{fmt::Debug, num::ParseIntError, path::PathBuf, str::FromStr};
 use thiserror::Error;
-use tracing::{debug, info_span};
+use tracing::{debug, error, info_span};
 
 pub(crate) use digitiser::{HDF5Config, Hdf5Digitiser};
 
@@ -250,6 +250,14 @@ impl DigitiserReader {
             true
         } else {
             ids.contains(&self.digitiser.get_id())
+        }
+    }
+}
+
+impl Drop for DigitiserReader {
+    fn drop(&mut self) {
+        if let Err(e) = self.producer.flush(Timeout::Never) {
+            error!("{e}");
         }
     }
 }

--- a/trace-reader/src/hdf5trace/mod.rs
+++ b/trace-reader/src/hdf5trace/mod.rs
@@ -18,7 +18,7 @@ use rdkafka::{
 };
 use std::{fmt::Debug, num::ParseIntError, path::PathBuf, str::FromStr};
 use thiserror::Error;
-use tracing::{debug, error, info_span};
+use tracing::{debug, error, info, info_span};
 
 pub(crate) use digitiser::{HDF5Config, Hdf5Digitiser};
 
@@ -198,6 +198,7 @@ impl DigitiserReader {
                 .and_then(|frame_number| digitiser.get_index_from_frame_number(frame_number))
                 .unwrap_or(digitiser.get_num_frames() - 1),
         );
+        info!("Reader for digitiser {}: from index {from_index} to {to_index}.", digitiser.get_id());
         let producer = client_config.create()?;
         Ok(Self {
             digitiser,

--- a/trace-reader/src/hdf5trace/mod.rs
+++ b/trace-reader/src/hdf5trace/mod.rs
@@ -14,7 +14,8 @@ use rayon::iter::{IntoParallelRefMutIterator, ParallelIterator};
 use rdkafka::{
     ClientConfig,
     error::KafkaError,
-    producer::{BaseRecord, DefaultProducerContext, Producer, ThreadedProducer}, util::Timeout,
+    producer::{BaseRecord, DefaultProducerContext, Producer, ThreadedProducer},
+    util::Timeout,
 };
 use std::{fmt::Debug, num::ParseIntError, path::PathBuf, str::FromStr};
 use thiserror::Error;
@@ -198,7 +199,10 @@ impl DigitiserReader {
                 .and_then(|frame_number| digitiser.get_index_from_frame_number(frame_number))
                 .unwrap_or(digitiser.get_num_frames() - 1),
         );
-        info!("Reader for digitiser {}: from index {from_index} to {to_index}.", digitiser.get_id());
+        info!(
+            "Reader for digitiser {}: from index {from_index} to {to_index}.",
+            digitiser.get_id()
+        );
         let producer = client_config.create()?;
         Ok(Self {
             digitiser,
@@ -223,8 +227,12 @@ impl DigitiserReader {
         index: usize,
     ) -> Result<(), Error> {
         let mut fbb = FlatBufferBuilder::new();
-        self.digitiser
-            .create_message(&mut fbb, self.from_index + index, args.sample_rate, args.shift_to_today, args.overwrite_period_number, args.overwrite_veto_flag, args.overwrite_protons_per_pulse, args.overwrite_running)?;
+        self.digitiser.create_message(
+            &mut fbb,
+            self.from_index + index,
+            args.sample_rate,
+            &args.overwrite_fields,
+        )?;
         info_span!("Send").in_scope(|| self.send_record(&mut fbb, trace_topic, key));
         Ok(())
     }
@@ -263,7 +271,8 @@ impl DigitiserReader {
     /// - index: the index to ensure is cached.
     #[tracing::instrument(skip_all)]
     pub(crate) fn ensure_elements_cached(&mut self, index: usize) {
-        self.digitiser.ensure_elements_cached(self.from_index + index);
+        self.digitiser
+            .ensure_elements_cached(self.from_index + index);
     }
 }
 
@@ -302,9 +311,7 @@ async fn read_hdf5_at_index(
             .get()
             .expect("Digitiser has span, this should never fail.")
             .clone()
-            .in_scope(||
-                spanned_digitiser.ensure_elements_cached(index)
-            );
+            .in_scope(|| spanned_digitiser.ensure_elements_cached(index));
     });
 
     spanned_digitisers
@@ -319,6 +326,8 @@ async fn read_hdf5_at_index(
 
 #[cfg(test)]
 mod tests {
+    use crate::OverwriteFields;
+
     use super::*;
     use digital_muon_streaming_types::dat2_digitizer_analog_trace_v2_generated::root_as_digitizer_analog_trace_message;
     use std::{fs::File, io::Read};
@@ -349,7 +358,7 @@ mod tests {
         // First Message
         assert!(
             digitisers[0]
-                .create_message(&mut fbb, 0, 1_000_000_000, false, None, None, None, None)
+                .create_message(&mut fbb, 0, 1_000_000_000, &OverwriteFields::default())
                 .is_ok()
         );
         let dat_test = root_as_digitizer_analog_trace_message(fbb.unfinished_data()).unwrap();
@@ -398,7 +407,7 @@ mod tests {
         fbb.reset();
         assert!(
             digitisers[0]
-                .create_message(&mut fbb, 1, 1_000_000_000, false, None, None, None, None)
+                .create_message(&mut fbb, 1, 1_000_000_000, &OverwriteFields::default())
                 .is_ok()
         );
         let dat_test = root_as_digitizer_analog_trace_message(fbb.unfinished_data()).unwrap();

--- a/trace-reader/src/main.rs
+++ b/trace-reader/src/main.rs
@@ -3,7 +3,7 @@ mod picoscope;
 
 use crate::{hdf5trace::read_hdf5_file, picoscope::read_picoscope_file};
 use chrono::{DateTime, Utc};
-use clap::{Parser, Subcommand};
+use clap::{Args, Parser, Subcommand};
 use digital_muon_common::{
     CommonKafkaOpts, DigitizerId, FrameNumber, init_tracer,
     tracer::{TracerEngine, TracerOptions},
@@ -25,15 +25,14 @@ struct Cli {
     #[clap(long, default_value = "")]
     otel_namespace: String,
 
-    /// The Kafka topic that trace messages will be produced to
+    /// The Kafka topic that trace messages will be produced to.
     #[clap(long)]
     trace_topic: String,
 
-    /// Relative path to the .trace file to be read
+    /// Relative path to the `.trace` or `.hdf` file to be read.
     #[clap(long)]
     file_name: PathBuf,
 
-    /// Relative path to the .trace file to be read
     #[clap(flatten)]
     run: Run,
 
@@ -45,6 +44,8 @@ struct Cli {
     mode: Mode,
 }
 
+/// If all options are set, then run start and run stop messages are emitted.
+/// FIXME: To implement.
 #[derive(Clone, Parser)]
 struct Run {
     /// The frame number to assign the message
@@ -118,10 +119,6 @@ struct Hdf5 {
     #[clap(short, long, value_delimiter = ',')]
     digitizer_id: Vec<DigitizerId>,
 
-    /// If set, all timestamps are shifted to today's date.
-    #[clap(long)]
-    shift_to_today: bool,
-
     /// If set, load the datasets in chunks of this size, otherwise use the given chunk size in the file.
     #[clap(long)]
     cache_size: Option<usize>,
@@ -130,13 +127,24 @@ struct Hdf5 {
     #[clap(long, default_value = "1000000000")]
     sample_rate: u64,
 
+    #[clap(flatten)]
+    overwrite_fields: OverwriteFields,
+}
+
+/// Encapsulates options that allow the user to overwrite fields in the digitiser messages.
+#[derive(Default, Clone, Args)]
+pub(crate) struct OverwriteFields {
+    /// If set, all timestamps are shifted to today's date.
+    #[clap(long)]
+    shift_to_today: bool,
+
     /// If present, use this value for the period number field in the digitiser messages.
     #[clap(long)]
     overwrite_period_number: Option<u64>,
 
     /// If present, use this value for the veto flags field in the digitiser messages.
     #[clap(long)]
-    overwrite_veto_flag: Option<u16>,
+    overwrite_veto_flags: Option<u16>,
 
     /// If present, use this value for the protons per pulse field in the digitiser messages.
     #[clap(long)]

--- a/trace-reader/src/main.rs
+++ b/trace-reader/src/main.rs
@@ -129,6 +129,22 @@ struct Hdf5 {
     /// If no value is present in the file, the sampling rate to use for the digitiser messages.
     #[clap(long, default_value = "1000000000")]
     sample_rate: u64,
+
+    /// If present, use this value for the period number field in the digitiser messages.
+    #[clap(long)]
+    overwrite_period_number: Option<u64>,
+
+    /// If present, use this value for the veto flags field in the digitiser messages.
+    #[clap(long)]
+    overwrite_veto_flag: Option<u16>,
+
+    /// If present, use this value for the protons per pulse field in the digitiser messages.
+    #[clap(long)]
+    overwrite_protons_per_pulse: Option<u8>,
+
+    /// If present, use this value for the running field in the digitiser messages.
+    #[clap(long)]
+    overwrite_running: Option<bool>,
 }
 
 #[tokio::main]


### PR DESCRIPTION
## Summary of changes

Changes needed for reading the saved trace data.

- Flush unsent messages on exit.
- Fix bug regarding relative indices.
- Fix `shift to today` bug.
- Add options to overwrite certain digitiser message fields.

## Instruction for review/testing

General code review, has been tested in a pipeline.
