### PR TITLE
Events analyser fixes and improvements for testing with recorded trace data

### DIFF
--- a/events-analyser/src/analysis/chart.rs
+++ b/events-analyser/src/analysis/chart.rs
@@ -1,5 +1,5 @@
 use crate::{
-    analysis::metrics::{CompletedMetricResult, MetricOutput},
+    analysis::metrics::{CompletedMetricResult, FittingError, MetricOutput, MetricResultError},
     engine::{FlatChart, FlatSeries},
 };
 use plotly::{
@@ -13,19 +13,19 @@ use thiserror::Error;
 
 #[derive(Debug, Error)]
 pub(crate) enum ChartOutputError {
-    #[error("Json Error {0}")]
+    #[error("Json Error: {0}")]
     Json(#[from] serde_json::error::Error),
-    #[error("IO Error {0}")]
+    #[error("IO Error: {0}")]
     IO(#[from] std::io::Error),
-    #[error("Other Error {0}")]
-    Other(String),
+    #[error("Metric Result Error: {0}")]
+    Metric(#[from] MetricResultError),
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub(crate) struct ChartOutput {
     chart: FlatChart,
-    data: Vec<MetricOutput<Vec<f64>>>,
+    data: Vec<Option<MetricOutput<Vec<f64>>>>,
 }
 
 impl ChartOutput {
@@ -39,10 +39,13 @@ impl ChartOutput {
             .iter()
             .map(|series: &FlatSeries| {
                 let metric = metrics.get(series.metric).expect("This should never fail");
-                metric.get_aggregate_property(series.from_bucket_block, &series.property)
+                match metric.get_aggregate_property(series.from_bucket_block, &series.property) {
+                    Ok(value) => Ok(Some(value)),
+                    Err(MetricResultError::Fitting(FittingError::NoValue)) => Ok(None),
+                    Err(e) => Err(e),
+                }
             })
-            .collect::<Result<Vec<_>, _>>()
-            .map_err(ChartOutputError::Other)?;
+            .collect::<Result<Vec<_>, _>>()?;
         Ok(Self {
             chart: chart.clone(),
             data,
@@ -74,6 +77,37 @@ impl ChartOutput {
         Ok(())
     }
 
+    pub(crate) fn build_trace(
+        &self,
+        series: &FlatSeries,
+        data: Option<&MetricOutput<Vec<f64>>>,
+    ) -> Box<Scatter<f64, f64>> {
+        let line = series.line_colour.iter().fold(
+            series
+                .line_style
+                .iter()
+                .fold(Line::new(), |line, dash| line.dash(dash.into())),
+            |line, colour| line.color(colour.to_string()),
+        );
+
+        match data {
+            Some(MetricOutput::Scalar(data)) => {
+                Scatter::new(self.chart.x_axis.clone(), data.clone())
+                    .line(line)
+                    .name(&series.name)
+            }
+            Some(MetricOutput::ScalarWithBand(value, band)) => {
+                Scatter::new(self.chart.x_axis.clone(), value.clone())
+                    .line(line)
+                    .name(&series.name)
+                    .error_y(ErrorData::new(ErrorType::Data).array(band.clone()))
+            }
+            None => Scatter::new(Default::default(), Default::default())
+                .line(line)
+                .name(format!("{} - values missing.", series.name)),
+        }
+    }
+
     pub(crate) fn build_graph(&self) -> Plot {
         let mut plot: Plot = Plot::new();
         let layout = Layout::new()
@@ -86,28 +120,7 @@ impl ChartOutput {
 
         plot.set_layout(layout);
         for (series, data) in Iterator::zip(self.chart.series.iter(), self.data.iter()) {
-            let line = series.line_colour.iter().fold(
-                series
-                    .line_style
-                    .iter()
-                    .fold(Line::new(), |line, dash| line.dash(dash.into())),
-                |line, colour| line.color(colour.to_string()),
-            );
-            match data {
-                MetricOutput::Scalar(data) => {
-                    let trace = Scatter::new(self.chart.x_axis.clone(), data.clone())
-                        .line(line)
-                        .name(&series.name);
-                    plot.add_trace(trace);
-                }
-                MetricOutput::ScalarWithBand(value, band) => {
-                    let trace = Scatter::new(self.chart.x_axis.clone(), value.clone())
-                        .line(line)
-                        .name(&series.name)
-                        .error_y(ErrorData::new(ErrorType::Data).array(band.clone()));
-                    plot.add_trace(trace);
-                }
-            }
+            plot.add_trace(self.build_trace(series, data.as_ref()));
         }
         plot
     }

--- a/events-analyser/src/analysis/chart.rs
+++ b/events-analyser/src/analysis/chart.rs
@@ -39,7 +39,7 @@ impl ChartOutput {
             .iter()
             .map(|series: &FlatSeries| {
                 let metric = metrics.get(series.metric).expect("This should never fail");
-                metric.get_aggregate_property(series.from_bucket, &series.property)
+                metric.get_aggregate_property(series.from_bucket_block, &series.property)
             })
             .collect::<Result<Vec<_>, _>>()
             .map_err(ChartOutputError::Other)?;

--- a/events-analyser/src/analysis/metrics/event_counts.rs
+++ b/events-analyser/src/analysis/metrics/event_counts.rs
@@ -1,6 +1,7 @@
 use crate::{
     analysis::metrics::{
-        CompleteMetricResultClass, MeanSD, MetricOutput, PartialMetricResultClass, SumWithSumOfSqrs,
+        CompleteMetricResultClass, MeanSD, MetricOutput, MetricResultError,
+        PartialMetricResultClass, SumWithSumOfSqrs,
     },
     engine::{FlatAlgorithm, FlatMetricEventCount, FlatWaveform, MetricProperty},
     eventlists::ChannelDataByTopic,
@@ -49,15 +50,15 @@ pub(crate) struct CompletedEventCount {
 
 impl CompleteMetricResultClass for CompletedEventCount {
     type Partial = EventCount;
-    type Error = ();
+    type Error = MetricResultError;
 
-    fn aggregate(source: &Self::Partial) -> Result<Self, ()> {
+    fn aggregate(source: &Self::Partial) -> Result<Self, MetricResultError> {
         Ok(Self {
             count: source.count.mean_and_stddev(),
         })
     }
 
-    fn get_property(&self, property: &MetricProperty) -> Result<MetricOutput<f64>, String> {
+    fn get_property(&self, property: &MetricProperty) -> Result<MetricOutput<f64>, Self::Error> {
         match property {
             MetricProperty::Mean => Ok(MetricOutput::Scalar(self.count.mean)),
             MetricProperty::SD => Ok(MetricOutput::ScalarWithBand(self.count.mean, self.count.sd)),

--- a/events-analyser/src/analysis/metrics/event_counts.rs
+++ b/events-analyser/src/analysis/metrics/event_counts.rs
@@ -5,6 +5,7 @@ use crate::{
     engine::{FlatAlgorithm, FlatMetricEventCount, FlatWaveform, MetricProperty},
     eventlists::ChannelDataByTopic,
 };
+use digital_muon_common::Channel;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -30,6 +31,7 @@ impl PartialMetricResultClass for EventCount {
         &mut self,
         _waveform: &FlatWaveform,
         _algorithm: &FlatAlgorithm,
+        _: Channel,
         collection_by_topic: &ChannelDataByTopic,
     ) {
         self.num += 1;
@@ -37,10 +39,6 @@ impl PartialMetricResultClass for EventCount {
             .get(self.topic)
             .expect("Topic should exist, this should never fail.");
         self.count.add_to(data.get_time_intensity().len() as f64);
-    }
-
-    fn len(&self) -> usize {
-        self.num
     }
 }
 

--- a/events-analyser/src/analysis/metrics/false_counts.rs
+++ b/events-analyser/src/analysis/metrics/false_counts.rs
@@ -1,7 +1,7 @@
 use crate::{
     analysis::metrics::{
-        CompleteMetricResultClass, MeanSD, MetricOutput, PartialMetricResultClass,
-        SumWithSumOfSqrs, utils::GroupDataBy,
+        CompleteMetricResultClass, MeanSD, MetricOutput, MetricResultError,
+        PartialMetricResultClass, SumWithSumOfSqrs, utils::GroupDataBy,
     },
     engine::{FlatAlgorithm, FlatMetricFalseCount, FlatWaveform, MetricProperty},
     event::ChannelData,
@@ -113,9 +113,9 @@ pub(crate) struct CompletedFalseCount {
 
 impl CompleteMetricResultClass for CompletedFalseCount {
     type Partial = FalseCount;
-    type Error = ();
+    type Error = MetricResultError;
 
-    fn aggregate(source: &Self::Partial) -> Result<Self, ()> {
+    fn aggregate(source: &Self::Partial) -> Result<Self, MetricResultError> {
         Ok(Self {
             true_positives: source.true_positive_sum.mean_and_stddev(),
             ambiguous_true_positives: source.ambiguous_true_positive_sum.mean_and_stddev(),
@@ -124,7 +124,7 @@ impl CompleteMetricResultClass for CompletedFalseCount {
         })
     }
 
-    fn get_property(&self, property: &MetricProperty) -> Result<MetricOutput<f64>, String> {
+    fn get_property(&self, property: &MetricProperty) -> Result<MetricOutput<f64>, Self::Error> {
         match property {
             MetricProperty::FalsePositivesMean => {
                 Ok(MetricOutput::Scalar(self.false_positives.mean))

--- a/events-analyser/src/analysis/metrics/false_counts.rs
+++ b/events-analyser/src/analysis/metrics/false_counts.rs
@@ -7,6 +7,7 @@ use crate::{
     event::ChannelData,
     eventlists::ChannelDataByTopic,
 };
+use digital_muon_common::Channel;
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -44,6 +45,7 @@ impl PartialMetricResultClass for FalseCount {
         &mut self,
         waveform: &FlatWaveform,
         algorithm: &FlatAlgorithm,
+        _: Channel,
         by_topic: &ChannelDataByTopic,
     ) {
         // true_by_estimates is indexed by the detected events, and the corresponding element is the list of true events that have been associated to it
@@ -69,10 +71,6 @@ impl PartialMetricResultClass for FalseCount {
         self.true_positive_sum.add_to(true_positives as f64);
         self.false_positive_sum.add_to(false_positives as f64);
         self.false_negative_sum.add_to(false_negatives as f64);
-    }
-
-    fn len(&self) -> usize {
-        self.num
     }
 }
 

--- a/events-analyser/src/analysis/metrics/mod.rs
+++ b/events-analyser/src/analysis/metrics/mod.rs
@@ -27,8 +27,6 @@ pub(crate) use utils::Histogram;
 
 #[derive(Debug, Error)]
 pub(crate) enum FittingError {
-    #[error("No Data")]
-    NoData,
     #[error("{0}")]
     ModelBuild(#[from] ModelBuildError),
     #[error("{0}")]

--- a/events-analyser/src/analysis/metrics/mod.rs
+++ b/events-analyser/src/analysis/metrics/mod.rs
@@ -9,6 +9,7 @@ use crate::{
     engine::{FlatAlgorithm, FlatWaveform, MetricProperty},
     eventlists::ChannelDataByTopic,
 };
+use digital_muon_common::Channel;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use thiserror::Error;
 use varpro::{
@@ -26,6 +27,8 @@ pub(crate) use utils::Histogram;
 
 #[derive(Debug, Error)]
 pub(crate) enum FittingError {
+    #[error("No Data")]
+    NoData,
     #[error("{0}")]
     ModelBuild(#[from] ModelBuildError),
     #[error("{0}")]
@@ -87,9 +90,9 @@ pub(crate) trait PartialMetricResultClass: MetricResultClass {
         &mut self,
         waveform: &FlatWaveform,
         algorithm: &FlatAlgorithm,
+        channel: Channel,
         by_topic: &ChannelDataByTopic,
     );
-    fn len(&self) -> usize;
 }
 
 pub(crate) trait CompleteMetricResultClass: MetricResultClass {

--- a/events-analyser/src/analysis/metrics/mod.rs
+++ b/events-analyser/src/analysis/metrics/mod.rs
@@ -33,8 +33,10 @@ pub(crate) enum FittingError {
     SeparableProblemBuilder(#[from] SeparableProblemBuilderError),
     #[error("{0:?}")]
     FitResult(Box<FitResult<SeparableModel<f64>, SingleRhs>>),
-    #[error("Not enough linear coefficients: {0}")]
-    NotEnoughCoefs(String),
+    #[error("Lifetime parameter unavailable.")]
+    LifetimeParameterUnavailable,
+    #[error("Lifetime variance unavailable")]
+    VarianceParameterUnavailable,
     #[error("Statistics Error {0}")]
     Statistics(#[from] StatisticsError<<SeparableModel<f64> as SeparableNonlinearModel>::Error>),
     #[error("Infinite Variance")]

--- a/events-analyser/src/analysis/metrics/mod.rs
+++ b/events-analyser/src/analysis/metrics/mod.rs
@@ -37,6 +37,8 @@ pub(crate) enum FittingError {
     NotEnoughCoefs(String),
     #[error("Statistics Error {0}")]
     Statistics(#[from] StatisticsError<<SeparableModel<f64> as SeparableNonlinearModel>::Error>),
+    #[error("Infinite Variance")]
+    InfiniteVariance,
 }
 
 /// Holds the running sum of a sequence, as well as the sum of squares.

--- a/events-analyser/src/analysis/metrics/mod.rs
+++ b/events-analyser/src/analysis/metrics/mod.rs
@@ -39,8 +39,8 @@ pub(crate) enum FittingError {
     VarianceParameterUnavailable,
     #[error("Statistics Error {0}")]
     Statistics(#[from] StatisticsError<<SeparableModel<f64> as SeparableNonlinearModel>::Error>),
-    #[error("Infinite Variance")]
-    InfiniteVariance,
+    #[error("No Value Present.")]
+    NoValue,
 }
 
 /// Holds the running sum of a sequence, as well as the sum of squares.
@@ -102,5 +102,5 @@ pub(crate) trait CompleteMetricResultClass: MetricResultClass {
     type Error: Into<MetricResultError>;
 
     fn aggregate(source: &Self::Partial) -> Result<Self, Self::Error>;
-    fn get_property(&self, property: &MetricProperty) -> Result<MetricOutput<f64>, String>;
+    fn get_property(&self, property: &MetricProperty) -> Result<MetricOutput<f64>, Self::Error>;
 }

--- a/events-analyser/src/analysis/metrics/muon_lifetime.rs
+++ b/events-analyser/src/analysis/metrics/muon_lifetime.rs
@@ -51,7 +51,7 @@ impl PartialMetricResultClass for MuonLifetime {
         let histogram = self.histograms
             .entry(channel)
             .or_insert_with(||
-                Histogram::new(self.source.num_bins, self.source.max_lifetime)
+                Histogram::new(self.source.num_bins, &self.source.interval)
         );
         
         for (time, _) in by_topic
@@ -161,7 +161,6 @@ impl CompleteMetricResultClass for CompletedMuonLifetime {
             .values()
             .map(Self::extract_lifetime)
             .collect::<Result<Vec<_>,Self::Error>>()?;
-
         let mean = channel_results.iter()
             .map(|(lifetime, _)|lifetime)
             .sum::<f64>()
@@ -193,29 +192,30 @@ impl CompleteMetricResultClass for CompletedMuonLifetime {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::analysis::metrics::Histogram;
+    use crate::{analysis::metrics::Histogram, engine::Interval};
 
     #[test]
     fn test1() {
         let histogram_counts = [
             17488.0, 4856.0, 1410.0, 554.0, 333.0, 250.0, 225.0, 225.0, 250.0, 237.0,
         ];
-        let mut histogram = Histogram::new(10, 30000.0);
+        let interval = Interval { min: 0.0, max: 30000.0 };
+        let mut histogram = Histogram::new(10, &interval);
         histogram.set(histogram_counts.to_vec());
 
         let source = MuonLifetime {
             source: FlatMetricMuonLifetime {
                 topic: 1,
                 num_bins: 10,
-                max_lifetime: 30000.0,
+                interval,
             },
             histograms: vec![(0,histogram)].into_iter().collect(),
         };
         let result = CompletedMuonLifetime::aggregate(&source);
         assert!(result.is_ok());
         let result = result.unwrap();
-        assert_eq!(result.lifetime.mean, 2269.633905394806);
-        assert_eq!(result.lifetime.sd, 8.573260580312361);
+        assert_eq!(result.lifetime.mean, 2269.633905415749);
+        assert_eq!(result.lifetime.sd, 8.573260580353312);
     }
 
     #[test]
@@ -223,21 +223,22 @@ mod tests {
         let histogram_counts = [
             7309.0, 2001.0, 542.0, 220.0, 76.0, 74.0, 43.0, 49.0, 47.0, 62.0,
         ];
-        let mut histogram = Histogram::new(10, 30000.0);
+        let interval = Interval { min: 0.0, max: 30000.0 };
+        let mut histogram = Histogram::new(10, &interval);
         histogram.set(histogram_counts.to_vec());
 
         let source = MuonLifetime {
             source: FlatMetricMuonLifetime {
                 topic: 1,
                 num_bins: 10,
-                max_lifetime: 30000.0,
+                interval,
             },
             histograms: vec![(0,histogram)].into_iter().collect(),
         };
         let result = CompletedMuonLifetime::aggregate(&source);
         assert!(result.is_ok());
         let result = result.unwrap();
-        assert_eq!(result.lifetime.mean, 2273.4931383121334);
-        assert_eq!(result.lifetime.sd, 16.381103858413592);
+        assert_eq!(result.lifetime.mean, 2273.493136014635);
+        assert_eq!(result.lifetime.sd, 16.381103849818405);
     }
 }

--- a/events-analyser/src/analysis/metrics/muon_lifetime.rs
+++ b/events-analyser/src/analysis/metrics/muon_lifetime.rs
@@ -2,7 +2,7 @@
 //!
 //! This calculates the estimated lifetime of the muon decay process that results in the given event list times.
 //! The times are placed in a histogram which is then used to fit an exponential decay function.
-use std::collections::HashMap;
+use std::{collections::HashMap, ops::Div};
 
 use crate::{
     analysis::metrics::{
@@ -15,7 +15,6 @@ use crate::{
 use digital_muon_common::Channel;
 use nalgebra::DVector;
 use serde::{Deserialize, Serialize};
-use tracing::warn;
 use varpro::{
     prelude::SeparableModelBuilder, problem::SeparableProblemBuilder,
     solvers::levmar::LevMarSolver, statistics::FitStatistics,
@@ -109,6 +108,50 @@ fn invariant_function(x: &DVector<f64>) -> DVector<f64> {
     DVector::from_element(x.len(), 1.)
 }
 
+impl CompletedMuonLifetime {
+    fn extract_lifetime(histogram: &Histogram) -> Result<(f64, f64), <Self as CompleteMetricResultClass>::Error> {
+        // Begin the fitting with the true muon lifetime.
+        let initial_guess = vec![2_200.0];
+        // The x-axis of the histogram.
+        let independent_variables = DVector::from_vec(histogram.get_bin_labels().to_vec());
+
+        let model = SeparableModelBuilder::new(["tau"])
+            .independent_variable(independent_variables)
+            .function(["tau"], exp_decay_function)
+            .partial_deriv("tau", exp_decay_deriv_wrs_tau)
+            .invariant_function(invariant_function)
+            .initial_parameters(initial_guess)
+            .build()?;
+
+        // The y-axis of the histogram.
+        let observations = DVector::from_vec(histogram.get_normalised_counts());
+        let problem = SeparableProblemBuilder::new(model)
+            .observations(observations)
+            .build()?;
+
+        // fit the data.
+        let fit_result = LevMarSolver::default()
+            .solve(problem)
+            .map_err(|result| FittingError::FitResult(Box::new(result)))?;
+        let coefs = fit_result.nonlinear_parameters();
+
+        let coef_error = || {
+            FittingError::NotEnoughCoefs(format!("{0:?}", coefs.into_iter().collect::<Vec<_>>()))
+        };
+
+        // Extract the lifetime parameter.
+        let lifetime = *coefs.get(0).ok_or_else(coef_error)?;
+
+        // Extract the standard deviation for the lifetime parameters.
+        let sd = FitStatistics::try_from(&fit_result)?
+            .nonlinear_parameters_variance()
+            .get(0)
+            .ok_or_else(coef_error)?
+            .sqrt();
+        Ok((lifetime, sd))
+    }
+}
+
 impl CompleteMetricResultClass for CompletedMuonLifetime {
     type Partial = MuonLifetime;
     type Error = FittingError;
@@ -116,55 +159,13 @@ impl CompleteMetricResultClass for CompletedMuonLifetime {
     fn aggregate(source: &Self::Partial) -> Result<Self, Self::Error> {
         let channel_results = source.histograms
             .values()
-            .map(|histogram| {
-                if histogram.get_num_values() == 0 {
-                    warn!("Found null bucket");
-                    return Err(FittingError::NoData);
-                }
-
-                // Begin the fitting with the true muon lifetime.
-                let initial_guess = vec![2_200.0];
-                // The x-axis of the histogram.
-                let independent_variables = DVector::from_vec(histogram.get_bin_labels().to_vec());
-
-                let model = SeparableModelBuilder::new(["tau"])
-                    .independent_variable(independent_variables)
-                    .function(["tau"], exp_decay_function)
-                    .partial_deriv("tau", exp_decay_deriv_wrs_tau)
-                    .invariant_function(invariant_function)
-                    .initial_parameters(initial_guess)
-                    .build()?;
-
-                // The y-axis of the histogram.
-                let observations = DVector::from_vec(histogram.get_counts().to_vec());
-                let problem = SeparableProblemBuilder::new(model)
-                    .observations(observations)
-                    .build()?;
-
-                // fit the data.
-                let fit_result = LevMarSolver::default()
-                    .solve(problem)
-                    .map_err(|result| FittingError::FitResult(Box::new(result)))?;
-                let coefs = fit_result.nonlinear_parameters();
-
-                let coef_error = || {
-                    FittingError::NotEnoughCoefs(format!("{0:?}", coefs.into_iter().collect::<Vec<_>>()))
-                };
-
-                // Extract the lifetime parameter.
-                let lifetime = *coefs.get(0).ok_or_else(coef_error)?;
-
-                // Extract the standard deviation for the lifetime parameters.
-                let sd = FitStatistics::try_from(&fit_result)?
-                    .nonlinear_parameters_variance()
-                    .get(0)
-                    .ok_or_else(coef_error)?
-                    .sqrt();
-                Ok((lifetime, sd))
-            })
+            .map(Self::extract_lifetime)
             .collect::<Result<Vec<_>,Self::Error>>()?;
 
-        let mean = channel_results.iter().map(|(lifetime, _)|lifetime).sum::<f64>()/channel_results.len() as f64;
+        let mean = channel_results.iter()
+            .map(|(lifetime, _)|lifetime)
+            .sum::<f64>()
+            .div(channel_results.len() as f64);
         let sd = *channel_results.iter()
             .map(|(_, sd)|sd)
             .max_by(|a,b|

--- a/events-analyser/src/analysis/metrics/muon_lifetime.rs
+++ b/events-analyser/src/analysis/metrics/muon_lifetime.rs
@@ -48,12 +48,11 @@ impl PartialMetricResultClass for MuonLifetime {
         channel: Channel,
         by_topic: &ChannelDataByTopic,
     ) {
-        let histogram = self.histograms
+        let histogram = self
+            .histograms
             .entry(channel)
-            .or_insert_with(||
-                Histogram::new(self.source.num_bins, &self.source.interval)
-        );
-        
+            .or_insert_with(|| Histogram::new(self.source.num_bins, &self.source.interval));
+
         for (time, _) in by_topic
             .get(self.source.topic)
             .expect("Topic should exist, this should never fail.")
@@ -109,7 +108,9 @@ fn invariant_function(x: &DVector<f64>) -> DVector<f64> {
 }
 
 impl CompletedMuonLifetime {
-    fn extract_lifetime(histogram: &Histogram) -> Result<(f64, f64), <Self as CompleteMetricResultClass>::Error> {
+    fn extract_lifetime(
+        histogram: &Histogram,
+    ) -> Result<(f64, f64), <Self as CompleteMetricResultClass>::Error> {
         // Begin the fitting with the true muon lifetime.
         let initial_guess = vec![2_200.0];
         // The x-axis of the histogram.
@@ -157,19 +158,20 @@ impl CompleteMetricResultClass for CompletedMuonLifetime {
     type Error = FittingError;
 
     fn aggregate(source: &Self::Partial) -> Result<Self, Self::Error> {
-        let channel_results = source.histograms
+        let channel_results = source
+            .histograms
             .values()
             .map(Self::extract_lifetime)
-            .collect::<Result<Vec<_>,Self::Error>>()?;
-        let mean = channel_results.iter()
-            .map(|(lifetime, _)|lifetime)
+            .collect::<Result<Vec<_>, Self::Error>>()?;
+        let mean = channel_results
+            .iter()
+            .map(|(lifetime, _)| lifetime)
             .sum::<f64>()
             .div(channel_results.len() as f64);
-        let sd = *channel_results.iter()
-            .map(|(_, sd)|sd)
-            .max_by(|a,b|
-                f64::partial_cmp(a,b).expect("This should never fail.")
-            )
+        let sd = *channel_results
+            .iter()
+            .map(|(_, sd)| sd)
+            .max_by(|a, b| f64::partial_cmp(a, b).expect("This should never fail."))
             .expect("This should never fail.");
 
         Ok(Self {
@@ -199,7 +201,10 @@ mod tests {
         let histogram_counts = [
             17488.0, 4856.0, 1410.0, 554.0, 333.0, 250.0, 225.0, 225.0, 250.0, 237.0,
         ];
-        let interval = Interval { min: 0.0, max: 30000.0 };
+        let interval = Interval {
+            min: 0.0,
+            max: 30000.0,
+        };
         let mut histogram = Histogram::new(10, &interval);
         histogram.set(histogram_counts.to_vec());
 
@@ -209,7 +214,7 @@ mod tests {
                 num_bins: 10,
                 interval,
             },
-            histograms: vec![(0,histogram)].into_iter().collect(),
+            histograms: vec![(0, histogram)].into_iter().collect(),
         };
         let result = CompletedMuonLifetime::aggregate(&source);
         assert!(result.is_ok());
@@ -223,7 +228,10 @@ mod tests {
         let histogram_counts = [
             7309.0, 2001.0, 542.0, 220.0, 76.0, 74.0, 43.0, 49.0, 47.0, 62.0,
         ];
-        let interval = Interval { min: 0.0, max: 30000.0 };
+        let interval = Interval {
+            min: 0.0,
+            max: 30000.0,
+        };
         let mut histogram = Histogram::new(10, &interval);
         histogram.set(histogram_counts.to_vec());
 
@@ -233,7 +241,7 @@ mod tests {
                 num_bins: 10,
                 interval,
             },
-            histograms: vec![(0,histogram)].into_iter().collect(),
+            histograms: vec![(0, histogram)].into_iter().collect(),
         };
         let result = CompletedMuonLifetime::aggregate(&source);
         assert!(result.is_ok());

--- a/events-analyser/src/analysis/metrics/muon_lifetime.rs
+++ b/events-analyser/src/analysis/metrics/muon_lifetime.rs
@@ -53,7 +53,6 @@ impl PartialMetricResultClass for MuonLifetime {
             .expect("Topic should exist, this should never fail.")
             .get_time_intensity()
         {
-            //histogram.push(*time as f64);
             self.histogram.push(*time as f64);
         }
     }

--- a/events-analyser/src/analysis/metrics/muon_lifetime.rs
+++ b/events-analyser/src/analysis/metrics/muon_lifetime.rs
@@ -69,7 +69,7 @@ impl PartialMetricResultClass for MuonLifetime {
 /// Note we are only interested in the `tau` parameter.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct CompletedMuonLifetime {
-    lifetime: MeanSD,
+    lifetime: Option<MeanSD>,
 }
 
 /// The exponential decay function used in the fitting model.
@@ -142,7 +142,7 @@ impl CompleteMetricResultClass for CompletedMuonLifetime {
         // Validate lifetime parameter.
         if !lifetime.is_finite() {
             warn!("Infinite lifetime found");
-            return Err(FittingError::InfiniteVariance);
+            return Ok(Self { lifetime: None });
         }
 
         // Extract the standard deviation for the lifetime parameters.
@@ -155,20 +155,22 @@ impl CompleteMetricResultClass for CompletedMuonLifetime {
         // Validate lifetime standard deviation.
         if !sd.is_finite() {
             warn!("Infinite variance found");
-            return Err(FittingError::InfiniteVariance);
+            return Ok(Self { lifetime: None });
         }
 
         Ok(Self {
-            lifetime: MeanSD { mean: lifetime, sd },
+            lifetime: Some(MeanSD { mean: lifetime, sd }),
         })
     }
 
-    fn get_property(&self, property: &MetricProperty) -> Result<MetricOutput<f64>, String> {
+    fn get_property(&self, property: &MetricProperty) -> Result<MetricOutput<f64>, Self::Error> {
         match property {
-            MetricProperty::Mean => Ok(MetricOutput::Scalar(self.lifetime.mean)),
+            MetricProperty::Mean => Ok(MetricOutput::Scalar(
+                self.lifetime.as_ref().ok_or(FittingError::NoValue)?.mean,
+            )),
             MetricProperty::SD => Ok(MetricOutput::ScalarWithBand(
-                self.lifetime.mean,
-                self.lifetime.sd,
+                self.lifetime.as_ref().ok_or(FittingError::NoValue)?.mean,
+                self.lifetime.as_ref().ok_or(FittingError::NoValue)?.sd,
             )),
             _ => unreachable!(),
         }
@@ -203,8 +205,8 @@ mod tests {
         let result = CompletedMuonLifetime::aggregate(&source);
         assert!(result.is_ok());
         let result = result.unwrap();
-        assert_eq!(result.lifetime.mean, 2269.633905415749);
-        assert_eq!(result.lifetime.sd, 8.573260580353312);
+        assert_eq!(result.lifetime.as_ref().unwrap().mean, 2269.633905415749);
+        assert_eq!(result.lifetime.as_ref().unwrap().sd, 8.573260580353312);
     }
 
     #[test]
@@ -230,7 +232,7 @@ mod tests {
         let result = CompletedMuonLifetime::aggregate(&source);
         assert!(result.is_ok());
         let result = result.unwrap();
-        assert_eq!(result.lifetime.mean, 2273.493136014635);
-        assert_eq!(result.lifetime.sd, 16.381103849818405);
+        assert_eq!(result.lifetime.as_ref().unwrap().mean, 2273.493136014635);
+        assert_eq!(result.lifetime.as_ref().unwrap().sd, 16.381103849818405);
     }
 }

--- a/events-analyser/src/analysis/metrics/muon_lifetime.rs
+++ b/events-analyser/src/analysis/metrics/muon_lifetime.rs
@@ -198,8 +198,7 @@ mod tests {
                 num_bins: 10,
                 interval,
             },
-            //histograms: vec![(0, histogram.clone())].into_iter().collect(),
-            histogram: histogram,
+            histogram,
         };
         let result = CompletedMuonLifetime::aggregate(&source);
         assert!(result.is_ok());
@@ -226,8 +225,7 @@ mod tests {
                 num_bins: 10,
                 interval,
             },
-            //histograms: vec![(0, histogram.clone())].into_iter().collect(),
-            histogram: histogram,
+            histogram,
         };
         let result = CompletedMuonLifetime::aggregate(&source);
         assert!(result.is_ok());

--- a/events-analyser/src/analysis/metrics/muon_lifetime.rs
+++ b/events-analyser/src/analysis/metrics/muon_lifetime.rs
@@ -2,6 +2,8 @@
 //!
 //! This calculates the estimated lifetime of the muon decay process that results in the given event list times.
 //! The times are placed in a histogram which is then used to fit an exponential decay function.
+use std::collections::HashMap;
+
 use crate::{
     analysis::metrics::{
         CompleteMetricResultClass, FittingError, MeanSD, MetricOutput, PartialMetricResultClass,
@@ -10,6 +12,7 @@ use crate::{
     engine::{FlatAlgorithm, FlatMetricMuonLifetime, FlatWaveform, MetricProperty},
     eventlists::ChannelDataByTopic,
 };
+use digital_muon_common::Channel;
 use nalgebra::DVector;
 use serde::{Deserialize, Serialize};
 use tracing::warn;
@@ -24,9 +27,8 @@ use varpro::{
 /// an exponential decay curve by [CompletedMuonLifetime].
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct MuonLifetime {
-    num: usize,
-    topic: usize,
-    histogram: Histogram,
+    source: FlatMetricMuonLifetime,
+    histograms: HashMap<Channel, Histogram>,
 }
 
 impl PartialMetricResultClass for MuonLifetime {
@@ -35,9 +37,8 @@ impl PartialMetricResultClass for MuonLifetime {
 
     fn make_default(source: &FlatMetricMuonLifetime) -> Self {
         Self {
-            num: Default::default(),
-            topic: source.topic,
-            histogram: Histogram::new(source.num_bins, source.max_lifetime),
+            source: source.clone(),
+            histograms: Default::default(),
         }
     }
 
@@ -45,20 +46,22 @@ impl PartialMetricResultClass for MuonLifetime {
         &mut self,
         _waveform: &FlatWaveform,
         _algorithm: &FlatAlgorithm,
+        channel: Channel,
         by_topic: &ChannelDataByTopic,
     ) {
-        self.num += 1;
+        let histogram = self.histograms
+            .entry(channel)
+            .or_insert_with(||
+                Histogram::new(self.source.num_bins, self.source.max_lifetime)
+        );
+        
         for (time, _) in by_topic
-            .get(self.topic)
-            .expect("This should never fail.")
+            .get(self.source.topic)
+            .expect("Topic should exist, this should never fail.")
             .get_time_intensity()
         {
-            self.histogram.push(*time as f64);
+            histogram.push(*time as f64);
         }
-    }
-
-    fn len(&self) -> usize {
-        self.num
     }
 }
 
@@ -111,54 +114,66 @@ impl CompleteMetricResultClass for CompletedMuonLifetime {
     type Error = FittingError;
 
     fn aggregate(source: &Self::Partial) -> Result<Self, Self::Error> {
-        if source.num == 0 {
-            warn!("Found null bucket");
-            return Ok(Self {
-                lifetime: MeanSD { mean: 0.0, sd: 0.0 },
-            });
-        }
+        let channel_results = source.histograms
+            .values()
+            .map(|histogram| {
+                if histogram.get_num_values() == 0 {
+                    warn!("Found null bucket");
+                    return Err(FittingError::NoData);
+                }
 
-        // Begin the fitting with the true muon lifetime.
-        let initial_guess = vec![2_200.0];
-        // The x-axis of the histogram.
-        let independent_variables = DVector::from_vec(source.histogram.get_bin_labels().to_vec());
+                // Begin the fitting with the true muon lifetime.
+                let initial_guess = vec![2_200.0];
+                // The x-axis of the histogram.
+                let independent_variables = DVector::from_vec(histogram.get_bin_labels().to_vec());
 
-        let model = SeparableModelBuilder::new(["tau"])
-            .independent_variable(independent_variables)
-            .function(["tau"], exp_decay_function)
-            .partial_deriv("tau", exp_decay_deriv_wrs_tau)
-            .invariant_function(invariant_function)
-            .initial_parameters(initial_guess)
-            .build()?;
+                let model = SeparableModelBuilder::new(["tau"])
+                    .independent_variable(independent_variables)
+                    .function(["tau"], exp_decay_function)
+                    .partial_deriv("tau", exp_decay_deriv_wrs_tau)
+                    .invariant_function(invariant_function)
+                    .initial_parameters(initial_guess)
+                    .build()?;
 
-        // The y-axis of the histogram.
-        let observations = DVector::from_vec(source.histogram.get_counts().to_vec());
-        let problem = SeparableProblemBuilder::new(model)
-            .observations(observations)
-            .build()?;
+                // The y-axis of the histogram.
+                let observations = DVector::from_vec(histogram.get_counts().to_vec());
+                let problem = SeparableProblemBuilder::new(model)
+                    .observations(observations)
+                    .build()?;
 
-        // fit the data.
-        let fit_result = LevMarSolver::default()
-            .solve(problem)
-            .map_err(|result| FittingError::FitResult(Box::new(result)))?;
-        let coefs = fit_result.nonlinear_parameters();
+                // fit the data.
+                let fit_result = LevMarSolver::default()
+                    .solve(problem)
+                    .map_err(|result| FittingError::FitResult(Box::new(result)))?;
+                let coefs = fit_result.nonlinear_parameters();
 
-        let coef_error = || {
-            FittingError::NotEnoughCoefs(format!("{0:?}", coefs.into_iter().collect::<Vec<_>>()))
-        };
+                let coef_error = || {
+                    FittingError::NotEnoughCoefs(format!("{0:?}", coefs.into_iter().collect::<Vec<_>>()))
+                };
 
-        // Extract the lifetime parameter.
-        let lifetime = *coefs.get(0).ok_or_else(coef_error)?;
+                // Extract the lifetime parameter.
+                let lifetime = *coefs.get(0).ok_or_else(coef_error)?;
 
-        // Extract the standard deviation for the lifetime parameters.
-        let sd = FitStatistics::try_from(&fit_result)?
-            .nonlinear_parameters_variance()
-            .get(0)
-            .ok_or_else(coef_error)?
-            .sqrt();
+                // Extract the standard deviation for the lifetime parameters.
+                let sd = FitStatistics::try_from(&fit_result)?
+                    .nonlinear_parameters_variance()
+                    .get(0)
+                    .ok_or_else(coef_error)?
+                    .sqrt();
+                Ok((lifetime, sd))
+            })
+            .collect::<Result<Vec<_>,Self::Error>>()?;
+
+        let mean = channel_results.iter().map(|(lifetime, _)|lifetime).sum::<f64>()/channel_results.len() as f64;
+        let sd = *channel_results.iter()
+            .map(|(_, sd)|sd)
+            .max_by(|a,b|
+                f64::partial_cmp(a,b).expect("This should never fail.")
+            )
+            .expect("This should never fail.");
 
         Ok(Self {
-            lifetime: MeanSD { mean: lifetime, sd },
+            lifetime: MeanSD { mean, sd },
         })
     }
 
@@ -188,9 +203,12 @@ mod tests {
         histogram.set(histogram_counts.to_vec());
 
         let source = MuonLifetime {
-            num: 1024,
-            topic: 1,
-            histogram,
+            source: FlatMetricMuonLifetime {
+                topic: 1,
+                num_bins: 10,
+                max_lifetime: 30000.0,
+            },
+            histograms: vec![(0,histogram)].into_iter().collect(),
         };
         let result = CompletedMuonLifetime::aggregate(&source);
         assert!(result.is_ok());
@@ -208,9 +226,12 @@ mod tests {
         histogram.set(histogram_counts.to_vec());
 
         let source = MuonLifetime {
-            num: 1024,
-            topic: 1,
-            histogram,
+            source: FlatMetricMuonLifetime {
+                topic: 1,
+                num_bins: 10,
+                max_lifetime: 30000.0,
+            },
+            histograms: vec![(0,histogram)].into_iter().collect(),
         };
         let result = CompletedMuonLifetime::aggregate(&source);
         assert!(result.is_ok());

--- a/events-analyser/src/analysis/metrics/muon_lifetime.rs
+++ b/events-analyser/src/analysis/metrics/muon_lifetime.rs
@@ -2,8 +2,7 @@
 //!
 //! This calculates the estimated lifetime of the muon decay process that results in the given event list times.
 //! The times are placed in a histogram which is then used to fit an exponential decay function.
-use std::{collections::HashMap, ops::Div};
-
+// use std::{collections::HashMap, ops::Div};
 use crate::{
     analysis::metrics::{
         CompleteMetricResultClass, FittingError, MeanSD, MetricOutput, PartialMetricResultClass,
@@ -15,6 +14,7 @@ use crate::{
 use digital_muon_common::Channel;
 use nalgebra::DVector;
 use serde::{Deserialize, Serialize};
+use tracing::warn;
 use varpro::{
     prelude::SeparableModelBuilder, problem::SeparableProblemBuilder,
     solvers::levmar::LevMarSolver, statistics::FitStatistics,
@@ -27,7 +27,7 @@ use varpro::{
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct MuonLifetime {
     source: FlatMetricMuonLifetime,
-    histograms: HashMap<Channel, Histogram>,
+    histogram: Histogram,
 }
 
 impl PartialMetricResultClass for MuonLifetime {
@@ -37,7 +37,7 @@ impl PartialMetricResultClass for MuonLifetime {
     fn make_default(source: &FlatMetricMuonLifetime) -> Self {
         Self {
             source: source.clone(),
-            histograms: Default::default(),
+            histogram: Histogram::new(source.num_bins, &source.interval),
         }
     }
 
@@ -45,20 +45,16 @@ impl PartialMetricResultClass for MuonLifetime {
         &mut self,
         _waveform: &FlatWaveform,
         _algorithm: &FlatAlgorithm,
-        channel: Channel,
+        _channel: Channel,
         by_topic: &ChannelDataByTopic,
     ) {
-        let histogram = self
-            .histograms
-            .entry(channel)
-            .or_insert_with(|| Histogram::new(self.source.num_bins, &self.source.interval));
-
         for (time, _) in by_topic
             .get(self.source.topic)
             .expect("Topic should exist, this should never fail.")
             .get_time_intensity()
         {
-            histogram.push(*time as f64);
+            //histogram.push(*time as f64);
+            self.histogram.push(*time as f64);
         }
     }
 }
@@ -107,15 +103,17 @@ fn invariant_function(x: &DVector<f64>) -> DVector<f64> {
     DVector::from_element(x.len(), 1.)
 }
 
-impl CompletedMuonLifetime {
-    fn extract_lifetime(
-        histogram: &Histogram,
-    ) -> Result<(f64, f64), <Self as CompleteMetricResultClass>::Error> {
+impl CompleteMetricResultClass for CompletedMuonLifetime {
+    type Partial = MuonLifetime;
+    type Error = FittingError;
+
+    fn aggregate(source: &Self::Partial) -> Result<Self, Self::Error> {
         // Begin the fitting with the true muon lifetime.
         let initial_guess = vec![2_200.0];
         // The x-axis of the histogram.
-        let independent_variables = DVector::from_vec(histogram.get_bin_labels().to_vec());
+        let independent_variables = DVector::from_vec(source.histogram.get_bin_labels().to_vec());
 
+        // Set up the exponential decay model.
         let model = SeparableModelBuilder::new(["tau"])
             .independent_variable(independent_variables)
             .function(["tau"], exp_decay_function)
@@ -125,7 +123,7 @@ impl CompletedMuonLifetime {
             .build()?;
 
         // The y-axis of the histogram.
-        let observations = DVector::from_vec(histogram.get_normalised_counts());
+        let observations = DVector::from_vec(source.histogram.get_normalised_counts());
         let problem = SeparableProblemBuilder::new(model)
             .observations(observations)
             .build()?;
@@ -136,46 +134,32 @@ impl CompletedMuonLifetime {
             .map_err(|result| FittingError::FitResult(Box::new(result)))?;
         let coefs = fit_result.nonlinear_parameters();
 
-        let coef_error = || {
-            FittingError::NotEnoughCoefs(format!("{0:?}", coefs.into_iter().collect::<Vec<_>>()))
-        };
-
         // Extract the lifetime parameter.
-        let lifetime = *coefs.get(0).ok_or_else(coef_error)?;
+        let lifetime = *coefs
+            .get(0)
+            .ok_or(FittingError::LifetimeParameterUnavailable)?;
+
+        // Validate lifetime parameter.
+        if !lifetime.is_finite() {
+            warn!("Infinite lifetime found");
+            return Err(FittingError::InfiniteVariance);
+        }
 
         // Extract the standard deviation for the lifetime parameters.
         let sd = FitStatistics::try_from(&fit_result)?
             .nonlinear_parameters_variance()
             .get(0)
-            .ok_or_else(coef_error)?
+            .ok_or(FittingError::VarianceParameterUnavailable)?
             .sqrt();
-        Ok((lifetime, sd))
-    }
-}
 
-impl CompleteMetricResultClass for CompletedMuonLifetime {
-    type Partial = MuonLifetime;
-    type Error = FittingError;
-
-    fn aggregate(source: &Self::Partial) -> Result<Self, Self::Error> {
-        let channel_results = source
-            .histograms
-            .values()
-            .map(Self::extract_lifetime)
-            .collect::<Result<Vec<_>, Self::Error>>()?;
-        let mean = channel_results
-            .iter()
-            .map(|(lifetime, _)| lifetime)
-            .sum::<f64>()
-            .div(channel_results.len() as f64);
-        let sd = *channel_results
-            .iter()
-            .map(|(_, sd)| sd)
-            .max_by(|a, b| f64::partial_cmp(a, b).expect("This should never fail."))
-            .expect("This should never fail.");
+        // Validate lifetime standard deviation.
+        if !sd.is_finite() {
+            warn!("Infinite variance found");
+            return Err(FittingError::InfiniteVariance);
+        }
 
         Ok(Self {
-            lifetime: MeanSD { mean, sd },
+            lifetime: MeanSD { mean: lifetime, sd },
         })
     }
 
@@ -214,7 +198,8 @@ mod tests {
                 num_bins: 10,
                 interval,
             },
-            histograms: vec![(0, histogram)].into_iter().collect(),
+            //histograms: vec![(0, histogram.clone())].into_iter().collect(),
+            histogram: histogram,
         };
         let result = CompletedMuonLifetime::aggregate(&source);
         assert!(result.is_ok());
@@ -241,7 +226,8 @@ mod tests {
                 num_bins: 10,
                 interval,
             },
-            histograms: vec![(0, histogram)].into_iter().collect(),
+            //histograms: vec![(0, histogram.clone())].into_iter().collect(),
+            histogram: histogram,
         };
         let result = CompletedMuonLifetime::aggregate(&source);
         assert!(result.is_ok());

--- a/events-analyser/src/analysis/metrics/results/complete.rs
+++ b/events-analyser/src/analysis/metrics/results/complete.rs
@@ -1,8 +1,8 @@
 use crate::{
     analysis::metrics::{
-        CompleteMetricResultClass, MetricOutput, event_counts::CompletedEventCount,
-        false_counts::CompletedFalseCount, muon_lifetime::CompletedMuonLifetime,
-        results::MetricResultStore,
+        CompleteMetricResultClass, MetricOutput, MetricResultError,
+        event_counts::CompletedEventCount, false_counts::CompletedFalseCount,
+        muon_lifetime::CompletedMuonLifetime, results::MetricResultStore,
     },
     engine::MetricProperty,
 };
@@ -13,9 +13,12 @@ impl<C: CompleteMetricResultClass> MetricResultStore<C> {
         &self,
         block: usize,
         property: &MetricProperty,
-    ) -> Result<MetricOutput<Vec<f64>>, String> {
-        let block = self.by_bucket.get(block).expect("This should never fail.");
-        if let Some((first, rest)) = block.split_first() {
+    ) -> Result<MetricOutput<Vec<f64>>, C::Error> {
+        let block = self
+            .by_bucket
+            .get(block)
+            .expect("Bucket block should exist, this should never fail.");
+        let output = if let Some((first, rest)) = block.split_first() {
             let mut agg: MetricOutput<Vec<f64>> = first
                 .get_property(property)?
                 .to_vector(self.by_bucket.len());
@@ -27,7 +30,8 @@ impl<C: CompleteMetricResultClass> MetricResultStore<C> {
         } else {
             None
         }
-        .ok_or_else(|| "No buckets, this should never fail.".to_string())
+        .expect("Buckets should exist, this should never fail.");
+        Ok(output)
     }
 }
 
@@ -43,11 +47,11 @@ impl CompletedMetricResult {
         &self,
         block: usize,
         property: &MetricProperty,
-    ) -> Result<MetricOutput<Vec<f64>>, String> {
-        match self {
-            Self::EventCount(completed) => completed.get_property(block, property),
-            Self::FalseCount(completed) => completed.get_property(block, property),
-            Self::MuonLifetime(completed) => completed.get_property(block, property),
-        }
+    ) -> Result<MetricOutput<Vec<f64>>, MetricResultError> {
+        Ok(match self {
+            Self::EventCount(completed) => completed.get_property(block, property)?,
+            Self::FalseCount(completed) => completed.get_property(block, property)?,
+            Self::MuonLifetime(completed) => completed.get_property(block, property)?,
+        })
     }
 }

--- a/events-analyser/src/analysis/metrics/results/complete.rs
+++ b/events-analyser/src/analysis/metrics/results/complete.rs
@@ -15,12 +15,12 @@ impl<C: CompleteMetricResultClass> MetricResultStore<C> {
         property: &MetricProperty,
     ) -> Result<MetricOutput<Vec<f64>>, String> {
         let block = self.by_bucket.get(block).expect("This should never fail.");
-        if let Some(((_, first), rest)) = block.split_first() {
+        if let Some((first, rest)) = block.split_first() {
             let mut agg: MetricOutput<Vec<f64>> = first
                 .get_property(property)?
                 .to_vector(self.by_bucket.len());
 
-            for (_, metric) in rest {
+            for metric in rest {
                 agg.append(&metric.get_property(property)?);
             }
             Some(agg)

--- a/events-analyser/src/analysis/metrics/results/complete.rs
+++ b/events-analyser/src/analysis/metrics/results/complete.rs
@@ -15,12 +15,12 @@ impl<C: CompleteMetricResultClass> MetricResultStore<C> {
         property: &MetricProperty,
     ) -> Result<MetricOutput<Vec<f64>>, String> {
         let block = self.by_bucket.get(block).expect("This should never fail.");
-        if let Some((first, rest)) = block.split_first() {
+        if let Some(((_, first), rest)) = block.split_first() {
             let mut agg: MetricOutput<Vec<f64>> = first
                 .get_property(property)?
                 .to_vector(self.by_bucket.len());
 
-            for metric in rest {
+            for (_, metric) in rest {
                 agg.append(&metric.get_property(property)?);
             }
             Some(agg)

--- a/events-analyser/src/analysis/metrics/results/mod.rs
+++ b/events-analyser/src/analysis/metrics/results/mod.rs
@@ -45,12 +45,4 @@ where
 pub(crate) enum MetricResultError {
     #[error("{0}")]
     Fitting(#[from] FittingError),
-    #[error("No Error")]
-    NullError,
-}
-
-impl From<()> for MetricResultError {
-    fn from(_: ()) -> Self {
-        MetricResultError::NullError
-    }
 }

--- a/events-analyser/src/analysis/metrics/results/mod.rs
+++ b/events-analyser/src/analysis/metrics/results/mod.rs
@@ -37,7 +37,7 @@ pub(crate) struct MetricResultStore<C>
 where
     C: MetricResultClass,
 {
-    /// Metric results storage by bucket block and bucket. FIXME
+    /// Metric results storage by bucket block and bucket.
     by_bucket: BucketBlockStore<C>,
 }
 

--- a/events-analyser/src/analysis/metrics/results/mod.rs
+++ b/events-analyser/src/analysis/metrics/results/mod.rs
@@ -1,6 +1,8 @@
 mod complete;
 mod partial;
 
+use std::ops::Deref;
+
 use crate::analysis::metrics::{FittingError, MetricResultClass};
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
 use thiserror::Error;
@@ -12,7 +14,21 @@ pub(crate) use partial::PartialMetricResult;
 type BucketStore<C> = Vec<C>;
 
 /// Type which stores metric results by bucket block.
-type BucketBlockStore<C> = Vec<BucketStore<C>>;
+type BucketBlockStore<C> = Vec<BucketStore<StoreObject<C>>>;
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub(crate) struct StoreObject<C> {
+    pub(crate) num_messages: usize,
+    pub(crate) object: C,
+}
+
+impl<C> Deref for StoreObject<C> {
+    type Target = C;
+
+    fn deref(&self) -> &Self::Target {
+        &self.object
+    }
+}
 
 /// A generic type which stores
 #[derive(Debug, Serialize, Deserialize)]
@@ -22,7 +38,7 @@ where
     C: MetricResultClass,
 {
     /// Metric results storage by bucket block and bucket. FIXME
-    by_bucket: BucketBlockStore<(usize, C)>,
+    by_bucket: BucketBlockStore<C>,
 }
 
 #[derive(Debug, Error)]

--- a/events-analyser/src/analysis/metrics/results/mod.rs
+++ b/events-analyser/src/analysis/metrics/results/mod.rs
@@ -21,8 +21,8 @@ pub(crate) struct MetricResultStore<C>
 where
     C: MetricResultClass,
 {
-    /// Metric results storage by bucket block and bucket.
-    by_bucket: BucketBlockStore<C>,
+    /// Metric results storage by bucket block and bucket. FIXME
+    by_bucket: BucketBlockStore<(usize, C)>,
 }
 
 #[derive(Debug, Error)]

--- a/events-analyser/src/analysis/metrics/results/partial.rs
+++ b/events-analyser/src/analysis/metrics/results/partial.rs
@@ -43,7 +43,7 @@ where
             .expect("This should never fail.")
             .iter()
             .zip(buckets.iter())
-            .all(|(c,b)| c.len() >= b.limits.min)
+            .all(|(c, b)| c.len() >= b.limits.min)
     }
 
     /// Adds data to the metric, pushing it to the given bucket index.

--- a/events-analyser/src/analysis/metrics/results/partial.rs
+++ b/events-analyser/src/analysis/metrics/results/partial.rs
@@ -6,13 +6,35 @@ use crate::{
             event_counts::EventCount,
             false_counts::FalseCount,
             muon_lifetime::MuonLifetime,
-            results::{MetricResultError, MetricResultStore, complete::CompletedMetricResult},
+            results::{MetricResultError, MetricResultStore, StoreObject, complete::CompletedMetricResult},
         },
     },
     engine::{FlatAlgorithm, FlatBucket, FlatMetricType, FlatWaveform},
     eventlists::ChannelCollection,
 };
 use serde::{Deserialize, Serialize};
+
+impl<C> StoreObject<C>
+where C: PartialMetricResultClass, {
+    pub(crate) fn new(source: &C::Source) -> Self {
+        Self {
+            num_messages: Default::default(),
+            object: C::make_default(source)
+        }
+    }
+
+    pub(crate) fn is_bucket_full_enough(&self, bucket: &FlatBucket) -> bool {
+        self.num_messages >= bucket.limits.min
+    }
+
+    pub(crate) fn increment_count(&mut self) {
+        self.num_messages += 1;
+    }
+
+    pub(crate) fn aggregate(&self) -> Result<StoreObject<C::Complete>, <C::Complete as CompleteMetricResultClass>::Error> {
+        Ok(StoreObject { num_messages: self.num_messages, object: C::Complete::aggregate(self)? })
+    }
+}
 
 impl<C: PartialMetricResultClass> MetricResultStore<C>
 where
@@ -27,7 +49,7 @@ where
     pub(super) fn new(source: C::Source, bucket_block_sizes: &[usize]) -> Self {
         let by_bucket = bucket_block_sizes
             .iter()
-            .map(|size| vec![( Default::default(), C::make_default(&source)); *size])
+            .map(|size| vec![StoreObject::<C>::new(&source); *size])
             .collect::<Vec<_>>();
         Self { by_bucket }
     }
@@ -43,7 +65,7 @@ where
             .expect("This should never fail.")
             .iter()
             .zip(buckets.iter())
-            .all(|((num, _), b)| *num >= b.limits.min)
+            .all(|(store_object, bucket)| store_object.is_bucket_full_enough(bucket))
     }
 
     /// Adds data to the metric, pushing it to the given bucket index.
@@ -54,15 +76,16 @@ where
         bucket_index: BucketIndex,
         collection: &ChannelCollection,
     ) {
-        let (num, partial_metric_result) = self
+        let partial_metric_result = self
             .by_bucket
             .get_mut(bucket_index.block_index)
-            .expect("Index should be valid. This should never fail")
+            .expect("Block index should be valid, this should never fail")
             .get_mut(bucket_index.bucket_index)
-            .expect("Index should be valid. This should never fail");
-        *num += 1;
+            .expect("Bucket index should be valid, this should never fail");
+        
+        partial_metric_result.increment_count();
         for (&channel, by_topic) in collection.iter() {
-            partial_metric_result.push(waveform, algorithm, channel, by_topic);
+            partial_metric_result.object.push(waveform, algorithm, channel, by_topic);
         }
     }
 
@@ -76,7 +99,7 @@ where
                 .iter()
                 .map(|by| {
                     by.iter()
-                        .map(|(num,c)|Ok((*num, C::Complete::aggregate(c)?)))
+                        .map(StoreObject::aggregate)
                         .collect::<Result<_, _>>()
                 })
                 .collect::<Result<_, _>>()?,

--- a/events-analyser/src/analysis/metrics/results/partial.rs
+++ b/events-analyser/src/analysis/metrics/results/partial.rs
@@ -6,7 +6,9 @@ use crate::{
             event_counts::EventCount,
             false_counts::FalseCount,
             muon_lifetime::MuonLifetime,
-            results::{MetricResultError, MetricResultStore, StoreObject, complete::CompletedMetricResult},
+            results::{
+                MetricResultError, MetricResultStore, StoreObject, complete::CompletedMetricResult,
+            },
         },
     },
     engine::{FlatAlgorithm, FlatBucket, FlatMetricType, FlatWaveform},
@@ -15,11 +17,13 @@ use crate::{
 use serde::{Deserialize, Serialize};
 
 impl<C> StoreObject<C>
-where C: PartialMetricResultClass, {
+where
+    C: PartialMetricResultClass,
+{
     pub(crate) fn new(source: &C::Source) -> Self {
         Self {
             num_messages: Default::default(),
-            object: C::make_default(source)
+            object: C::make_default(source),
         }
     }
 
@@ -31,8 +35,13 @@ where C: PartialMetricResultClass, {
         self.num_messages += 1;
     }
 
-    pub(crate) fn aggregate(&self) -> Result<StoreObject<C::Complete>, <C::Complete as CompleteMetricResultClass>::Error> {
-        Ok(StoreObject { num_messages: self.num_messages, object: C::Complete::aggregate(self)? })
+    pub(crate) fn aggregate(
+        &self,
+    ) -> Result<StoreObject<C::Complete>, <C::Complete as CompleteMetricResultClass>::Error> {
+        Ok(StoreObject {
+            num_messages: self.num_messages,
+            object: C::Complete::aggregate(self)?,
+        })
     }
 }
 
@@ -82,10 +91,12 @@ where
             .expect("Block index should be valid, this should never fail")
             .get_mut(bucket_index.bucket_index)
             .expect("Bucket index should be valid, this should never fail");
-        
+
         partial_metric_result.increment_count();
         for (&channel, by_topic) in collection.iter() {
-            partial_metric_result.object.push(waveform, algorithm, channel, by_topic);
+            partial_metric_result
+                .object
+                .push(waveform, algorithm, channel, by_topic);
         }
     }
 

--- a/events-analyser/src/analysis/metrics/results/partial.rs
+++ b/events-analyser/src/analysis/metrics/results/partial.rs
@@ -37,12 +37,12 @@ where
     /// # Parameters
     /// - block: the block index to test.
     /// - min: the minimum amount of data the block should have.
-    pub(crate) fn are_buckets_full_enough(&self, block: usize, min: &[FlatBucket]) -> bool {
+    pub(crate) fn are_buckets_full_enough(&self, block: usize, buckets: &[FlatBucket]) -> bool {
         self.by_bucket
             .get(block)
             .expect("This should never fail.")
             .iter()
-            .zip(min.iter())
+            .zip(buckets.iter())
             .all(|(c,b)| c.len() >= b.limits.min)
     }
 

--- a/events-analyser/src/analysis/metrics/results/partial.rs
+++ b/events-analyser/src/analysis/metrics/results/partial.rs
@@ -27,7 +27,7 @@ where
     pub(super) fn new(source: C::Source, bucket_block_sizes: &[usize]) -> Self {
         let by_bucket = bucket_block_sizes
             .iter()
-            .map(|size| vec![C::make_default(&source); *size])
+            .map(|size| vec![( Default::default(), C::make_default(&source)); *size])
             .collect::<Vec<_>>();
         Self { by_bucket }
     }
@@ -43,7 +43,7 @@ where
             .expect("This should never fail.")
             .iter()
             .zip(buckets.iter())
-            .all(|(c, b)| c.len() >= b.limits.min)
+            .all(|((num, _), b)| *num >= b.limits.min)
     }
 
     /// Adds data to the metric, pushing it to the given bucket index.
@@ -54,14 +54,15 @@ where
         bucket_index: BucketIndex,
         collection: &ChannelCollection,
     ) {
-        let partial_metric_result = self
+        let (num, partial_metric_result) = self
             .by_bucket
             .get_mut(bucket_index.block_index)
             .expect("Index should be valid. This should never fail")
             .get_mut(bucket_index.bucket_index)
             .expect("Index should be valid. This should never fail");
-        for by_topic in collection.values() {
-            partial_metric_result.push(waveform, algorithm, by_topic);
+        *num += 1;
+        for (&channel, by_topic) in collection.iter() {
+            partial_metric_result.push(waveform, algorithm, channel, by_topic);
         }
     }
 
@@ -75,7 +76,7 @@ where
                 .iter()
                 .map(|by| {
                     by.iter()
-                        .map(C::Complete::aggregate)
+                        .map(|(num,c)|Ok((*num, C::Complete::aggregate(c)?)))
                         .collect::<Result<_, _>>()
                 })
                 .collect::<Result<_, _>>()?,

--- a/events-analyser/src/analysis/metrics/results/partial.rs
+++ b/events-analyser/src/analysis/metrics/results/partial.rs
@@ -9,7 +9,7 @@ use crate::{
             results::{MetricResultError, MetricResultStore, complete::CompletedMetricResult},
         },
     },
-    engine::{FlatAlgorithm, FlatMetricType, FlatWaveform},
+    engine::{FlatAlgorithm, FlatBucket, FlatMetricType, FlatWaveform},
     eventlists::ChannelCollection,
 };
 use serde::{Deserialize, Serialize};
@@ -37,12 +37,13 @@ where
     /// # Parameters
     /// - block: the block index to test.
     /// - min: the minimum amount of data the block should have.
-    pub(crate) fn are_buckets_full_enough(&self, block: usize, min: usize) -> bool {
+    pub(crate) fn are_buckets_full_enough(&self, block: usize, min: &[FlatBucket]) -> bool {
         self.by_bucket
             .get(block)
             .expect("This should never fail.")
             .iter()
-            .all(|c| c.len() >= min)
+            .zip(min.iter())
+            .all(|(c,b)| c.len() >= b.limits.min)
     }
 
     /// Adds data to the metric, pushing it to the given bucket index.
@@ -108,7 +109,7 @@ impl PartialMetricResult {
         }
     }
 
-    pub(crate) fn are_buckets_full_enough(&self, block: usize, min: usize) -> bool {
+    pub(crate) fn are_buckets_full_enough(&self, block: usize, min: &[FlatBucket]) -> bool {
         match self {
             Self::EventCount(patrial_metric_result_class) => {
                 patrial_metric_result_class.are_buckets_full_enough(block, min)

--- a/events-analyser/src/analysis/metrics/utils.rs
+++ b/events-analyser/src/analysis/metrics/utils.rs
@@ -1,4 +1,4 @@
-use crate::event::ChannelData;
+use crate::{engine::Interval, event::ChannelData};
 use digital_muon_common::{Intensity, Time};
 use serde::{Deserialize, Serialize};
 use std::{iter::once, ops::AddAssign};
@@ -256,33 +256,34 @@ pub(crate) struct Histogram {
     num_values: usize,
     bins: Vec<f64>,
     bin_labels: Vec<f64>,
-    max_value: f64,
+    interval: Interval<f64>,
 }
 
 impl Histogram {
-    pub(crate) fn new(num: usize, max_value: f64) -> Self {
+    pub(crate) fn new(num: usize, interval: &Interval<f64>) -> Self {
         let bins = vec![Default::default(); num];
+        let coef = (interval.max - interval.min)/ num as f64;
         let bin_labels = (0..num)
-            .map(|i| max_value * i as f64 / num as f64)
+            .map(|i|  i as f64 * coef)
             .collect();
         Self {
             num_values: Default::default(),
             bin_labels,
             bins,
-            max_value,
+            interval: interval.clone(),
         }
     }
 
     pub(crate) fn push(&mut self, value: f64) {
         self.num_values += 1;
-        let index = (self.bins.len() as f64 * value / self.max_value) as usize;
-        if index < self.bins.len() {
+        if self.interval.min <= value && value < self.interval.max {
+            let index = (self.bins.len() as f64 * (value - self.interval.min) / (self.interval.max - self.interval.min)) as usize;
             self.bins
                 .get_mut(index)
-                .expect("This should never fail")
+                .expect("Element should exist, this should never fail")
                 .add_assign(1.0);
         } else {
-            warn!("Histogram value out of range {value} > {}", self.max_value);
+            warn!("Histogram value out of range {value} \notin ({},{})", self.interval.min, self.interval.max);
         }
     }
 
@@ -297,11 +298,11 @@ impl Histogram {
     }
 */
     pub(crate) fn get_normalised_counts(&self) -> Vec<f64> {
+        let coef = 1.0/self.num_values as f64;
         self.bins
-        .iter()
-        .map(|value|value/self.num_values as f64)
-        .collect()
-
+            .iter()
+            .map(|value|value*coef)
+            .collect()
     }
     /* 
     pub(crate) fn get_counts(&self) -> &[f64] {

--- a/events-analyser/src/analysis/metrics/utils.rs
+++ b/events-analyser/src/analysis/metrics/utils.rs
@@ -274,6 +274,7 @@ impl Histogram {
     }
 
     pub(crate) fn push(&mut self, value: f64) {
+        self.num_values += 1;
         let index = (self.bins.len() as f64 * value / self.max_value) as usize;
         if index < self.bins.len() {
             self.bins
@@ -288,7 +289,21 @@ impl Histogram {
     pub(crate) fn get_bin_labels(&self) -> &[f64] {
         &self.bin_labels
     }
+/*
+    pub(crate) fn normalise(&mut self) {
+        for bin in &mut self.bins {
+            bin.div_assign(self.num_values as f64)
+        }
+    }
+*/
+    pub(crate) fn get_normalised_counts(&self) -> Vec<f64> {
+        self.bins
+        .iter()
+        .map(|value|value/self.num_values as f64)
+        .collect()
 
+    }
+    /* 
     pub(crate) fn get_counts(&self) -> &[f64] {
         &self.bins
     }
@@ -296,7 +311,7 @@ impl Histogram {
     pub(crate) fn get_num_values(&self) -> usize {
         self.num_values
     }
-
+    */
     #[cfg(test)]
     pub(crate) fn set(&mut self, bins: Vec<f64>) {
         self.num_values = bins.iter().sum::<f64>() as usize;

--- a/events-analyser/src/analysis/metrics/utils.rs
+++ b/events-analyser/src/analysis/metrics/utils.rs
@@ -2,7 +2,6 @@ use crate::{engine::Interval, event::ChannelData};
 use digital_muon_common::{Intensity, Time};
 use serde::{Deserialize, Serialize};
 use std::{iter::once, ops::AddAssign};
-use tracing::warn;
 
 pub(super) struct GroupDataBy<'a, F>
 where

--- a/events-analyser/src/analysis/metrics/utils.rs
+++ b/events-analyser/src/analysis/metrics/utils.rs
@@ -262,10 +262,8 @@ pub(crate) struct Histogram {
 impl Histogram {
     pub(crate) fn new(num: usize, interval: &Interval<f64>) -> Self {
         let bins = vec![Default::default(); num];
-        let coef = (interval.max - interval.min)/ num as f64;
-        let bin_labels = (0..num)
-            .map(|i|  i as f64 * coef)
-            .collect();
+        let coef = (interval.max - interval.min) / num as f64;
+        let bin_labels = (0..num).map(|i| i as f64 * coef).collect();
         Self {
             num_values: Default::default(),
             bin_labels,
@@ -277,34 +275,35 @@ impl Histogram {
     pub(crate) fn push(&mut self, value: f64) {
         self.num_values += 1;
         if self.interval.min <= value && value < self.interval.max {
-            let index = (self.bins.len() as f64 * (value - self.interval.min) / (self.interval.max - self.interval.min)) as usize;
+            let index = (self.bins.len() as f64 * (value - self.interval.min)
+                / (self.interval.max - self.interval.min)) as usize;
             self.bins
                 .get_mut(index)
                 .expect("Element should exist, this should never fail")
                 .add_assign(1.0);
         } else {
-            warn!("Histogram value out of range {value} \notin ({},{})", self.interval.min, self.interval.max);
+            warn!(
+                "Histogram value out of range {value} \notin ({},{})",
+                self.interval.min, self.interval.max
+            );
         }
     }
 
     pub(crate) fn get_bin_labels(&self) -> &[f64] {
         &self.bin_labels
     }
-/*
-    pub(crate) fn normalise(&mut self) {
-        for bin in &mut self.bins {
-            bin.div_assign(self.num_values as f64)
+    /*
+        pub(crate) fn normalise(&mut self) {
+            for bin in &mut self.bins {
+                bin.div_assign(self.num_values as f64)
+            }
         }
-    }
-*/
+    */
     pub(crate) fn get_normalised_counts(&self) -> Vec<f64> {
-        let coef = 1.0/self.num_values as f64;
-        self.bins
-            .iter()
-            .map(|value|value*coef)
-            .collect()
+        let coef = 1.0 / self.num_values as f64;
+        self.bins.iter().map(|value| value * coef).collect()
     }
-    /* 
+    /*
     pub(crate) fn get_counts(&self) -> &[f64] {
         &self.bins
     }

--- a/events-analyser/src/analysis/metrics/utils.rs
+++ b/events-analyser/src/analysis/metrics/utils.rs
@@ -253,6 +253,7 @@ mod tests {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub(crate) struct Histogram {
+    num_values: usize,
     bins: Vec<f64>,
     bin_labels: Vec<f64>,
     max_value: f64,
@@ -265,6 +266,7 @@ impl Histogram {
             .map(|i| max_value * i as f64 / num as f64)
             .collect();
         Self {
+            num_values: Default::default(),
             bin_labels,
             bins,
             max_value,
@@ -291,8 +293,13 @@ impl Histogram {
         &self.bins
     }
 
+    pub(crate) fn get_num_values(&self) -> usize {
+        self.num_values
+    }
+
     #[cfg(test)]
     pub(crate) fn set(&mut self, bins: Vec<f64>) {
+        self.num_values = bins.iter().sum::<f64>() as usize;
         self.bins = bins;
     }
 }

--- a/events-analyser/src/analysis/metrics/utils.rs
+++ b/events-analyser/src/analysis/metrics/utils.rs
@@ -257,6 +257,8 @@ pub(crate) struct Histogram {
     bins: Vec<f64>,
     bin_labels: Vec<f64>,
     interval: Interval<f64>,
+    num_too_small: usize,
+    num_too_big: usize,
 }
 
 impl Histogram {
@@ -269,49 +271,36 @@ impl Histogram {
             bin_labels,
             bins,
             interval: interval.clone(),
+            num_too_small: Default::default(),
+            num_too_big: Default::default(),
         }
     }
 
     pub(crate) fn push(&mut self, value: f64) {
-        self.num_values += 1;
         if self.interval.min <= value && value < self.interval.max {
+            self.num_values += 1;
             let index = (self.bins.len() as f64 * (value - self.interval.min)
                 / (self.interval.max - self.interval.min)) as usize;
             self.bins
                 .get_mut(index)
                 .expect("Element should exist, this should never fail")
                 .add_assign(1.0);
+        } else if value < self.interval.min {
+            self.num_too_small += 1;
         } else {
-            warn!(
-                "Histogram value out of range {value} \notin ({},{})",
-                self.interval.min, self.interval.max
-            );
+            self.num_too_big += 1;
         }
     }
 
     pub(crate) fn get_bin_labels(&self) -> &[f64] {
         &self.bin_labels
     }
-    /*
-        pub(crate) fn normalise(&mut self) {
-            for bin in &mut self.bins {
-                bin.div_assign(self.num_values as f64)
-            }
-        }
-    */
+
     pub(crate) fn get_normalised_counts(&self) -> Vec<f64> {
         let coef = 1.0 / self.num_values as f64;
         self.bins.iter().map(|value| value * coef).collect()
     }
-    /*
-    pub(crate) fn get_counts(&self) -> &[f64] {
-        &self.bins
-    }
 
-    pub(crate) fn get_num_values(&self) -> usize {
-        self.num_values
-    }
-    */
     #[cfg(test)]
     pub(crate) fn set(&mut self, bins: Vec<f64>) {
         self.num_values = bins.iter().sum::<f64>() as usize;

--- a/events-analyser/src/analysis/mod.rs
+++ b/events-analyser/src/analysis/mod.rs
@@ -104,28 +104,28 @@ impl AnalysisEngine {
     /// the analysis engine has been idle for the required number of settings.
     /// If so then set `trigger_when` to `Now`.
     pub(crate) fn test_idle_time(&mut self) {
-        if let FlatTriggerWhen::IdleTimeExceededSec(seconds) = self.trigger_when {
-            if let Some(last_message_timestamp) = self.last_message_timestamp {
-                if Utc::now() - last_message_timestamp > TimeDelta::seconds(seconds) {
-                    self.trigger_when = FlatTriggerWhen::Now;
-                    info!("Frame Number Trigger Satisfied.");
-                }
-            }
+        if let FlatTriggerWhen::IdleTimeExceededSec(seconds) = self.trigger_when
+            && let Some(last_message_timestamp) = self.last_message_timestamp
+            && Utc::now() - last_message_timestamp > TimeDelta::seconds(seconds)
+        {
+            self.trigger_when = FlatTriggerWhen::Now;
+            info!("Idle Time Trigger Satisfied, last push: {}.", last_message_timestamp.to_rfc3339());
         }
     }
 
     pub(crate) fn push(&mut self, collection: EventlistsCollection) -> Result<(), AnalysisError> {
-        if let FlatTriggerWhen::TimestampMet(timestamp) = self.trigger_when {
-            if collection.metadata.timestamp >= timestamp {
-                info!("Timestamp Trigger Satisfied.");
-                self.trigger_when = FlatTriggerWhen::Now;
-            }
-        } else if let FlatTriggerWhen::FrameNumberMet(frame_number) = self.trigger_when {
-            if collection.metadata.frame_number >= frame_number {
-                info!("Frame Number Trigger Satisfied.");
-                self.trigger_when = FlatTriggerWhen::Now;
-            }
+        if let FlatTriggerWhen::TimestampMet(timestamp) = self.trigger_when
+            && collection.metadata.timestamp >= timestamp
+        {
+            info!("Timestamp Trigger Satisfied.");
+            self.trigger_when = FlatTriggerWhen::Now;
+        } else if let FlatTriggerWhen::FrameNumberMet(frame_number) = self.trigger_when
+            && collection.metadata.frame_number >= frame_number
+        {
+            info!("Frame Number Trigger Satisfied.");
+            self.trigger_when = FlatTriggerWhen::Now;
         }
+
         let (index, bucket) = self
             .buckets
             .iter_mut()

--- a/events-analyser/src/analysis/mod.rs
+++ b/events-analyser/src/analysis/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     engine::{AnalysisSettings, FlatBucketBlock, FlatChart, FlatTriggerWhen, Flattenable},
     eventlists::EventlistsCollection,
 };
-use chrono::ParseError;
+use chrono::{DateTime, ParseError, TimeDelta, Utc};
 use digital_muon_common::{
     Channel, DigitizerId,
     spanned::{SpanOnceError, Spanned, SpannedAggregator},
@@ -58,6 +58,7 @@ pub(crate) struct AnalysisEngine {
     metrics: Vec<PartialMetricResult>,
     charts: Vec<FlatChart>,
     trigger_when: FlatTriggerWhen,
+    last_message_timestamp: Option<DateTime<Utc>>,
 }
 
 impl AnalysisEngine {
@@ -90,12 +91,27 @@ impl AnalysisEngine {
             buckets,
             charts,
             metrics_json_name: settings.metrics_json_name,
-            trigger_when: settings.trigger_charts_when.flatten(())?
+            trigger_when: settings.trigger_charts_when.flatten(())?,
+            last_message_timestamp: None,
         };
         if load_metrics {
             this.load_json_metrics()?;
         }
         Ok(this)
+    }
+
+    /// If the `trigger_when` field is `IdleTimeExceededSec`, then test whether
+    /// the analysis engine has been idle for the required number of settings.
+    /// If so then set `trigger_when` to `Now`.
+    pub(crate) fn test_idle_time(&mut self) {
+        if let FlatTriggerWhen::IdleTimeExceededSec(seconds) = self.trigger_when {
+            if let Some(last_message_timestamp) = self.last_message_timestamp {
+                if Utc::now() - last_message_timestamp > TimeDelta::seconds(seconds) {
+                    self.trigger_when = FlatTriggerWhen::Now;
+                    info!("Frame Number Trigger Satisfied.");
+                }
+            }
+        }
     }
 
     pub(crate) fn push(&mut self, collection: EventlistsCollection) -> Result<(), AnalysisError> {
@@ -110,7 +126,6 @@ impl AnalysisEngine {
                 self.trigger_when = FlatTriggerWhen::Now;
             }
         }
-
         let (index, bucket) = self
             .buckets
             .iter_mut()
@@ -156,6 +171,9 @@ impl AnalysisEngine {
         } else {
             info!("Bucket {}, {} full", index.block_index, index.bucket_index);
         }
+
+        // Update last idle time field.
+        self.last_message_timestamp = Some(Utc::now());
         Ok(())
     }
 
@@ -220,7 +238,7 @@ impl AnalysisEngine {
                 }
                 info!("Bucket Min Limit Trigger Satisfied.");
                 Ok(true)
-            },
+            }
             FlatTriggerWhen::Now => Ok(true),
             _ => Ok(false),
         }

--- a/events-analyser/src/analysis/mod.rs
+++ b/events-analyser/src/analysis/mod.rs
@@ -6,9 +6,10 @@ mod metrics;
 
 use crate::{
     analysis::{chart::ChartOutputError, metrics::MetricResultError},
-    engine::{AnalysisSettings, FlatBucketBlock, FlatChart},
+    engine::{AnalysisSettings, FlatBucketBlock, FlatChart, FlatTriggerWhen, Flattenable},
     eventlists::EventlistsCollection,
 };
+use chrono::ParseError;
 use digital_muon_common::{
     Channel, DigitizerId,
     spanned::{SpanOnceError, Spanned, SpannedAggregator},
@@ -40,6 +41,8 @@ pub(crate) enum AnalysisError {
     MetricResult(#[from] MetricResultError),
     #[error("No Json Metric Specified")]
     NoJsonMetricSpecified,
+    #[error("DateTime parse error {0}")]
+    ParseError(#[from] ParseError),
 }
 
 #[derive(Clone, Copy)]
@@ -54,6 +57,7 @@ pub(crate) struct AnalysisEngine {
     buckets: Vec<FlatBucketBlock>,
     metrics: Vec<PartialMetricResult>,
     charts: Vec<FlatChart>,
+    trigger_when: FlatTriggerWhen,
 }
 
 impl AnalysisEngine {
@@ -86,6 +90,7 @@ impl AnalysisEngine {
             buckets,
             charts,
             metrics_json_name: settings.metrics_json_name,
+            trigger_when: settings.trigger_charts_when.flatten(())?
         };
         if load_metrics {
             this.load_json_metrics()?;
@@ -94,6 +99,18 @@ impl AnalysisEngine {
     }
 
     pub(crate) fn push(&mut self, collection: EventlistsCollection) -> Result<(), AnalysisError> {
+        if let FlatTriggerWhen::TimestampMet(timestamp) = self.trigger_when {
+            if collection.metadata.timestamp >= timestamp {
+                info!("Timestamp Trigger Satisfied.");
+                self.trigger_when = FlatTriggerWhen::Now;
+            }
+        } else if let FlatTriggerWhen::FrameNumberMet(frame_number) = self.trigger_when {
+            if collection.metadata.frame_number >= frame_number {
+                info!("Frame Number Trigger Satisfied.");
+                self.trigger_when = FlatTriggerWhen::Now;
+            }
+        }
+
         let (index, bucket) = self
             .buckets
             .iter_mut()
@@ -191,14 +208,21 @@ impl AnalysisEngine {
     }
 
     pub(crate) fn evaluate_chart_readiness(&mut self) -> Result<bool, String> {
-        for chart in &mut self.charts {
-            if chart.evaluate_readiness(&self.buckets, &self.metrics) {
-                trace!("{}, ready.", chart.title);
-            } else {
-                trace!("{}, not ready.", chart.title);
-                return Ok(false);
-            }
+        match self.trigger_when {
+            FlatTriggerWhen::BucketsExceedMinLimit => {
+                for chart in &mut self.charts {
+                    if chart.evaluate_readiness(&self.buckets, &self.metrics) {
+                        trace!("{}, ready.", chart.title);
+                    } else {
+                        trace!("{}, not ready.", chart.title);
+                        return Ok(false);
+                    }
+                }
+                info!("Bucket Min Limit Trigger Satisfied.");
+                Ok(true)
+            },
+            FlatTriggerWhen::Now => Ok(true),
+            _ => Ok(false),
         }
-        Ok(true)
     }
 }

--- a/events-analyser/src/analysis/mod.rs
+++ b/events-analyser/src/analysis/mod.rs
@@ -170,7 +170,11 @@ impl AnalysisEngine {
             self.metrics = serde_json::from_reader(File::open(&path)?)?;
 
             // Set the last message timestamp field to trigger the evaluation.
-            self.last_message_timestamp = Some(Utc::now().checked_sub_signed(self.idle_time).expect("Subtracted time should be in range, this should never fail."));
+            self.last_message_timestamp = Some(
+                Utc::now()
+                    .checked_sub_signed(self.idle_time)
+                    .expect("Subtracted time should be in range, this should never fail."),
+            );
             Ok(())
         } else {
             Err(AnalysisError::NoJsonMetricSpecified)

--- a/events-analyser/src/analysis/mod.rs
+++ b/events-analyser/src/analysis/mod.rs
@@ -58,6 +58,7 @@ pub(crate) struct AnalysisEngine {
     metrics: Vec<PartialMetricResult>,
     charts: Vec<FlatChart>,
     trigger_when: FlatTriggerWhen,
+    idle_time: TimeDelta,
     last_message_timestamp: Option<DateTime<Utc>>,
 }
 
@@ -92,25 +93,13 @@ impl AnalysisEngine {
             charts,
             metrics_json_name: settings.metrics_json_name,
             trigger_when: settings.trigger_charts_when.flatten(())?,
+            idle_time: TimeDelta::seconds(settings.idle_time_sec),
             last_message_timestamp: None,
         };
         if load_metrics {
             this.load_json_metrics()?;
         }
         Ok(this)
-    }
-
-    /// If the `trigger_when` field is `IdleTimeExceededSec`, then test whether
-    /// the analysis engine has been idle for the required number of settings.
-    /// If so then set `trigger_when` to `Now`.
-    pub(crate) fn test_idle_time(&mut self) {
-        if let FlatTriggerWhen::IdleTimeExceededSec(seconds) = self.trigger_when
-            && let Some(last_message_timestamp) = self.last_message_timestamp
-            && Utc::now() - last_message_timestamp > TimeDelta::seconds(seconds)
-        {
-            self.trigger_when = FlatTriggerWhen::Now;
-            info!("Idle Time Trigger Satisfied, last push: {}.", last_message_timestamp.to_rfc3339());
-        }
     }
 
     pub(crate) fn push(&mut self, collection: EventlistsCollection) -> Result<(), AnalysisError> {
@@ -225,22 +214,35 @@ impl AnalysisEngine {
         Ok(())
     }
 
-    pub(crate) fn evaluate_chart_readiness(&mut self) -> Result<bool, String> {
-        match self.trigger_when {
-            FlatTriggerWhen::BucketsExceedMinLimit => {
-                for chart in &mut self.charts {
-                    if chart.evaluate_readiness(&self.buckets, &self.metrics) {
-                        trace!("{}, ready.", chart.title);
-                    } else {
-                        trace!("{}, not ready.", chart.title);
-                        return Ok(false);
-                    }
+    /// If the `trigger_when` field is `IdleTimeExceededSec`, then test whether
+    /// the analysis engine has been idle for the required number of settings.
+    /// If so then set `trigger_when` to `Now`.
+    pub(crate) fn test_idle_time(&mut self) {
+        if let FlatTriggerWhen::IdleTimeExceededSec(seconds) = self.trigger_when
+            && let Some(last_message_timestamp) = self.last_message_timestamp
+            && Utc::now() - last_message_timestamp > TimeDelta::seconds(seconds)
+        {
+            self.trigger_when = FlatTriggerWhen::Now;
+            info!("Idle Time Trigger Satisfied, last push: {}.", last_message_timestamp.to_rfc3339());
+        }
+    }
+
+    pub(crate) fn evaluate_chart_readiness(&mut self) -> bool {
+        if let Some(last_message_timestamp) = self.last_message_timestamp
+            && Utc::now() - last_message_timestamp > self.idle_time
+        {
+            info!("Idle Time Trigger Satisfied, last push: {}.", last_message_timestamp.to_rfc3339());
+            for chart in &mut self.charts {
+                if chart.evaluate_readiness(&self.buckets, &self.metrics) {
+                    trace!("{}, ready.", chart.title);
+                } else {
+                    trace!("{}, not ready.", chart.title);
+                    return false;
                 }
-                info!("Bucket Min Limit Trigger Satisfied.");
-                Ok(true)
             }
-            FlatTriggerWhen::Now => Ok(true),
-            _ => Ok(false),
+            true
+        } else {
+            false
         }
     }
 }

--- a/events-analyser/src/analysis/mod.rs
+++ b/events-analyser/src/analysis/mod.rs
@@ -168,6 +168,9 @@ impl AnalysisEngine {
             path.push(metrics_json_name);
             path.add_extension("json");
             self.metrics = serde_json::from_reader(File::open(&path)?)?;
+
+            // Set the last message timestamp field to trigger the evaluation.
+            self.last_message_timestamp = Some(Utc::now().checked_sub_signed(self.idle_time).expect("Subtracted time should be in range, this should never fail."));
             Ok(())
         } else {
             Err(AnalysisError::NoJsonMetricSpecified)

--- a/events-analyser/src/analysis/mod.rs
+++ b/events-analyser/src/analysis/mod.rs
@@ -85,7 +85,12 @@ impl AnalysisEngine {
             .map(|metric| PartialMetricResult::new(metric.metric_type, &bucket_block_sizes))
             .collect::<Vec<_>>();
 
-        info!("Analysis Engine created with {} metric(s), {} chart(s), and {} bucket block(s).", metrics.len(), charts.len(), bucket_block_sizes.len());
+        info!(
+            "Analysis Engine created with {} metric(s), {} chart(s), and {} bucket block(s).",
+            metrics.len(),
+            charts.len(),
+            bucket_block_sizes.len()
+        );
         info!("Metric(s): {metrics:?}");
         info!("Chart(s): {charts:?}");
         info!("Bucket size(s): {bucket_block_sizes:?}");
@@ -212,7 +217,10 @@ impl AnalysisEngine {
         if let Some(last_message_timestamp) = self.last_message_timestamp
             && Utc::now() - last_message_timestamp > self.idle_time
         {
-            info!("Idle Time Trigger Satisfied, last push: {}.", last_message_timestamp.to_rfc3339());
+            info!(
+                "Idle Time Trigger Satisfied, last push: {}.",
+                last_message_timestamp.to_rfc3339()
+            );
             for chart in &mut self.charts {
                 if chart.evaluate_readiness(&self.buckets, &self.metrics) {
                     trace!("{}, ready.", chart.title);

--- a/events-analyser/src/analysis/mod.rs
+++ b/events-analyser/src/analysis/mod.rs
@@ -6,7 +6,7 @@ mod metrics;
 
 use crate::{
     analysis::{chart::ChartOutputError, metrics::MetricResultError},
-    engine::{AnalysisSettings, FlatBucketBlock, FlatChart, FlatTriggerWhen, Flattenable},
+    engine::{AnalysisSettings, FlatBucketBlock, FlatChart},
     eventlists::EventlistsCollection,
 };
 use chrono::{DateTime, ParseError, TimeDelta, Utc};
@@ -57,7 +57,6 @@ pub(crate) struct AnalysisEngine {
     buckets: Vec<FlatBucketBlock>,
     metrics: Vec<PartialMetricResult>,
     charts: Vec<FlatChart>,
-    trigger_when: FlatTriggerWhen,
     idle_time: TimeDelta,
     last_message_timestamp: Option<DateTime<Utc>>,
 }
@@ -86,13 +85,17 @@ impl AnalysisEngine {
             .map(|metric| PartialMetricResult::new(metric.metric_type, &bucket_block_sizes))
             .collect::<Vec<_>>();
 
+        info!("Analysis Engine created with {} metric(s), {} chart(s), and {} bucket block(s).", metrics.len(), charts.len(), bucket_block_sizes.len());
+        info!("Metric(s): {metrics:?}");
+        info!("Chart(s): {charts:?}");
+        info!("Bucket size(s): {bucket_block_sizes:?}");
+
         let mut this = Self {
             path,
             metrics,
             buckets,
             charts,
             metrics_json_name: settings.metrics_json_name,
-            trigger_when: settings.trigger_charts_when.flatten(())?,
             idle_time: TimeDelta::seconds(settings.idle_time_sec),
             last_message_timestamp: None,
         };
@@ -103,18 +106,6 @@ impl AnalysisEngine {
     }
 
     pub(crate) fn push(&mut self, collection: EventlistsCollection) -> Result<(), AnalysisError> {
-        if let FlatTriggerWhen::TimestampMet(timestamp) = self.trigger_when
-            && collection.metadata.timestamp >= timestamp
-        {
-            info!("Timestamp Trigger Satisfied.");
-            self.trigger_when = FlatTriggerWhen::Now;
-        } else if let FlatTriggerWhen::FrameNumberMet(frame_number) = self.trigger_when
-            && collection.metadata.frame_number >= frame_number
-        {
-            info!("Frame Number Trigger Satisfied.");
-            self.trigger_when = FlatTriggerWhen::Now;
-        }
-
         let (index, bucket) = self
             .buckets
             .iter_mut()
@@ -214,19 +205,9 @@ impl AnalysisEngine {
         Ok(())
     }
 
-    /// If the `trigger_when` field is `IdleTimeExceededSec`, then test whether
-    /// the analysis engine has been idle for the required number of settings.
-    /// If so then set `trigger_when` to `Now`.
-    pub(crate) fn test_idle_time(&mut self) {
-        if let FlatTriggerWhen::IdleTimeExceededSec(seconds) = self.trigger_when
-            && let Some(last_message_timestamp) = self.last_message_timestamp
-            && Utc::now() - last_message_timestamp > TimeDelta::seconds(seconds)
-        {
-            self.trigger_when = FlatTriggerWhen::Now;
-            info!("Idle Time Trigger Satisfied, last push: {}.", last_message_timestamp.to_rfc3339());
-        }
-    }
-
+    /// Determine whether the charts are ready to be created.
+    /// That is, return whether the idle time condition has passed, and
+    /// whether each applicable metric has collected enough data.
     pub(crate) fn evaluate_chart_readiness(&mut self) -> bool {
         if let Some(last_message_timestamp) = self.last_message_timestamp
             && Utc::now() - last_message_timestamp > self.idle_time

--- a/events-analyser/src/engine/elements/bucket.rs
+++ b/events-analyser/src/engine/elements/bucket.rs
@@ -302,10 +302,11 @@ impl FlatBucket {
                 .criteria
                 .frames
                 .is_valid(collection.metadata.frame_number)
-            && collection
-                .channels
-                .iter()
-                .any(|&channel| self.criteria.channels.is_valid(channel))
+            && (collection.channels.is_empty()
+                || collection
+                    .channels
+                    .iter()
+                    .any(|&channel| self.criteria.channels.is_valid(channel)))
     }
 }
 
@@ -314,7 +315,7 @@ mod tests {
     use chrono::Utc;
     use digital_muon_streaming_types::FrameMetadata;
 
-    use crate::engine::values::ConstantFilter;
+    use crate::engine::values::Filter;
 
     use super::*;
 
@@ -323,10 +324,10 @@ mod tests {
         let bucket = FlatBucket {
             span: Default::default(),
             criteria: FlatCriteria {
-                periods: ConstantFilter::Any,
-                frames: ConstantFilter::Any,
-                channels: ConstantFilter::Any,
-                digitiser_ids: ConstantFilter::Any,
+                periods: Filter::Any,
+                frames: Filter::Any,
+                channels: Filter::Any,
+                digitiser_ids: Filter::Any,
             },
             algorithm: FlatAlgorithm::FixedThreshold {
                 _threshold: Default::default(),
@@ -337,7 +338,7 @@ mod tests {
                 width: Default::default(),
             },
             count: 0,
-            limits: Interval { min: 0, max: 1 }
+            limits: Interval { min: 0, max: 1 },
         };
         let collection = EventlistsCollection {
             span: Default::default(),
@@ -361,10 +362,10 @@ mod tests {
         let bucket_1 = FlatBucket {
             span: Default::default(),
             criteria: FlatCriteria {
-                periods: ConstantFilter::Is(0),
-                frames: ConstantFilter::Any,
-                channels: ConstantFilter::Any,
-                digitiser_ids: ConstantFilter::Any,
+                periods: Filter::Is(0),
+                frames: Filter::Any,
+                channels: Filter::Any,
+                digitiser_ids: Filter::Any,
             },
             algorithm: FlatAlgorithm::FixedThreshold {
                 _threshold: Default::default(),
@@ -375,15 +376,15 @@ mod tests {
                 width: Default::default(),
             },
             count: 0,
-            limits: Interval { min: 0, max: 1 }
+            limits: Interval { min: 0, max: 1 },
         };
         let bucket_2 = FlatBucket {
             span: Default::default(),
             criteria: FlatCriteria {
-                periods: ConstantFilter::Is(1),
-                frames: ConstantFilter::Any,
-                channels: ConstantFilter::Any,
-                digitiser_ids: ConstantFilter::Any,
+                periods: Filter::Is(1),
+                frames: Filter::Any,
+                channels: Filter::Any,
+                digitiser_ids: Filter::Any,
             },
             algorithm: FlatAlgorithm::FixedThreshold {
                 _threshold: Default::default(),
@@ -394,7 +395,7 @@ mod tests {
                 width: Default::default(),
             },
             count: 0,
-            limits: Interval { min: 0, max: 1 }
+            limits: Interval { min: 0, max: 1 },
         };
         let collection = EventlistsCollection {
             span: Default::default(),

--- a/events-analyser/src/engine/elements/bucket.rs
+++ b/events-analyser/src/engine/elements/bucket.rs
@@ -6,7 +6,7 @@ use crate::{
             criteria::{Criteria, CriteriaError, FlatCriteria},
             waveform::FlatWaveform,
         },
-        values::{Interval, ValueError},
+        values::{Interval, Value, ValueError},
     },
     eventlists::EventlistsCollection,
 };
@@ -78,7 +78,7 @@ pub(crate) struct BucketBlockProperties {
     /// The name of the modelling waveform these buckets expect.
     pub(crate) waveform: Option<String>,
     /// Specifies the minimum and maximum number of eventlist collections these buckets allow.
-    pub(crate) limits: Option<Interval<usize>>,
+    pub(crate) limits: Option<Interval<Value<usize>>>,
 }
 
 ///
@@ -163,12 +163,13 @@ impl Flattenable<&Templates> for BucketBlock {
                 let criteria = self.criteria.flatten(library, index)?;
                 let algorithm = algorithm.flatten(library.get_arrays(), index)?;
                 let waveform = waveform.flatten(&library.arrays, index)?;
+                let limits = limits.flatten(&library.arrays, index)?;
                 let mut bucket = FlatBucket {
                     span: SpanOnce::default(),
                     criteria,
                     algorithm,
                     waveform,
-                    limits: limits.clone(),
+                    limits,
                     count: Default::default(),
                 };
                 bucket.span_init()?;

--- a/events-analyser/src/engine/elements/bucket.rs
+++ b/events-analyser/src/engine/elements/bucket.rs
@@ -88,7 +88,7 @@ pub(crate) struct BucketBlockProperties {
 #[serde(rename_all = "kebab-case")]
 pub(crate) struct BucketBlock {
     /// Bucket Block Template to use as a source.
-    pub(crate) source: String,
+    pub(crate) use_template: String,
     /// Name of this bucket block.
     pub(crate) name: String,
     /// The crieria that is required for an eventlist collection to belong to one of these buckets.
@@ -100,7 +100,7 @@ pub(crate) struct BucketBlock {
 
 impl HasSource for BucketBlock {
     fn get_source(&self) -> &str {
-        &self.source
+        &self.use_template
     }
 }
 
@@ -168,6 +168,7 @@ impl Flattenable<&Templates> for BucketBlock {
                     criteria,
                     algorithm,
                     waveform,
+                    limits: limits.clone(),
                     count: Default::default(),
                 };
                 bucket.span_init()?;
@@ -177,7 +178,6 @@ impl Flattenable<&Templates> for BucketBlock {
         Ok(FlatBucketBlock {
             name: self.get_name().to_string(),
             buckets,
-            limits: limits.clone(),
         })
     }
 }
@@ -190,8 +190,6 @@ pub(crate) struct FlatBucketBlock {
     pub(crate) name: String,
     /// Buckets in this block.
     pub(crate) buckets: Vec<FlatBucket>,
-    /// Specifies the minimum and maximum number of eventlist collections these buckets allow.
-    pub(crate) limits: Interval<usize>,
 }
 
 impl HasName for FlatBucketBlock {
@@ -204,7 +202,6 @@ impl Debug for FlatBucketBlock {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("FlatBucketBlock")
             .field("buckets", &self.buckets)
-            .field("limits", &self.limits)
             .finish()
     }
 }
@@ -218,7 +215,7 @@ impl FlatBucketBlock {
             .iter_mut()
             .enumerate()
             .find(|(_, bucket)| bucket.is_collection_in(collection))
-            .map(|(index, bucket)| (index, (self.limits.max > bucket.count).then_some(bucket)))
+            .map(|(index, bucket)| (index, bucket.is_bucket_available().then_some(bucket)))
     }
 }
 
@@ -235,6 +232,8 @@ pub(crate) struct FlatBucket {
     pub(crate) waveform: FlatWaveform,
     /// The number of eventlist collections that have been placed in this bucket FIXME: Maybe Remove.
     pub(crate) count: usize,
+    /// Specifies the minimum and maximum number of eventlist collections these buckets allow.
+    pub(crate) limits: Interval<usize>,
 }
 
 impl Spanned for FlatBucket {
@@ -275,6 +274,7 @@ impl Debug for FlatBucket {
             .field("algorithm", &self.algorithm)
             .field("waveform", &self.waveform)
             .field("count", &self.count)
+            .field("limits", &self.limits)
             .finish()
     }
 }
@@ -282,6 +282,10 @@ impl Debug for FlatBucket {
 impl FlatBucket {
     pub(crate) fn increment_count(&mut self) {
         self.count += 1;
+    }
+
+    fn is_bucket_available(&self) -> bool {
+        self.limits.max > self.count
     }
 
     /// Determine whether the eventlist collection satisfies the bucket's criteria.
@@ -332,6 +336,7 @@ mod tests {
                 width: Default::default(),
             },
             count: 0,
+            limits: Interval { min: 0, max: 1 }
         };
         let collection = EventlistsCollection {
             span: Default::default(),
@@ -369,6 +374,7 @@ mod tests {
                 width: Default::default(),
             },
             count: 0,
+            limits: Interval { min: 0, max: 1 }
         };
         let bucket_2 = FlatBucket {
             span: Default::default(),
@@ -387,6 +393,7 @@ mod tests {
                 width: Default::default(),
             },
             count: 0,
+            limits: Interval { min: 0, max: 1 }
         };
         let collection = EventlistsCollection {
             span: Default::default(),

--- a/events-analyser/src/engine/elements/chart.rs
+++ b/events-analyser/src/engine/elements/chart.rs
@@ -253,7 +253,7 @@ impl FlatChart {
                 .expect("This should never fail");
             let metric = metrics.get(series.metric).expect("This should never fail");
 
-            if !metric.are_buckets_full_enough(series.from_bucket, block.limits.min) {
+            if !metric.are_buckets_full_enough(series.from_bucket, &block.buckets) {
                 //info!("Testing Bucket Block: {}... block not ready.", block.name);
                 return false;
             }

--- a/events-analyser/src/engine/elements/chart.rs
+++ b/events-analyser/src/engine/elements/chart.rs
@@ -43,6 +43,7 @@ pub(crate) struct Series {
     from_bucket: String,
 }
 
+/// Encapsulates the style to use for the line of a series.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub(crate) enum DashStyle {
@@ -223,16 +224,16 @@ impl FlatChart {
     /// Determines whether the chart is ready to be written.
     ///
     /// # Parameters
-    /// - buckets:
-    /// - metrics:
+    /// - buckets_blocks: slice of all available bucket blocks.
+    /// - metrics: slice of all available metrics.
     pub(crate) fn evaluate_readiness(
         &mut self,
-        buckets: &[FlatBucketBlock],
+        bucket_blocks: &[FlatBucketBlock],
         metrics: &[PartialMetricResult],
     ) -> bool {
         if self.ready {
             true
-        } else if self.is_chart_ready(buckets, metrics) {
+        } else if self.is_chart_ready(bucket_blocks, metrics) {
             self.ready = true;
             true
         } else {
@@ -244,15 +245,15 @@ impl FlatChart {
     /// Namely whether all relevant metrics have enough data in their buckets.
     ///
     /// # Parameters
-    /// - buckets:
-    /// - metrics:
+    /// - buckets_blocks: slice of all available bucket blocks.
+    /// - metrics: slice of all available metrics.
     fn is_chart_ready(
         &self,
-        flat_buckets_blocks: &[FlatBucketBlock],
+        buckets_blocks: &[FlatBucketBlock],
         metrics: &[PartialMetricResult],
     ) -> bool {
         for series in &self.series {
-            let block = flat_buckets_blocks
+            let block = buckets_blocks
                 .get(series.from_bucket_block)
                 .expect("This should never fail");
             let metric = metrics.get(series.metric).expect("This should never fail");

--- a/events-analyser/src/engine/elements/chart.rs
+++ b/events-analyser/src/engine/elements/chart.rs
@@ -258,7 +258,7 @@ impl FlatChart {
             let metric = metrics.get(series.metric).expect("This should never fail");
 
             if !metric.are_buckets_full_enough(series.from_bucket_block, &block.buckets) {
-                //info!("Testing Bucket Block: {}... block not ready.", block.name);
+                info!("Testing Bucket Block: {}... block not ready.", block.name);
                 return false;
             }
             info!("Testing Bucket Block: {}... block ready.", block.name);

--- a/events-analyser/src/engine/elements/chart.rs
+++ b/events-analyser/src/engine/elements/chart.rs
@@ -246,7 +246,11 @@ impl FlatChart {
     /// # Parameters
     /// - buckets:
     /// - metrics:
-    fn is_chart_ready(&self, flat_buckets_blocks: &[FlatBucketBlock], metrics: &[PartialMetricResult]) -> bool {
+    fn is_chart_ready(
+        &self,
+        flat_buckets_blocks: &[FlatBucketBlock],
+        metrics: &[PartialMetricResult],
+    ) -> bool {
         for series in &self.series {
             let block = flat_buckets_blocks
                 .get(series.from_bucket_block)

--- a/events-analyser/src/engine/elements/chart.rs
+++ b/events-analyser/src/engine/elements/chart.rs
@@ -72,7 +72,7 @@ impl Flattenable<&AnalysisSettings> for Series {
     type Error = SeriesError;
 
     fn flatten(&self, library: &AnalysisSettings) -> Result<Self::Flat, Self::Error> {
-        let from_bucket = library
+        let from_bucket_block = library
             .get_bucket_block_index(&self.from_bucket)
             .ok_or_else(|| SeriesError::BucketNotFound(self.from_bucket.clone()))?;
 
@@ -86,7 +86,7 @@ impl Flattenable<&AnalysisSettings> for Series {
             name: self.name.clone(),
             line_colour: self.line_colour.clone(),
             line_style: self.line_style.clone(),
-            from_bucket,
+            from_bucket_block,
             metric,
             property,
         })
@@ -108,7 +108,7 @@ pub(crate) struct FlatSeries {
     /// Specific property of the metric from which the y-values are collected.
     pub(crate) property: MetricProperty,
     /// Index of bucket block from which the y-values are collected.
-    pub(crate) from_bucket: usize,
+    pub(crate) from_bucket_block: usize,
 }
 
 #[derive(Debug, Error)]
@@ -151,7 +151,7 @@ impl Flattenable<(&AnalysisSettings, &[FlatBucketBlock])> for Chart {
 
     fn flatten(
         &self,
-        (library, buckets): (&AnalysisSettings, &[FlatBucketBlock]),
+        (library, flat_bucket_blocks): (&AnalysisSettings, &[FlatBucketBlock]),
     ) -> Result<Self::Flat, Self::Error> {
         if !self.output_to_html && !self.output_to_json {
             return Err(ChartError::NoOutputModeSet);
@@ -165,9 +165,9 @@ impl Flattenable<(&AnalysisSettings, &[FlatBucketBlock])> for Chart {
             .series
             .iter()
             .map(|series| {
-                series.flatten(library).and_then(|flat| {
-                    let bucket_number = buckets
-                        .get(flat.from_bucket)
+                series.flatten(library).and_then(|flat_series| {
+                    let bucket_number = flat_bucket_blocks
+                        .get(flat_series.from_bucket_block)
                         .expect("This should never fail.")
                         .buckets
                         .len();
@@ -178,7 +178,7 @@ impl Flattenable<(&AnalysisSettings, &[FlatBucketBlock])> for Chart {
                             self.width,
                         ))
                     } else {
-                        Ok(flat)
+                        Ok(flat_series)
                     }
                 })
             })
@@ -246,14 +246,14 @@ impl FlatChart {
     /// # Parameters
     /// - buckets:
     /// - metrics:
-    fn is_chart_ready(&self, buckets: &[FlatBucketBlock], metrics: &[PartialMetricResult]) -> bool {
+    fn is_chart_ready(&self, flat_buckets_blocks: &[FlatBucketBlock], metrics: &[PartialMetricResult]) -> bool {
         for series in &self.series {
-            let block = buckets
-                .get(series.from_bucket)
+            let block = flat_buckets_blocks
+                .get(series.from_bucket_block)
                 .expect("This should never fail");
             let metric = metrics.get(series.metric).expect("This should never fail");
 
-            if !metric.are_buckets_full_enough(series.from_bucket, &block.buckets) {
+            if !metric.are_buckets_full_enough(series.from_bucket_block, &block.buckets) {
                 //info!("Testing Bucket Block: {}... block not ready.", block.name);
                 return false;
             }

--- a/events-analyser/src/engine/elements/criteria.rs
+++ b/events-analyser/src/engine/elements/criteria.rs
@@ -56,7 +56,7 @@ impl HasName for CriteriaTemplate {
 #[serde(rename_all = "kebab-case")]
 pub(crate) struct Criteria {
     /// Refers to the [CriteriaTemplate] that can fill out any missing fields of [CriteriaProperties].
-    pub(crate) source: String,
+    pub(crate) use_template: String,
     /// Contains fields used in the crieria object, can be either specified here or in the [CriteriaTemplate] referred to by [Self::source].
     #[serde(flatten)]
     pub(crate) properties: CriteriaProperties,
@@ -64,12 +64,12 @@ pub(crate) struct Criteria {
 
 impl HasSource for Criteria {
     fn get_source(&self) -> &str {
-        &self.source
+        &self.use_template
     }
 }
 
 /// Encapsulates crieria used in a [FlatBucket] object.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
 pub(crate) struct FlatCriteria {
     /// Is applied to all voltages when traces are created
     pub(crate) periods: ConstantFilter<u64>,

--- a/events-analyser/src/engine/elements/criteria.rs
+++ b/events-analyser/src/engine/elements/criteria.rs
@@ -1,6 +1,6 @@
 use crate::engine::{
     FlattenableWithIndex, HasName, HasSource, Templates,
-    values::{ConstantFilter, ValueError, ValueFilter},
+    values::{Filter, ValueError, ValueFilter},
 };
 use digital_muon_common::{Channel, DigitizerId, FrameNumber};
 use serde::Deserialize;
@@ -72,13 +72,13 @@ impl HasSource for Criteria {
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct FlatCriteria {
     /// Is applied to all voltages when traces are created
-    pub(crate) periods: ConstantFilter<u64>,
+    pub(crate) periods: Filter<u64>,
     /// Is applied to all voltages when traces are created
-    pub(crate) frames: ConstantFilter<FrameNumber>,
+    pub(crate) frames: Filter<FrameNumber>,
     /// Is applied to all voltages when traces are created
-    pub(crate) channels: ConstantFilter<Channel>,
+    pub(crate) channels: Filter<Channel>,
     /// Is applied to all voltages when traces are created
-    pub(crate) digitiser_ids: ConstantFilter<DigitizerId>,
+    pub(crate) digitiser_ids: Filter<DigitizerId>,
 }
 
 impl FlattenableWithIndex for Criteria {

--- a/events-analyser/src/engine/elements/metric.rs
+++ b/events-analyser/src/engine/elements/metric.rs
@@ -1,4 +1,7 @@
-use crate::engine::{Flattenable, HasName, values::{Interval, ValueError}};
+use crate::engine::{
+    Flattenable, HasName,
+    values::{Interval, ValueError},
+};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 

--- a/events-analyser/src/engine/elements/metric.rs
+++ b/events-analyser/src/engine/elements/metric.rs
@@ -1,4 +1,4 @@
-use crate::engine::{Flattenable, HasName, values::ValueError};
+use crate::engine::{Flattenable, HasName, values::{Interval, ValueError}};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
@@ -50,7 +50,7 @@ pub(crate) enum MetricType {
     MuonLifetime {
         topic: String,
         num_bins: usize,
-        max_lifetime: f64,
+        interval: Interval<f64>,
     },
 }
 
@@ -137,7 +137,7 @@ impl Flattenable<&[String]> for Metric {
             MetricType::MuonLifetime {
                 topic,
                 num_bins,
-                max_lifetime,
+                interval,
             } => FlatMetricType::MuonLifetime(FlatMetricMuonLifetime {
                 topic: library
                     .iter()
@@ -145,7 +145,7 @@ impl Flattenable<&[String]> for Metric {
                     .find_map(|(index, this_topic)| (this_topic == topic).then_some(index))
                     .expect("This should never fail."),
                 num_bins: *num_bins,
-                max_lifetime: *max_lifetime,
+                interval: interval.clone(),
             }),
         };
         Ok(FlatMetric {
@@ -196,5 +196,5 @@ pub(crate) struct FlatMetricEventCount {
 pub(crate) struct FlatMetricMuonLifetime {
     pub(crate) topic: usize,
     pub(crate) num_bins: usize,
-    pub(crate) max_lifetime: f64,
+    pub(crate) interval: Interval<f64>,
 }

--- a/events-analyser/src/engine/elements/mod.rs
+++ b/events-analyser/src/engine/elements/mod.rs
@@ -8,7 +8,8 @@ mod waveform;
 pub(crate) use {
     algorithm::{Algorithm, AlgorithmProperties, FlatAlgorithm},
     bucket::{
-        BucketBlock, BucketBlockProperties, BucketBlockTemplate, BucketError, FlatBucketBlock, FlatBucket
+        BucketBlock, BucketBlockProperties, BucketBlockTemplate, BucketError, FlatBucket,
+        FlatBucketBlock,
     },
     chart::{Chart, ChartError, FlatChart, FlatSeries},
     criteria::CriteriaTemplate,

--- a/events-analyser/src/engine/elements/mod.rs
+++ b/events-analyser/src/engine/elements/mod.rs
@@ -8,7 +8,7 @@ mod waveform;
 pub(crate) use {
     algorithm::{Algorithm, AlgorithmProperties, FlatAlgorithm},
     bucket::{
-        BucketBlock, BucketBlockProperties, BucketBlockTemplate, BucketError, FlatBucketBlock,
+        BucketBlock, BucketBlockProperties, BucketBlockTemplate, BucketError, FlatBucketBlock, FlatBucket
     },
     chart::{Chart, ChartError, FlatChart, FlatSeries},
     criteria::CriteriaTemplate,

--- a/events-analyser/src/engine/mod.rs
+++ b/events-analyser/src/engine/mod.rs
@@ -8,7 +8,7 @@ pub(crate) use crate::engine::{
         FlatMetricEventCount, FlatMetricFalseCount, FlatMetricMuonLifetime, FlatMetricType,
         FlatSeries, FlatWaveform, Metric, MetricProperty,
     },
-    settings::{AnalysisSettings, Array, FlatTriggerWhen, Templates},
+    settings::{AnalysisSettings, Array, Templates},
     values::Interval,
 };
 

--- a/events-analyser/src/engine/mod.rs
+++ b/events-analyser/src/engine/mod.rs
@@ -8,7 +8,7 @@ pub(crate) use crate::engine::{
         FlatMetricEventCount, FlatMetricFalseCount, FlatMetricMuonLifetime, FlatMetricType,
         FlatSeries, FlatWaveform, Metric, MetricProperty,
     },
-    settings::{AnalysisSettings, Array, Templates, FlatTriggerWhen},
+    settings::{AnalysisSettings, Array, FlatTriggerWhen, Templates},
     values::Interval,
 };
 

--- a/events-analyser/src/engine/mod.rs
+++ b/events-analyser/src/engine/mod.rs
@@ -4,9 +4,9 @@ mod values;
 
 pub(crate) use crate::engine::{
     elements::{
-        Chart, FlatAlgorithm, FlatBucketBlock, FlatBucket, FlatChart, FlatMetric, FlatMetricEventCount,
-        FlatMetricFalseCount, FlatMetricMuonLifetime, FlatMetricType, FlatSeries, FlatWaveform,
-        Metric, MetricProperty,
+        Chart, FlatAlgorithm, FlatBucket, FlatBucketBlock, FlatChart, FlatMetric,
+        FlatMetricEventCount, FlatMetricFalseCount, FlatMetricMuonLifetime, FlatMetricType,
+        FlatSeries, FlatWaveform, Metric, MetricProperty,
     },
     settings::{AnalysisSettings, Array, Templates},
 };

--- a/events-analyser/src/engine/mod.rs
+++ b/events-analyser/src/engine/mod.rs
@@ -8,7 +8,7 @@ pub(crate) use crate::engine::{
         FlatMetricEventCount, FlatMetricFalseCount, FlatMetricMuonLifetime, FlatMetricType,
         FlatSeries, FlatWaveform, Metric, MetricProperty,
     },
-    settings::{AnalysisSettings, Array, Templates},
+    settings::{AnalysisSettings, Array, Templates, FlatTriggerWhen},
 };
 
 /// Provides methods for flattening dependencies.

--- a/events-analyser/src/engine/mod.rs
+++ b/events-analyser/src/engine/mod.rs
@@ -4,7 +4,7 @@ mod values;
 
 pub(crate) use crate::engine::{
     elements::{
-        Chart, FlatAlgorithm, FlatBucketBlock, FlatChart, FlatMetric, FlatMetricEventCount,
+        Chart, FlatAlgorithm, FlatBucketBlock, FlatBucket, FlatChart, FlatMetric, FlatMetricEventCount,
         FlatMetricFalseCount, FlatMetricMuonLifetime, FlatMetricType, FlatSeries, FlatWaveform,
         Metric, MetricProperty,
     },

--- a/events-analyser/src/engine/mod.rs
+++ b/events-analyser/src/engine/mod.rs
@@ -9,6 +9,7 @@ pub(crate) use crate::engine::{
         FlatSeries, FlatWaveform, Metric, MetricProperty,
     },
     settings::{AnalysisSettings, Array, Templates, FlatTriggerWhen},
+    values::Interval,
 };
 
 /// Provides methods for flattening dependencies.

--- a/events-analyser/src/engine/settings.rs
+++ b/events-analyser/src/engine/settings.rs
@@ -6,8 +6,6 @@ use crate::engine::{
     },
     values::ValueError,
 };
-use chrono::{DateTime, ParseError, Utc};
-use digital_muon_common::FrameNumber;
 use serde::Deserialize;
 use std::ops::Deref;
 
@@ -77,8 +75,6 @@ pub(crate) struct AnalysisSettings {
     /// List of Charts.
     pub(crate) charts: Vec<Chart>,
     /// Controls when to start the evaluation phase.
-    pub(crate) trigger_charts_when: TriggerWhen,
-    /// Controls when to start the evaluation phase.
     pub(crate) idle_time_sec: i64,
 }
 
@@ -131,47 +127,6 @@ impl AnalysisSettings {
             .expect("This should never fail.")
             .get_property(property_name)
     }
-}
-
-/// Represents a filter that can be applied to values.
-#[derive(Debug, Deserialize, Clone)]
-#[serde(rename_all = "kebab-case")]
-pub(crate) enum TriggerWhen {
-    TimestampMet(String),
-    FrameNumberMet(FrameNumber),
-    IdleTimeExceededSec(i64),
-    BucketsExceedMinLimit,
-}
-
-impl Flattenable<()> for TriggerWhen {
-    type Flat = FlatTriggerWhen;
-    type Error = ParseError;
-
-    fn flatten(&self, _: ()) -> Result<Self::Flat, Self::Error> {
-        Ok(match &self {
-            TriggerWhen::TimestampMet(timestamp) => {
-                FlatTriggerWhen::TimestampMet(timestamp.parse()?)
-            }
-            TriggerWhen::FrameNumberMet(frame_number) => {
-                FlatTriggerWhen::FrameNumberMet(*frame_number)
-            }
-            TriggerWhen::BucketsExceedMinLimit => FlatTriggerWhen::BucketsExceedMinLimit,
-            TriggerWhen::IdleTimeExceededSec(seconds) => {
-                FlatTriggerWhen::IdleTimeExceededSec(*seconds)
-            }
-        })
-    }
-}
-
-/// Represents a filter that can be applied to values.
-#[derive(Debug, Deserialize, Clone)]
-#[serde(rename_all = "kebab-case")]
-pub(crate) enum FlatTriggerWhen {
-    TimestampMet(DateTime<Utc>),
-    FrameNumberMet(FrameNumber),
-    BucketsExceedMinLimit,
-    IdleTimeExceededSec(i64),
-    Now,
 }
 
 /// List of floating point values that can be used in `Function` structures.

--- a/events-analyser/src/engine/settings.rs
+++ b/events-analyser/src/engine/settings.rs
@@ -6,6 +6,8 @@ use crate::engine::{
     },
     values::ValueError,
 };
+use chrono::{DateTime, ParseError, Utc};
+use digital_muon_common::FrameNumber;
 use serde::Deserialize;
 use std::ops::Deref;
 
@@ -74,6 +76,8 @@ pub(crate) struct AnalysisSettings {
     pub(crate) buckets: Vec<BucketBlock>,
     /// List of Charts.
     pub(crate) charts: Vec<Chart>,
+    /// Controls when to start the evaluation phase.
+    pub(crate) trigger_charts_when: TriggerWhen
 }
 
 impl AnalysisSettings {
@@ -125,6 +129,38 @@ impl AnalysisSettings {
             .expect("This should never fail.")
             .get_property(property_name)
     }
+}
+
+/// Represents a filter that can be applied to values.
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum TriggerWhen {
+    TimestampMet(String),
+    FrameNumberMet(FrameNumber),
+    BucketsExceedMinLimit
+}
+
+impl Flattenable<()> for TriggerWhen {
+    type Flat = FlatTriggerWhen;
+    type Error = ParseError;
+
+    fn flatten(&self, _: ()) -> Result<Self::Flat, Self::Error> {
+        Ok(match &self {
+            TriggerWhen::TimestampMet(timestamp) => FlatTriggerWhen::TimestampMet(timestamp.parse()?),
+            TriggerWhen::FrameNumberMet(frame_number) => FlatTriggerWhen::FrameNumberMet(frame_number.clone()),
+            TriggerWhen::BucketsExceedMinLimit => FlatTriggerWhen::BucketsExceedMinLimit,
+        })
+    }
+}
+
+/// Represents a filter that can be applied to values.
+#[derive(Debug, Deserialize, Clone)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) enum FlatTriggerWhen {
+    TimestampMet(DateTime<Utc>),
+    FrameNumberMet(FrameNumber),
+    BucketsExceedMinLimit,
+    Now
 }
 
 /// List of floating point values that can be used in `Function` structures.

--- a/events-analyser/src/engine/settings.rs
+++ b/events-analyser/src/engine/settings.rs
@@ -151,7 +151,7 @@ impl Flattenable<()> for TriggerWhen {
                 FlatTriggerWhen::TimestampMet(timestamp.parse()?)
             }
             TriggerWhen::FrameNumberMet(frame_number) => {
-                FlatTriggerWhen::FrameNumberMet(frame_number.clone())
+                FlatTriggerWhen::FrameNumberMet(*frame_number)
             }
             TriggerWhen::BucketsExceedMinLimit => FlatTriggerWhen::BucketsExceedMinLimit,
             TriggerWhen::IdleTimeExceededSec(seconds) => {

--- a/events-analyser/src/engine/settings.rs
+++ b/events-analyser/src/engine/settings.rs
@@ -78,6 +78,8 @@ pub(crate) struct AnalysisSettings {
     pub(crate) charts: Vec<Chart>,
     /// Controls when to start the evaluation phase.
     pub(crate) trigger_charts_when: TriggerWhen,
+    /// Controls when to start the evaluation phase.
+    pub(crate) idle_time_sec: i64,
 }
 
 impl AnalysisSettings {

--- a/events-analyser/src/engine/settings.rs
+++ b/events-analyser/src/engine/settings.rs
@@ -77,7 +77,7 @@ pub(crate) struct AnalysisSettings {
     /// List of Charts.
     pub(crate) charts: Vec<Chart>,
     /// Controls when to start the evaluation phase.
-    pub(crate) trigger_charts_when: TriggerWhen
+    pub(crate) trigger_charts_when: TriggerWhen,
 }
 
 impl AnalysisSettings {
@@ -137,7 +137,8 @@ impl AnalysisSettings {
 pub(crate) enum TriggerWhen {
     TimestampMet(String),
     FrameNumberMet(FrameNumber),
-    BucketsExceedMinLimit
+    IdleTimeExceededSec(i64),
+    BucketsExceedMinLimit,
 }
 
 impl Flattenable<()> for TriggerWhen {
@@ -146,9 +147,16 @@ impl Flattenable<()> for TriggerWhen {
 
     fn flatten(&self, _: ()) -> Result<Self::Flat, Self::Error> {
         Ok(match &self {
-            TriggerWhen::TimestampMet(timestamp) => FlatTriggerWhen::TimestampMet(timestamp.parse()?),
-            TriggerWhen::FrameNumberMet(frame_number) => FlatTriggerWhen::FrameNumberMet(frame_number.clone()),
+            TriggerWhen::TimestampMet(timestamp) => {
+                FlatTriggerWhen::TimestampMet(timestamp.parse()?)
+            }
+            TriggerWhen::FrameNumberMet(frame_number) => {
+                FlatTriggerWhen::FrameNumberMet(frame_number.clone())
+            }
             TriggerWhen::BucketsExceedMinLimit => FlatTriggerWhen::BucketsExceedMinLimit,
+            TriggerWhen::IdleTimeExceededSec(seconds) => {
+                FlatTriggerWhen::IdleTimeExceededSec(*seconds)
+            }
         })
     }
 }
@@ -160,7 +168,8 @@ pub(crate) enum FlatTriggerWhen {
     TimestampMet(DateTime<Utc>),
     FrameNumberMet(FrameNumber),
     BucketsExceedMinLimit,
-    Now
+    IdleTimeExceededSec(i64),
+    Now,
 }
 
 /// List of floating point values that can be used in `Function` structures.

--- a/events-analyser/src/engine/values.rs
+++ b/events-analyser/src/engine/values.rs
@@ -25,6 +25,8 @@ pub(crate) enum ValueFilter<T: Number> {
     Constant(ConstantFilter<T>),
     /// Represents a filter that resolves to a single value filter when flattened with an index.
     Dependent(Dependency<T>),
+    /// Represents a filter that resolves to a single value filter when flattened with an index.
+    AnyInRangeDependent(Interval<Dependency<T>>),
 }
 
 /// Represents a filter that can be applied to values.
@@ -70,6 +72,9 @@ impl<T: Number> FlattenableWithIndex for ValueFilter<T> {
         match self {
             ValueFilter::Dependent(dependency) => {
                 Ok(ConstantFilter::Is(dependency.flatten(arrays, index)?))
+            }
+            ValueFilter::AnyInRangeDependent(interval) => {
+                Ok(ConstantFilter::AnyInRange(interval.flatten(arrays, index)?))
             }
             ValueFilter::Constant(constant) => Ok(constant.clone()),
         }
@@ -158,6 +163,19 @@ where
 impl<T: PartialOrd + Copy> Interval<T> {
     pub(crate) fn range_inclusive(&self) -> RangeInclusive<T> {
         self.min..=self.max
+    }
+}
+
+impl<T: Number> FlattenableWithIndex for Interval<Dependency<T>> {
+    type Flat = Interval<T>;
+    type Library = [Array];
+    type Error = ValueError;
+
+    fn flatten(&self, library: &Self::Library, index: usize) -> Result<Self::Flat, Self::Error> {
+        Ok(Interval {
+            min: self.min.flatten(library, index)?,
+            max: self.max.flatten(library, index)?,
+        })
     }
 }
 

--- a/events-analyser/src/engine/values.rs
+++ b/events-analyser/src/engine/values.rs
@@ -22,17 +22,15 @@ impl<T> Number for T where
 #[serde(rename_all = "kebab-case")]
 pub(crate) enum ValueFilter<T: Number> {
     /// Represents a filter with no external dependencies.
-    Constant(ConstantFilter<T>),
+    Constant(Filter<T>),
     /// Represents a filter that resolves to a single value filter when flattened with an index.
-    Dependent(Dependency<T>),
-    /// Represents a filter that resolves to a single value filter when flattened with an index.
-    AnyInRangeDependent(Interval<Dependency<T>>),
+    Dependency(Filter<Dependency<T>>),
 }
 
 /// Represents a filter that can be applied to values.
 #[derive(Debug, Deserialize, Clone)]
 #[serde(rename_all = "kebab-case")]
-pub(crate) enum ConstantFilter<T: Clone> {
+pub(crate) enum Filter<T: Clone> {
     /// Only a single value passes this filter.
     Is(T),
     /// Only the given values passes this filter.
@@ -43,41 +41,42 @@ pub(crate) enum ConstantFilter<T: Clone> {
     Any,
 }
 
-impl<T: Number + PartialEq + PartialOrd> ConstantFilter<T> {
+impl<T: Number + PartialEq + PartialOrd> Filter<T> {
     /// Tests whether a value passes this filter.
     /// # Parameters
     /// - other_value: value to test.
     pub(crate) fn is_valid(&self, other_value: T) -> bool {
         match self {
-            ConstantFilter::Is(value) => other_value.eq(value),
-            ConstantFilter::AnyOf(items) => items.iter().any(|value| other_value.eq(value)),
-            ConstantFilter::AnyInRange(interval) => {
-                interval.range_inclusive().contains(&other_value)
-            }
-            ConstantFilter::Any => true,
+            Self::Is(value) => other_value.eq(value),
+            Self::AnyOf(items) => items.iter().any(|value| other_value.eq(value)),
+            Self::AnyInRange(interval) => interval.range_inclusive().contains(&other_value),
+            Self::Any => true,
         }
     }
 }
 
 impl<T: Number> FlattenableWithIndex for ValueFilter<T> {
-    type Flat = ConstantFilter<T>;
+    type Flat = Filter<T>;
     type Library = [Array];
     type Error = ValueError;
 
-    fn flatten(
-        &self,
-        arrays: &Self::Library,
-        index: usize,
-    ) -> Result<ConstantFilter<T>, Self::Error> {
-        match self {
-            ValueFilter::Dependent(dependency) => {
-                Ok(ConstantFilter::Is(dependency.flatten(arrays, index)?))
-            }
-            ValueFilter::AnyInRangeDependent(interval) => {
-                Ok(ConstantFilter::AnyInRange(interval.flatten(arrays, index)?))
-            }
-            ValueFilter::Constant(constant) => Ok(constant.clone()),
-        }
+    fn flatten(&self, arrays: &Self::Library, index: usize) -> Result<Filter<T>, Self::Error> {
+        Ok(match self {
+            ValueFilter::Dependency(dependency_filter) => match dependency_filter {
+                Filter::Is(dependency) => Filter::Is(dependency.flatten(arrays, index)?),
+                Filter::AnyOf(items) => Filter::AnyOf(
+                    items
+                        .iter()
+                        .map(|dependency| dependency.flatten(arrays, index))
+                        .collect::<Result<_, _>>()?,
+                ),
+                Filter::AnyInRange(interval) => {
+                    Filter::AnyInRange(interval.flatten(arrays, index)?)
+                }
+                Filter::Any => Filter::Any,
+            },
+            ValueFilter::Constant(constant) => constant.clone(),
+        })
     }
 }
 
@@ -88,7 +87,7 @@ pub(crate) enum Value<T: Number> {
     /// A constant value.
     Constant(T),
     /// Value derived from either an `Array` or `Function`.
-    Dependent(Dependency<T>),
+    Dependency(Dependency<T>),
 }
 
 impl<T: Number> FlattenableWithIndex for Value<T> {
@@ -98,7 +97,7 @@ impl<T: Number> FlattenableWithIndex for Value<T> {
 
     fn flatten(&self, arrays: &Self::Library, index: usize) -> Result<T, Self::Error> {
         match self {
-            Value::Dependent(dependency) => dependency.flatten(arrays, index),
+            Value::Dependency(dependency) => dependency.flatten(arrays, index),
             Value::Constant(constant) => Ok(*constant),
         }
     }

--- a/events-analyser/src/engine/values.rs
+++ b/events-analyser/src/engine/values.rs
@@ -161,6 +161,19 @@ impl<T: PartialOrd + Copy> Interval<T> {
     }
 }
 
+impl<T: Number> FlattenableWithIndex for Interval<Value<T>> {
+    type Flat = Interval<T>;
+    type Library = [Array];
+    type Error = ValueError;
+
+    fn flatten(&self, library: &Self::Library, index: usize) -> Result<Self::Flat, Self::Error> {
+        Ok(Interval {
+            min: self.min.flatten(library, index)?,
+            max: self.max.flatten(library, index)?,
+        })
+    }
+}
+
 /// Represents a linear function that typically operates on an index.
 #[derive(Debug, Deserialize, Clone)]
 #[serde(rename_all = "kebab-case")]

--- a/events-analyser/src/engine/values.rs
+++ b/events-analyser/src/engine/values.rs
@@ -1,6 +1,6 @@
 use crate::engine::{Array, FlattenableWithIndex, HasName};
 use num::NumCast;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::ops::{Add, Mul, RangeInclusive};
 use thiserror::Error;
 
@@ -149,7 +149,7 @@ pub(crate) enum ValueError {
 }
 
 /// Represents an end-inclusive interval of values.
-#[derive(Clone, Debug, Deserialize)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "kebab-case")]
 pub(crate) struct Interval<T>
 where

--- a/events-analyser/src/evaluator_task.rs
+++ b/events-analyser/src/evaluator_task.rs
@@ -66,8 +66,8 @@ async fn recv_and_evaluate(
             }
             _ = chart_poll_interval.tick() => {
                 trace!("Polling for chart completion.");
-                analysis_engine.test_idle_time();
-                if analysis_engine.evaluate_chart_readiness().expect("This should never fail.") {
+                //analysis_engine.test_idle_time();
+                if analysis_engine.evaluate_chart_readiness() {
                     match analysis_engine.build_charts() {
                         Ok(_) => (),
                         Err(e) => {

--- a/events-analyser/src/evaluator_task.rs
+++ b/events-analyser/src/evaluator_task.rs
@@ -66,7 +66,6 @@ async fn recv_and_evaluate(
             }
             _ = chart_poll_interval.tick() => {
                 trace!("Polling for chart completion.");
-                //analysis_engine.test_idle_time();
                 if analysis_engine.evaluate_chart_readiness() {
                     match analysis_engine.build_charts() {
                         Ok(_) => (),

--- a/events-analyser/src/evaluator_task.rs
+++ b/events-analyser/src/evaluator_task.rs
@@ -66,6 +66,7 @@ async fn recv_and_evaluate(
             }
             _ = chart_poll_interval.tick() => {
                 trace!("Polling for chart completion.");
+                analysis_engine.test_idle_time();
                 if analysis_engine.evaluate_chart_readiness().expect("This should never fail.") {
                     match analysis_engine.build_charts() {
                         Ok(_) => (),


### PR DESCRIPTION
## Summary of changes

- Moved `limits` field to `bucket`, from `bucket_block` and allowed them to vary.
- Made the `Filter`, `Dependency` objects more flexible.
- Fixed bug regarding the selection of the correct bucket.
- Change how the evaluate phase is triggered. Now waits for a specified amount of inactivity before checking buckets are ready.
- Allow `ChartOutput` to handle missing series.
- Simplify `get_property` error handling.
- Added a minimum value for the muon lifetime histogram to allow for a delay in arrival time.
- Made various variable names more consistent and explicit.

## Instruction for review/testing

General code review, has been tested in a pipeline.
